### PR TITLE
✨ Feat: 유저 프로필 정보 수정 기능 구현 및 검증 완료

### DIFF
--- a/src/main/java/com/dodo/backend/user/dto/request/UserRequest.java
+++ b/src/main/java/com/dodo/backend/user/dto/request/UserRequest.java
@@ -4,6 +4,7 @@ import com.dodo.backend.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,10 +31,13 @@ public class UserRequest {
 
         @Schema(description = "유저 닉네임", example = "강력한 개발자")
         @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$", message = "닉네임은 한글, 영문, 숫자만 가능합니다.")
         private String nickname;
 
         @Schema(description = "활동 지역", example = "서울시 동대문구")
         @NotBlank(message = "지역 정보는 필수입니다.")
+        @Size(max = 50, message = "지역 정보가 너무 깁니다.")
         private String region;
 
         @Schema(description = "가족 여부", example = "true")
@@ -66,5 +70,33 @@ public class UserRequest {
         @NotBlank(message = "인증 번호는 필수입니다.")
         @Size(min = 6, max = 6, message = "인증 번호는 6자리여야 합니다.")
         private String authCode;
+    }
+
+    /**
+     * 기존 사용자 정보를 수정하기 위한 요청 DTO입니다.
+     * <p>
+     * 닉네임, 활동 지역, 가족 여부 중 변경을 원하는 필드만 선택적으로 전송할 수 있습니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "유저 정보 수정 요청")
+    public static class UserUpdateRequest {
+
+        /** 변경하고자 하는 새로운 닉네임 (변경 시에만 포함) */
+        @Schema(description = "변경할 닉네임 (선택)", example = "김길자")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$", message = "닉네임은 한글, 영문, 숫자만 가능합니다.")
+        private String nickname;
+
+        /** 변경하고자 하는 새로운 활동 지역 (변경 시에만 포함) */
+        @Schema(description = "변경할 활동 지역 (선택)", example = "부산시 해운대구")
+        @Size(max = 50, message = "지역 정보가 너무 깁니다.")
+        private String region;
+
+        /** 변경하고자 하는 새로운 가족 여부 (변경 시에만 포함) */
+        @Schema(description = "변경할 가족 여부 (선택)", example = "false")
+        private Boolean hasFamily;
     }
 }

--- a/src/main/java/com/dodo/backend/user/dto/response/UserResponse.java
+++ b/src/main/java/com/dodo/backend/user/dto/response/UserResponse.java
@@ -101,4 +101,57 @@ public class UserResponse {
                     .build();
         }
     }
+
+    /**
+     * 유저 정보 수정 성공 시 반환되는 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "유저 정보 수정 완료 응답")
+    public static class UserUpdateResponse {
+
+        @Schema(description = "응답 메시지", example = "유저 정보 조회 성공했습니다.")
+        private String message;
+
+        @Schema(description = "이메일 주소", example = "100gusqls@naver.com")
+        private String email;
+
+        @Schema(description = "유저 실명", example = "백현빈")
+        private String name;
+
+        @Schema(description = "유저 닉네임", example = "김길자")
+        private String nickname;
+
+        @Schema(description = "활동 지역", example = "부산시 해운대구")
+        private String region;
+
+        @Schema(description = "가족 여부", example = "false")
+        private Boolean hasFamily;
+
+        @Schema(description = "프로필 이미지 URL", example = "https://i.pravatar.cc/150?img=3")
+        private String profileUrl;
+
+        @Schema(description = "계정 생성일", example = "2025-09-30T14:30:00Z")
+        private LocalDateTime createdAt;
+
+        /**
+         * 엔티티 객체를 수정 완료 응답 DTO로 변환합니다.
+         *
+         * @param user 수정된 유저 엔티티
+         * @return UserUpdateExResponse DTO
+         */
+        public static UserUpdateResponse toDto(User user, String message, String nickname, String region, Boolean hasFamily) {
+            return UserUpdateResponse.builder()
+                    .message(message)
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .nickname(nickname)
+                    .region(region)
+                    .hasFamily(hasFamily)
+                    .profileUrl(user.getProfileUrl())
+                    .createdAt(user.getUserCreatedAt())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/dodo/backend/user/mapper/UserMapper.java
+++ b/src/main/java/com/dodo/backend/user/mapper/UserMapper.java
@@ -34,4 +34,14 @@ public interface UserMapper {
      * @param status 변경하고자 하는 새로운 유저 상태값
      */
     void updateUserStatus(@Param("userId") UUID userId, @Param("status") String status);
+
+    /**
+     * 기존 사용자의 프로필 정보(닉네임, 지역, 가족 여부)를 선택적으로 업데이트합니다.
+     * <p>
+     * 엔티티 내의 필드 값이 null이 아닌 경우에만 해당 컬럼을 수정하며,
+     * 주로 유저 정보 수정(PATCH) API의 비즈니스 로직에서 호출됩니다.
+     *
+     * @param user 변경할 데이터가 담긴 유저 엔티티 객체
+     */
+    void updateUserProfileInfo(User user);
 }

--- a/src/main/java/com/dodo/backend/user/service/UserService.java
+++ b/src/main/java/com/dodo/backend/user/service/UserService.java
@@ -1,11 +1,16 @@
 package com.dodo.backend.user.service;
 
+import com.dodo.backend.user.dto.request.UserRequest;
 import com.dodo.backend.user.dto.request.UserRequest.UserRegisterRequest;
+import com.dodo.backend.user.dto.response.UserResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserInfoResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserRegisterResponse;
+import com.dodo.backend.user.dto.response.UserResponse.UserUpdateResponse;
 
 import java.util.Map;
 import java.util.UUID;
+
+import static com.dodo.backend.user.dto.request.UserRequest.*;
 
 /**
  * 사용자 정보 관리 및 회원 관련 비즈니스 로직을 담당하는 서비스 인터페이스입니다.
@@ -65,4 +70,17 @@ public interface UserService {
      * @param authCode 사용자가 입력한 6자리 인증 번호
      */
     void deleteWithdrawal(UUID userId, String authCode);
+
+    /**
+     * 기존 사용자의 프로필 정보(닉네임, 지역, 가족 여부)를 수정합니다.
+     * <p>
+     * 변경을 원하는 항목만 선택적으로 업데이트할 수 있으며,
+     * 닉네임 변경 시 시스템 내 중복 여부를 사전에 검증합니다.
+     *
+     * @param userId  정보를 수정할 사용자의 고유 ID
+     * @param request 수정할 항목들이 담긴 DTO 객체
+     * @return 수정이 완료된 후의 최신 사용자 정보 응답 DTO
+     */
+    UserUpdateResponse updateUserInfo(UUID userId, UserUpdateRequest request);
+
 }

--- a/src/main/resources/com/dodo/backend/user/mapper/UserMapper.xml
+++ b/src/main/resources/com/dodo/backend/user/mapper/UserMapper.xml
@@ -32,4 +32,15 @@
         WHERE
             users_id = #{userId}
     </update>
+
+    <update id="updateUserProfileInfo" parameterType="com.dodo.backend.user.entity.User">
+        UPDATE users
+        <set>
+            <if test="nickname != null">nickname = #{nickname},</if>
+            <if test="region != null">region = #{region},</if>
+            <if test="hasFamily != null">has_family = #{hasFamily},</if>
+            user_status_updated_at = NOW()
+        </set>
+        WHERE users_id = #{usersId}
+    </update>
 </mapper>

--- a/src/test/java/com/dodo/backend/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/dodo/backend/user/mapper/UserMapperTest.java
@@ -1,0 +1,136 @@
+package com.dodo.backend.user.mapper;
+
+import com.dodo.backend.user.entity.User;
+import com.dodo.backend.user.entity.UserRole;
+import com.dodo.backend.user.entity.UserStatus;
+import com.dodo.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * MyBatis 매퍼인 {@link UserMapper}의 SQL 실행 결과를 검증하는 통합 테스트 클래스입니다.
+ * <p>
+ * MyBatis와 JPA가 동일한 데이터베이스 세션을 공유하므로 영속성 컨텍스트 관리를 통한 정합성 검증을 수행합니다.
+ */
+@SpringBootTest
+@Transactional
+@Slf4j
+class UserMapperTest {
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private User testUser;
+
+    /**
+     * 각 테스트 실행 전 가입 대기 유저를 생성하고 물리적 데이터 반영 후 1차 캐시를 비웁니다.
+     */
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("mapper_test@example.com")
+                .name("매퍼테스터")
+                .nickname("초기닉네임")
+                .region("서울")
+                .hasFamily(true)
+                .userStatus(UserStatus.REGISTER)
+                .role(UserRole.USER)
+                .notificationEnabled(true)
+                .profileUrl("https://i.pravatar.cc/150")
+                .userCreatedAt(LocalDateTime.now())
+                .build();
+        userRepository.save(testUser);
+        em.flush();
+        em.clear();
+        log.info("기초 데이터 저장 및 영속성 컨텍스트 초기화 수행 완료");
+    }
+
+    /**
+     * 회원가입 추가 정보를 반영하는 SQL 쿼리가 정상 작동하는지 확인합니다.
+     */
+    @Test
+    @DisplayName("매퍼를 통한 회원 정보 업데이트 및 상태 변경")
+    void updateUserRegistrationInfoTest() {
+        // given
+        User updateParam = User.builder()
+                .email(testUser.getEmail())
+                .nickname("가입완료닉네임")
+                .region("경기")
+                .hasFamily(false)
+                .build();
+        log.info("회원가입 정보 업데이트 매퍼 쿼리 실행");
+
+        // when
+        userMapper.updateUserRegistrationInfo(updateParam);
+
+        // then
+        em.clear();
+        User updatedUser = userRepository.findByEmail(testUser.getEmail()).orElseThrow();
+        assertThat(updatedUser.getNickname()).isEqualTo("가입완료닉네임");
+        assertThat(updatedUser.getUserStatus()).isEqualTo(UserStatus.ACTIVE);
+        log.info("회원가입 정보 업데이트 SQL 실행 결과 검증 성공");
+    }
+
+    /**
+     * 유저 식별자를 이용해 상태값만 변경하는 SQL 쿼리를 검증합니다.
+     */
+    @Test
+    @DisplayName("매퍼를 통한 유저 상태값 명시적 변경")
+    void updateUserStatusTest() {
+        // given
+        UUID userId = testUser.getUsersId();
+        String newStatus = UserStatus.DELETED.name();
+        log.info("계정 상태 변경 매퍼 테스트 시작 - 변경될 상태: {}", newStatus);
+
+        // when
+        userMapper.updateUserStatus(userId, newStatus);
+
+        // then
+        em.clear();
+        User updatedUser = userRepository.findById(userId).orElseThrow();
+        assertThat(updatedUser.getUserStatus().name()).isEqualTo(newStatus);
+        log.info("계정 상태 변경 SQL 실행 결과 검증 완료");
+    }
+
+    /**
+     * 동적 SQL을 통해 제공된 필드만 수정되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("매퍼를 통한 프로필 필드 선택적 수정")
+    void updateUserProfileInfoTest() {
+        // given
+        User updateParam = User.builder()
+                .usersId(testUser.getUsersId())
+                .nickname("수정닉네임")
+                .region(null)
+                .build();
+        log.info("프로필 선택적 수정 매퍼 테스트 시작 - 필드: 닉네임");
+
+        // when
+        userMapper.updateUserProfileInfo(updateParam);
+
+        // then
+        em.clear();
+        User result = userRepository.findById(testUser.getUsersId()).orElseThrow();
+        assertThat(result.getNickname()).isEqualTo("수정닉네임");
+        assertThat(result.getRegion()).isEqualTo("서울");
+        log.info("동적 쿼리 필드 선택적 수정 검증 성공");
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- MyBatis 동적 SQL을 활용하여 닉네임, 지역, 가족 여부 중 변경 요청된 필드만 업데이트하는 로직 구현
- 서비스 레이어 내 메모리 조립 방식을 통해 DB 재조회 없이 최신 데이터를 포함한 응답 DTO 반환
- 닉네임 변경 시 중복 체크 수행 및 본인 기존 닉네임 유지 시 예외 처리 제외 로직 반영
- UserServiceImplTest: 선택적 필드 업데이트 및 데이터 보존 로직 통합 테스트 완료
- UserMapperTest: MyBatis 실행 결과와 JPA 영속성 컨텍스트 간 데이터 동기화 검증 완료

<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

- Closes #36

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

프로필 정보 수정 기능 구현했는데 request에서 선택적으로 body값에 파라미터 보내면 그거에 맞춰서 업데이트 하게 해놨습니다.
