### PR TITLE
✨ Feat: 회원 탈퇴 기능 구현 및 MyBatis UUID 자동 매핑 적용

### DIFF
--- a/src/main/java/com/dodo/backend/auth/dto/request/AuthRequest.java
+++ b/src/main/java/com/dodo/backend/auth/dto/request/AuthRequest.java
@@ -9,20 +9,20 @@ import lombok.NoArgsConstructor;
 
 /**
  * 인증(Auth) 도메인 관련 요청 데이터를 그룹화하여 관리하는 클래스입니다.
+ * <p>
+ * 소셜 로그인 인가 코드 전달, 토큰 재발급 요청 등 인증 프로세스 전반에서 클라이언트가 서버로 전송하는 데이터를 정의합니다.
  */
+@Schema(description = "인증 관련 요청 DTO 그룹")
 public class AuthRequest {
 
     /**
      * 소셜 로그인 인증을 위해 클라이언트가 전달하는 요청 DTO입니다.
-     * <p>
-     * 사용 프로세스:
-     * 1. 클라이언트가 소셜 인증 서버(Google/Naver)로부터 인가 코드(Code) 발급
-     * 2. 발급된 코드와 제공자 타입(Provider)을 이 객체에 담아 백엔드에 토큰 발급 요청
      */
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    @Schema(description = "소셜 로그인 및 토큰 발급 요청")
     public static class SocialLoginRequest {
 
         @Schema(description = "소셜 제공자 타입 (GOOGLE, NAVER)", example = "GOOGLE")
@@ -33,5 +33,4 @@ public class AuthRequest {
         @NotBlank(message = "code는 필수 값입니다.")
         private String code;
     }
-
 }

--- a/src/main/java/com/dodo/backend/auth/dto/response/AuthResponse.java
+++ b/src/main/java/com/dodo/backend/auth/dto/response/AuthResponse.java
@@ -7,19 +7,19 @@ import lombok.Getter;
 
 /**
  * 인증(Auth) 도메인 관련 응답 데이터를 그룹화하여 관리하는 클래스입니다.
+ * <p>
+ * 소셜 로그인 성공 여부에 따른 서비스 토큰 발급 또는 신규 가입을 위한 임시 토큰 전달 등 인증 결과에 대한 응답 구조를 정의합니다.
  */
+@Schema(description = "인증 관련 응답 DTO 그룹")
 public class AuthResponse {
 
     /**
      * 소셜 로그인 성공 시(기존 회원) 클라이언트에게 반환하는 응답 DTO입니다.
-     * <p>
-     * 사용 프로세스:
-     * 1. 이메일 조회 결과 이미 가입된 정회원(ACTIVE)임이 확인됨
-     * 2. 서비스 이용이 가능한 Access Token과 Refresh Token을 즉시 발급
      */
     @Getter
     @Builder
     @AllArgsConstructor
+    @Schema(description = "소셜 로그인 성공 응답 (기존 회원)")
     public static class SocialLoginResponse {
 
         @Schema(description = "응답 메시지", example = "로그인이 완료되었습니다.")
@@ -50,15 +50,11 @@ public class AuthResponse {
 
     /**
      * 신규 회원가입 대상자일 경우 반환하는 응답 DTO입니다.
-     * <p>
-     * 사용 프로세스:
-     * 1. 이메일 조회 결과 가입되지 않은 신규 유저임이 확인됨
-     * 2. 추가 정보 입력을 위해 본인 인증용 임시 토큰(registrationToken) 발급
-     * 3. 클라이언트는 이 토큰과 함께 닉네임 등을 입력하여 회원가입 완료 요청
      */
     @Getter
     @Builder
     @AllArgsConstructor
+    @Schema(description = "신규 가입 대상자 응답 (추가 정보 입력 필요)")
     public static class SocialRegisterResponse {
 
         @Schema(description = "응답 메시지", example = "추가 정보가 필요합니다.")

--- a/src/main/java/com/dodo/backend/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/dodo/backend/auth/exception/AuthErrorCode.java
@@ -48,7 +48,7 @@ public enum AuthErrorCode implements BaseErrorCode {
      * <p>
      * HTTP {@code 403 Forbidden}을 반환합니다.
      */
-    ACCOUNT_RESTRICTED(HttpStatus.FORBIDDEN, "정지된 계정입니다. 또는 휴면 계정입니다."),
+    ACCOUNT_RESTRICTED(HttpStatus.FORBIDDEN, "정지된 계정 또는 휴면 계정입니다."),
 
     /**
      * 요청한 식별자(ID)에 해당하는 회원을 찾을 수 없을 때 사용합니다.

--- a/src/main/java/com/dodo/backend/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/dodo/backend/auth/service/AuthServiceImpl.java
@@ -7,7 +7,7 @@ import com.dodo.backend.auth.dto.response.AuthResponse.SocialRegisterResponse;
 import com.dodo.backend.auth.entity.RefreshToken;
 import com.dodo.backend.auth.exception.AuthException;
 import com.dodo.backend.auth.repository.RefreshTokenRepository;
-import com.dodo.backend.common.util.JwtTokenProvider;
+import com.dodo.backend.common.jwt.JwtTokenProvider;
 import com.dodo.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/dodo/backend/auth/service/RateLimitService.java
+++ b/src/main/java/com/dodo/backend/auth/service/RateLimitService.java
@@ -69,4 +69,30 @@ public interface RateLimitService {
      * @param duration 코드의 유효 유지 시간 (분 단위)
      */
     void saveVerificationCode(String email, String code, int duration);
+
+    /**
+     * 특정 이메일 주소로 발송되어 저장된 인증 코드를 조회합니다.
+     *
+     * @param email 수신자 이메일 (Key)
+     * @return 저장된 인증 코드 문자열, 만료되었거나 존재하지 않으면 {@code null}
+     */
+    String getVerificationCode(String email);
+
+    /**
+     * 특정 이메일과 관련된 인증 코드 데이터를 Redis에서 즉시 삭제합니다.
+     * <p>
+     * 인증 성공 직후 데이터를 초기화하기 위해 사용됩니다.
+     *
+     * @param email 삭제할 데이터의 기준 이메일 주소
+     */
+    void deleteVerificationCode(String email);
+
+    /**
+     * 특정 이메일 주소에 적용된 메일 발송 쿨타임(1분)을 즉시 해제합니다.
+     * <p>
+     * 본인 인증이 성공적으로 완료되었을 때, 남아있는 발송 제한을 초기화하기 위해 사용됩니다.
+     *
+     * @param email 쿨타임을 해제할 이메일 주소
+     */
+    void deleteEmailCooldown(String email);
 }

--- a/src/main/java/com/dodo/backend/auth/service/RateLimitServiceImpl.java
+++ b/src/main/java/com/dodo/backend/auth/service/RateLimitServiceImpl.java
@@ -107,4 +107,39 @@ public class RateLimitServiceImpl implements RateLimitService {
         String key = AUTH_CODE_PREFIX + email;
         redisTemplate.opsForValue().set(key, code, duration, TimeUnit.MINUTES);
     }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Redis의 {@code opsForValue().get()}을 사용하여 특정 이메일에 매핑된 인증 번호를 조회합니다.
+     * 저장된 데이터가 없거나 만료된 경우 {@code null}을 반환합니다.
+     */
+    @Override
+    public String getVerificationCode(String email) {
+        String key = AUTH_CODE_PREFIX + email;
+        return (String) redisTemplate.opsForValue().get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Redis에서 해당 이메일의 인증 번호 키를 즉시 삭제합니다.
+     * 본인 확인이 완료된 후 불필요한 데이터를 정리하기 위해 호출됩니다.
+     */
+    @Override
+    public void deleteVerificationCode(String email) {
+        String key = AUTH_CODE_PREFIX + email;
+        redisTemplate.delete(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Redis에서 해당 이메일의 메일 발송 제한 키를 삭제하여 즉시 재발송이 가능한 상태로 만듭니다.
+     */
+    @Override
+    public void deleteEmailCooldown(String email) {
+        String key = EMAIL_LIMIT_PREFIX + email;
+        redisTemplate.delete(key);
+    }
 }

--- a/src/main/java/com/dodo/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/dodo/backend/common/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.dodo.backend.common.config;
 
-import com.dodo.backend.common.util.JwtAuthenticationFilter;
-import com.dodo.backend.common.util.JwtTokenProvider;
+import com.dodo.backend.common.jwt.JwtAuthenticationFilter;
+import com.dodo.backend.common.jwt.JwtTokenProvider;
 import com.dodo.backend.user.exception.UserErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/dodo/backend/common/handler/UuidTypeHandler.java
+++ b/src/main/java/com/dodo/backend/common/handler/UuidTypeHandler.java
@@ -1,0 +1,44 @@
+package com.dodo.backend.common.handler;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+import java.nio.ByteBuffer;
+import java.sql.*;
+import java.util.UUID;
+
+@MappedTypes(UUID.class)
+public class UuidTypeHandler extends BaseTypeHandler<UUID> {
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, UUID parameter, JdbcType jdbcType) throws SQLException {
+        ps.setBytes(i, uuidToBytes(parameter));
+    }
+
+    @Override
+    public UUID getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return bytesToUuid(rs.getBytes(columnName));
+    }
+
+    @Override
+    public UUID getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return bytesToUuid(rs.getBytes(columnIndex));
+    }
+
+    @Override
+    public UUID getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return bytesToUuid(cs.getBytes(columnIndex));
+    }
+
+    private byte[] uuidToBytes(UUID uuid) {
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        return bb.array();
+    }
+
+    private UUID bytesToUuid(byte[] bytes) {
+        if (bytes == null) return null;
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        return new UUID(bb.getLong(), bb.getLong());
+    }
+}

--- a/src/main/java/com/dodo/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dodo/backend/common/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.dodo.backend.common.util;
+package com.dodo.backend.common.jwt;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/dodo/backend/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dodo/backend/common/jwt/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.dodo.backend.common.util;
+package com.dodo.backend.common.jwt;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/java/com/dodo/backend/user/dto/request/UserRequest.java
+++ b/src/main/java/com/dodo/backend/user/dto/request/UserRequest.java
@@ -4,27 +4,28 @@ import com.dodo.backend.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 유저(User) 도메인의 요청 데이터를 그룹화하여 관리하는 클래스입니다.
+ * 사용자(User) 도메인 관련 요청 데이터를 그룹화하여 관리하는 클래스입니다.
+ * <p>
+ * 회원가입 시의 프로필 추가 정보 입력, 계정 상태 변경을 위한 본인 인증 번호 전달 등 사용자 정보 수정과 관련된 요청 구조를 정의합니다.
  */
+@Schema(description = "유저 관련 요청 DTO 그룹")
 public class UserRequest {
 
     /**
      * 회원가입(추가 정보 입력) 요청 시 클라이언트가 전송하는 DTO입니다.
-     * <p>
-     * 사용 프로세스:
-     * 1. 소셜 로그인 후 'REGISTER' 상태인 유저가 닉네임, 지역 등 필수 정보를 입력
-     * 2. 이 DTO를 통해 전달된 데이터로 DB의 유저 정보를 업데이트하고 정회원(ACTIVE)으로 전환
      */
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    @Schema(description = "회원가입 추가 정보 입력 요청")
     public static class UserRegisterRequest {
 
         @Schema(description = "유저 닉네임", example = "강력한 개발자")
@@ -41,12 +42,6 @@ public class UserRequest {
 
         /**
          * DTO의 데이터와 식별자(Email)를 조합하여 업데이트용 User 엔티티를 생성합니다.
-         * <p>
-         * MyBatis Mapper에 파라미터로 전달하기 위해 사용되며,
-         * 이때 반환된 User 객체는 DB 저장이 아닌 업데이트 쿼리의 파라미터 용도로만 쓰입니다.
-         *
-         * @param email 토큰에서 추출한 유저의 이메일 (WHERE 조건)
-         * @return 업데이트할 정보를 담은 User 객체
          */
         public User toEntity(String email) {
             return User.builder()
@@ -56,5 +51,20 @@ public class UserRequest {
                     .hasFamily(this.hasFamily)
                     .build();
         }
+    }
+
+    /**
+     * 회원 탈퇴 확정을 위한 인증 번호 검증 요청 DTO입니다.
+     */
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "회원 탈퇴 본인 인증 요청")
+    public static class WithdrawalRequest {
+
+        @Schema(description = "이메일로 발송된 6자리 인증 번호", example = "936514")
+        @NotBlank(message = "인증 번호는 필수입니다.")
+        @Size(min = 6, max = 6, message = "인증 번호는 6자리여야 합니다.")
+        private String authCode;
     }
 }

--- a/src/main/java/com/dodo/backend/user/dto/response/UserResponse.java
+++ b/src/main/java/com/dodo/backend/user/dto/response/UserResponse.java
@@ -13,16 +13,16 @@ import java.time.LocalDateTime;
  * <p>
  * 내부 정적 클래스를 통해 회원가입 완료, 정보 조회 등 상황별 응답 DTO를 정의합니다.
  */
+@Schema(description = "유저 관련 response 그룹")
 public class UserResponse {
 
     /**
      * 회원가입 완료 후 클라이언트에게 반환되는 응답 DTO입니다.
-     * <p>
-     * 가입 성공 메시지와 함께 서비스 이용에 필요한 JWT(Access/Refresh) 토큰 정보를 포함합니다.
      */
     @Getter
     @Builder
     @AllArgsConstructor
+    @Schema(description = "회원가입 완료 및 토큰 발급 응답")
     public static class UserRegisterResponse {
 
         @Schema(description = "응답 메시지", example = "회원가입이 완료되었습니다.")
@@ -40,16 +40,6 @@ public class UserResponse {
         @Schema(description = "액세스 토큰 만료 시간 (밀리초 단위)", example = "3600000")
         private Long accessTokenExpiresIn;
 
-        /**
-         * 정적 팩토리 메서드: User 엔티티와 발급된 토큰 정보를 받아 응답 DTO를 생성합니다.
-         *
-         * @param user 엔티티 객체
-         * @param message 응답 메시지
-         * @param accessToken 발급된 액세스 토큰
-         * @param refreshToken 발급된 리프레시 토큰
-         * @param accessTokenExpiresIn 토큰 만료 시간
-         * @return 생성된 {@link UserRegisterResponse} 객체
-         */
         public static UserRegisterResponse toDto(User user, String message, String accessToken, String refreshToken, Long accessTokenExpiresIn) {
             return UserRegisterResponse.builder()
                     .message(message)
@@ -63,12 +53,11 @@ public class UserResponse {
 
     /**
      * 유저의 상세 프로필 정보를 반환하는 응답 DTO입니다.
-     * <p>
-     * 마이페이지 조회 등 유저의 계정 정보와 활동 정보를 전달할 때 사용됩니다.
      */
     @Getter
     @Builder
     @AllArgsConstructor
+    @Schema(description = "유저 상세 정보 조회 응답")
     public static class UserInfoResponse {
 
         @Schema(description = "응답 메시지", example = "유저 정보 조회 성공했습니다.")
@@ -98,13 +87,6 @@ public class UserResponse {
         @Schema(description = "계정 생성일", example = "2025-09-30T14:30:00Z")
         private LocalDateTime userCreatedAt;
 
-        /**
-         * 정적 팩토리 메서드: User 엔티티 정보를 상세 정보 응답 DTO로 변환합니다.
-         *
-         * @param user 엔티티 객체
-         * @param message 응답 메시지
-         * @return 생성된 {@link UserInfoResponse} 객체
-         */
         public static UserInfoResponse toDto(User user, String message) {
             return UserInfoResponse.builder()
                     .message(message)

--- a/src/main/java/com/dodo/backend/user/mapper/UserMapper.java
+++ b/src/main/java/com/dodo/backend/user/mapper/UserMapper.java
@@ -14,5 +14,24 @@ import java.util.UUID;
 @Mapper
 public interface UserMapper {
 
+    /**
+     * 신규 가입 유저의 추가 정보(닉네임, 지역 등)를 업데이트하고 계정을 활성화 상태로 변경합니다.
+     * <p>
+     * 소셜 로그인 이후 'REGISTER' 상태인 유저가 필수 정보를 모두 입력했을 때 호출되며,
+     * 엔티티의 필드 값을 기반으로 DB 레코드를 갱신합니다.
+     *
+     * @param user 추가 정보가 포함된 유저 엔티티 객체
+     */
     void updateUserRegistrationInfo(User user);
+
+    /**
+     * 유저의 계정 상태(UserStatus)를 명시적으로 변경합니다.
+     * <p>
+     * 주로 회원 탈퇴(DELETED), 계정 정지(SUSPENDED) 등 특정 상태 값만
+     * 빠르게 업데이트해야 하는 비즈니스 로직에서 사용됩니다.
+     *
+     * @param userId 유저의 고유 식별자 (UUID)
+     * @param status 변경하고자 하는 새로운 유저 상태값
+     */
+    void updateUserStatus(@Param("userId") UUID userId, @Param("status") String status);
 }

--- a/src/main/java/com/dodo/backend/user/service/UserService.java
+++ b/src/main/java/com/dodo/backend/user/service/UserService.java
@@ -57,4 +57,12 @@ public interface UserService {
      * @param userId 탈퇴 인증을 진행할 사용자의 아이디
      */
     void requestWithdrawal(UUID userId);
+
+    /**
+     * 사용자가 입력한 인증 번호를 검증하고 최종 탈퇴 처리를 수행합니다.
+     *
+     * @param userId   탈퇴를 진행할 유저의 UUID
+     * @param authCode 사용자가 입력한 6자리 인증 번호
+     */
+    void deleteWithdrawal(UUID userId, String authCode);
 }

--- a/src/main/resources/com/dodo/backend/user/mapper/UserMapper.xml
+++ b/src/main/resources/com/dodo/backend/user/mapper/UserMapper.xml
@@ -20,4 +20,16 @@
             user_status = 'ACTIVE'
         WHERE email = #{email}
     </update>
+
+    <!-- 사용자의 계정 상태를 'DELETED'로 전환합니다.
+         1. user_status : 삭제를 의미하는 'DELETED' 상태로 변경
+         2. WHERE users_id : 토큰에서 추출한 userId를 기준으로 특정 유저를 식별-->
+    <update id="updateUserStatus">
+        UPDATE users
+        SET
+            user_status = #{status},
+            user_status_updated_at = NOW()
+        WHERE
+            users_id = #{userId}
+    </update>
 </mapper>

--- a/src/test/java/com/dodo/backend/common/util/JwtTokenProviderTest.java
+++ b/src/test/java/com/dodo/backend/common/util/JwtTokenProviderTest.java
@@ -1,5 +1,6 @@
 package com.dodo.backend.common.util;
 
+import com.dodo.backend.common.jwt.JwtTokenProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 이메일 인증 번호 검증을 통한 사용자 상태 변경(DELETED) 기능 구현
- 탈퇴 성공 시 Redis 내 인증 코드 및 메일 발송 제한 데이터 즉시 삭제
- Java UUID와 MySQL BINARY(16) 간의 자동 형변환을 위한 전역 UuidTypeHandler 도입
- XML 내 하드코딩된 변환 함수(UNHEX, REPLACE)를 제거하여 표준 SQL 가독성 확보
- 매퍼 인터페이스 파라미터 타입 일관화(UUID)를 통한 데이터 바인딩 정상화


<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #34

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.
회원 탈퇴 기능 구현 했고 MyBatis UUID 처리할때 SQL 쿼리 함수로 계속해서 해주기 좀 그래서 Handler 생성했습니다.
