### PR TITLE
✨ Feat: 토큰 재발급(Reissue) 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/auth/dto/request/AuthRequest.java
+++ b/src/main/java/com/dodo/backend/auth/dto/request/AuthRequest.java
@@ -48,4 +48,18 @@ public class AuthRequest {
         @NotBlank(message = "리프레시 토큰은 필수 값입니다.")
         private String refreshToken;
     }
+
+    /**
+     * 액세스 토큰 재발급을 위한 요청 DTO입니다.
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "토큰 재발급 요청")
+    public static class ReissueRequest {
+
+        @Schema(description = "만료된 액세스 토큰을 갱신하기 위한 리프레시 토큰", example = "abc12300f29184b...")
+        @NotBlank(message = "리프레시 토큰은 필수 값입니다.")
+        private String refreshToken;
+    }
 }

--- a/src/main/java/com/dodo/backend/auth/dto/response/AuthResponse.java
+++ b/src/main/java/com/dodo/backend/auth/dto/response/AuthResponse.java
@@ -82,4 +82,39 @@ public class AuthResponse {
                     .build();
         }
     }
+
+    /**
+     * 토큰 재발급 성공 시 반환되는 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "토큰 재발급 응답 (RTR 적용)")
+    public static class TokenResponse {
+
+        @Schema(description = "새로 발급된 서버 접근용 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        private String accessToken;
+
+        @Schema(description = "새로 갱신된 리프레시 토큰 (Rotation)", example = "def50200f29184b294277418292...")
+        private String refreshToken;
+
+        @Schema(description = "액세스 토큰 만료 시간 (초 단위)", example = "3600")
+        private Long accessTokenExpiresIn;
+
+        /**
+         * 토큰 문자열과 만료 시간을 받아 응답 DTO를 생성하는 정적 팩토리 메서드입니다.
+         *
+         * @param accessToken       새로 생성된 액세스 토큰
+         * @param refreshToken      새로 생성된 리프레시 토큰
+         * @param accessTokenExpiresIn 액세스 토큰의 유효 기간 (밀리초 단위 -> 초 단위 변환 필요 시 로직 확인)
+         * @return 빌드된 TokenResponse 객체
+         */
+        public static TokenResponse toDto(String accessToken, String refreshToken, Long accessTokenExpiresIn) {
+            return TokenResponse.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .accessTokenExpiresIn(accessTokenExpiresIn)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/dodo/backend/auth/service/AuthService.java
+++ b/src/main/java/com/dodo/backend/auth/service/AuthService.java
@@ -2,6 +2,9 @@ package com.dodo.backend.auth.service;
 
 import com.dodo.backend.auth.dto.request.AuthRequest;
 import com.dodo.backend.auth.dto.request.AuthRequest.LogoutRequest;
+import com.dodo.backend.auth.dto.request.AuthRequest.ReissueRequest;
+import com.dodo.backend.auth.dto.response.AuthResponse;
+import com.dodo.backend.auth.dto.response.AuthResponse.TokenResponse;
 import org.springframework.http.ResponseEntity;
 
 /**
@@ -41,4 +44,16 @@ public interface AuthService {
      * @param accessToken 현재 사용 중인 액세스 토큰 (Header에서 추출)
      */
     void logout(LogoutRequest request, String accessToken);
+
+    /**
+     * 리프레시 토큰을 검증하고 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.
+     * <p>
+     * 보안 강화를 위해 <b>RTR(Refresh Token Rotation)</b> 방식을 사용하여,
+     * 재발급 요청 시 기존 리프레시 토큰은 파기되고 새로운 리프레시 토큰이 발급됩니다.
+     *
+     * @param request 유효한 리프레시 토큰이 담긴 요청 객체
+     * @return 새로 발급된 토큰 쌍(Access/Refresh)과 만료 시간을 담은 응답 DTO
+     * @throws com.dodo.backend.auth.exception.AuthException 토큰이 유효하지 않거나 만료된 경우, 또는 Redis에 존재하지 않는 경우
+     */
+    TokenResponse reissueToken(ReissueRequest request);
 }

--- a/src/main/java/com/dodo/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/dodo/backend/common/config/SecurityConfig.java
@@ -65,7 +65,8 @@ public class SecurityConfig {
                                 "/auth/social-login",
                                 "/view/login",
                                 "/google-login",
-                                "/naver-login"
+                                "/naver-login",
+                                "/auth/reissue"
                         ).permitAll()
                         .requestMatchers(
                                 "/swagger-ui.html",


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- Access Token 및 Refresh Token 재발급 API(/auth/reissue) 구현
- 보안 강화를 위한 RTR(Refresh Token Rotation) 방식 적용
- SecurityConfig 재발급 경로 접근 허용(permitAll) 설정
- 관련 Request/Response DTO 추가 및 단위 테스트 코드 작성
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #42

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 토큰 재발급 기능 개발했습니다.
- 재발급 기능은 AccessToken이 만료된것이기 때문에 그냥 허용 SecurityConfig에 경로 추가했습니다.
