### PR TITLE
🔨 Refactor: Redis 도입 및 Refresh Token 저장 로직 구현

### DIFF
--- a/src/main/java/com/dodo/backend/auth/dto/request/AuthRequest.java
+++ b/src/main/java/com/dodo/backend/auth/dto/request/AuthRequest.java
@@ -15,7 +15,7 @@ public class AuthRequest {
     @NoArgsConstructor
     public static class SocialLoginRequest {
 
-        @Schema(description = "소셜 제공자 타입 (GOOGLE, NAVER, KAKAO 등)", example = "GOOGLE")
+        @Schema(description = "소셜 제공자 타입 (GOOGLE, NAVER)", example = "GOOGLE")
         @NotBlank(message = "provider는 필수 값입니다.")
         private String provider;
 

--- a/src/main/java/com/dodo/backend/auth/entity/RefreshToken.java
+++ b/src/main/java/com/dodo/backend/auth/entity/RefreshToken.java
@@ -1,0 +1,28 @@
+package com.dodo.backend.auth.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+
+/**
+ * 사용자 인증 갱신을 위한 리프레시 토큰(Refresh Token) 정보를 관리하는 Redis 엔티티 클래스입니다.
+ * <p>
+ * Redis의 {@code refresh_token} 해시(Hash)와 매핑됩니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@RedisHash(value = "refresh_token", timeToLive = 1209600000)
+public class RefreshToken {
+
+    @Id
+    private String usersId;
+
+    @Indexed
+    private String refreshToken;
+
+    private String role;
+}

--- a/src/main/java/com/dodo/backend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/dodo/backend/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,21 @@
+package com.dodo.backend.auth.repository;
+
+import com.dodo.backend.auth.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+/**
+ * 리프레시 토큰(Refresh Token) 엔티티의 데이터 접근 및 관리를 담당하는 리포지토리 인터페이스입니다.
+ * <p>
+ * Redis의 {@code refresh_token} 해시에 저장된 데이터를 처리합니다.
+ */
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+    /**
+     * 주어진 리프레시 토큰(Refresh Token) 값을 기준으로 저장된 엔티티 정보를 조회합니다.
+     * <p>
+     * {@code @Indexed}가 적용된 토큰 필드를 사용하여 데이터를 검색합니다.
+     */
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/test/java/com/dodo/backend/auth/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/dodo/backend/auth/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,120 @@
+package com.dodo.backend.auth.repository;
+
+import com.dodo.backend.auth.entity.RefreshToken;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 리프레시 토큰 리포지토리(RefreshTokenRepository)의 기능 검증을 위한 테스트 클래스입니다.
+ * <p>
+ * {@link DataRedisTest}를 사용하여 Redis 저장 및 조회 로직을 테스트합니다.
+ */
+@DataRedisTest
+@Slf4j
+class RefreshTokenRepositoryTest {
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 각 테스트 케이스 실행 후 Redis에 저장된 테스트 데이터를 일괄 삭제합니다.
+     * <p>
+     * 테스트 간 데이터 독립성을 보장하기 위해 수행됩니다.
+     */
+    @AfterEach
+    void tearDown() {
+        refreshTokenRepository.deleteAll();
+        log.info("테스트 종료 후 Redis 데이터를 모두 삭제했습니다.");
+    }
+
+    /**
+     * 리프레시 토큰을 저장한 후 유저 식별자(userId)를 통해 정상적으로 조회되는지 검증합니다.
+     * <p>
+     * 저장된 데이터의 필드 값이 원본 데이터와 일치하는지 확인합니다.
+     */
+    @Test
+    @DisplayName("RefreshToken 저장 및 ID(userId)로 조회 테스트")
+    void saveAndFindById() {
+        log.info("saveAndFindById 테스트 시작");
+
+        // given
+        String userId = "test-user-uuid";
+        String tokenValue = "refresh-token-value-1234";
+        String role = "USER";
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .usersId(userId)
+                .refreshToken(tokenValue)
+                .role(role)
+                .build();
+
+        log.info("생성할 객체 정보 - userId: {}, role: {}", userId, role);
+
+        // when
+        refreshTokenRepository.save(refreshToken);
+        log.info("Redis에 데이터 저장 완료");
+
+        RefreshToken foundToken = refreshTokenRepository.findById(userId).orElse(null);
+
+        if (foundToken != null) {
+            log.info("ID로 조회 성공 - 조회된 userId: {}", foundToken.getUsersId());
+        } else {
+            log.error("ID로 조회 실패 - 데이터가 null입니다.");
+        }
+
+        // then
+        assertThat(foundToken).isNotNull();
+        assertThat(foundToken.getUsersId()).isEqualTo(userId);
+        assertThat(foundToken.getRefreshToken()).isEqualTo(tokenValue);
+        assertThat(foundToken.getRole()).isEqualTo(role);
+
+        log.info("검증 통과, 테스트 종료");
+    }
+
+    /**
+     * 토큰 문자열 값을 기준으로 Redis에 저장된 토큰 엔티티를 조회할 수 있는지 검증합니다.
+     * <p>
+     * 인덱싱된 필드({@code @Indexed})를 통한 검색 기능이 정상 작동하는지 확인합니다.
+     */
+    @Test
+    @DisplayName("RefreshToken 값으로 조회(findByRefreshToken) 테스트")
+    void findByRefreshToken() {
+        log.info("findByRefreshToken 테스트 시작");
+
+        // given
+        String userId = "test-user-uuid-2";
+        String tokenValue = "unique-refresh-token-value";
+        String role = "ADMIN";
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .usersId(userId)
+                .refreshToken(tokenValue)
+                .role(role)
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+        log.info("테스트 데이터 저장 완료 - tokenValue: {}", tokenValue);
+
+        // when
+        RefreshToken foundToken = refreshTokenRepository.findByRefreshToken(tokenValue).orElse(null);
+
+        if (foundToken != null) {
+            log.info("Token 값으로 조회 성공 - 조회된 userId: {}", foundToken.getUsersId());
+        } else {
+            log.error("Token 값으로 조회 실패 - 데이터가 null입니다.");
+        }
+
+        // then
+        assertThat(foundToken).isNotNull();
+        assertThat(foundToken.getUsersId()).isEqualTo(userId);
+        assertThat(foundToken.getRefreshToken()).isEqualTo(tokenValue);
+
+        log.info("검증 통과, 테스트 종료");
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- spring-boot-starter-data-redis 의존성 추가 및 기본 설정 완료
- Redis 전용 RefreshToken 엔티티 및 RefreshTokenRepository 구현
- 소셜 로그인 성공 시 발급된 Refresh Token을 Redis에 저장하도록 서비스 로직 수정
- RefreshTokenRepositoryTest를 통한 저장 및 조회 기능 검증 완료
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #18 

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

RefreshToken을 redis에 저장하고 시간 지나면 자동으로 삭제하는 개발했습니다.