### PR TITLE
✨ Feat: 가족 초대와 승인 프로세스 분리 및 멤버십 상태 관리 구현

### DIFF
--- a/src/main/java/com/dodo/backend/pet/controller/PetController.java
+++ b/src/main/java/com/dodo/backend/pet/controller/PetController.java
@@ -1,11 +1,10 @@
 package com.dodo.backend.pet.controller;
 
 import com.dodo.backend.common.exception.ErrorResponse;
-import com.dodo.backend.pet.dto.request.PetRequest;
+import com.dodo.backend.pet.dto.request.PetRequest.PetFamilyApprovalRequest;
 import com.dodo.backend.pet.dto.request.PetRequest.PetFamilyJoinRequest;
 import com.dodo.backend.pet.dto.request.PetRequest.PetRegisterRequest;
 import com.dodo.backend.pet.dto.request.PetRequest.PetUpdateRequest;
-import com.dodo.backend.pet.dto.response.PetResponse;
 import com.dodo.backend.pet.dto.response.PetResponse.*;
 import com.dodo.backend.pet.service.PetService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -183,19 +182,19 @@ public class PetController {
     }
 
     /**
-     * 초대 코드를 입력하여 반려동물 가족 그룹에 참여합니다.
+     * 초대 코드를 입력하여 반려동물 가족 그룹에 참여를 신청합니다.
      * <p>
-     * 유효한 코드인 경우 즉시 가족(APPROVED)으로 등록되며,
-     * 해당 반려동물의 정보와 현재 가족 구성원 목록을 응답합니다.
+     * 유효한 코드인 경우 대기(PENDING) 상태로 등록되며,
+     * 신청된 <b>펫 ID</b>와 <b>승인 대기 메시지</b>를 반환합니다.
      *
      * @param request     6자리 초대 코드가 담긴 요청 객체
      * @param userDetails 인증된 사용자 정보
-     * @return 참여한 펫 정보와 전체 가족 구성원 목록 (HTTP 200)
+     * @return 펫 ID와 처리 결과 메시지 (HTTP 200)
      */
-    @Operation(summary = "가족 초대 수락", description = "초대 코드를 입력하여 해당 반려동물의 가족으로 등록됩니다.")
+    @Operation(summary = "가족 초대 수락 신청", description = "초대 코드를 입력하여 해당 반려동물의 가족으로 등록을 신청합니다 (승인 대기)")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "가족 등록 성공",
-                    content = @Content(schema = @Schema(implementation = PetFamilyJoinResponse.class))),
+            @ApiResponse(responseCode = "200", description = "신청 성공",
+                    content = @Content(schema = @Schema(implementation = PetFamilyJoinRequestResponse.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
@@ -213,14 +212,67 @@ public class PetController {
                             examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
     })
     @PostMapping("/family")
-    public ResponseEntity<PetFamilyJoinResponse> joinFamily(
+    public ResponseEntity<PetFamilyJoinRequestResponse> joinFamily(
             @Valid @RequestBody PetFamilyJoinRequest request,
             @AuthenticationPrincipal UserDetails userDetails) {
 
         UUID userId = UUID.fromString(userDetails.getUsername());
         log.info("가족 초대 수락 요청 - User: {}, Code: {}", userId, request.getCode());
 
-        return ResponseEntity.ok(petService.joinFamily(userId, request));
+        return ResponseEntity.ok(petService.applyForFamily(userId, request));
+    }
+
+    /**
+     * 대기 중인 가족 등록 요청을 승인하거나 거절합니다.
+     * <p>
+     * 관리자(기존 가족 구성원)는 대기(PENDING) 상태인 요청을 승인하여 정식 구성원으로 등록하거나,
+     * 거절하여 요청 목록에서 삭제할 수 있습니다.
+     *
+     * @param request     승인/거절 처리에 필요한 요청 정보
+     * @param userDetails 인증된 사용자 정보
+     * @return 처리 결과 메시지 JSON
+     */
+    @Operation(summary = "가족 요청 승인/거절", description = "대기 중인 가족 등록 요청을 승인하거나 거절합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "신청 성공",
+                    content = @Content(schema = @Schema(implementation = PetFamilyApprovalResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "승인 권한 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"승인 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "대상 유저 또는 요청을 찾을 수 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"대상 유저 또는 요청을 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "이미 가족으로 등록되어있습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "409 Conflict", value = "{\"status\": 409, \"message\": \"이미 가족으로 등록되어있습니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @PostMapping("/family/approval")
+    public ResponseEntity<PetFamilyApprovalResponse> handleFamilyApproval(
+            @Valid @RequestBody PetFamilyApprovalRequest request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        UUID requesterId = UUID.fromString(userDetails.getUsername());
+
+        return ResponseEntity.ok(petService.manageFamily(
+                requesterId,
+                request.getPetId(),
+                request.getTargetUserId(),
+                request.getAction()
+        ));
     }
 
     /**

--- a/src/main/java/com/dodo/backend/pet/dto/request/PetRequest.java
+++ b/src/main/java/com/dodo/backend/pet/dto/request/PetRequest.java
@@ -3,6 +3,7 @@ package com.dodo.backend.pet.dto.request;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.pet.entity.PetSex;
 import com.dodo.backend.pet.entity.PetSpecies;
+import com.dodo.backend.userpet.entity.RegistrationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -14,6 +15,7 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 /**
  * 펫 도메인과 관련된 요청 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
@@ -138,6 +140,29 @@ public class PetRequest {
         @NotBlank(message = "초대 코드는 필수입니다.")
         @Size(min = 6, max = 6, message = "초대 코드는 6자리여야 합니다.")
         private String code;
+    }
+
+    /**
+     * 가족 등록 요청 승인/거절을 위한 DTO입니다.
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "가족 요청 승인/거절 요청")
+    public static class PetFamilyApprovalRequest {
+
+        @NotNull
+        @Schema(description = "반려동물 ID", example = "1")
+        private Long petId;
+
+        @NotNull
+        @Schema(description = "승인/거절 대상 유저 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+        private UUID targetUserId;
+
+        @NotBlank
+        @Schema(description = "처리할 상태 (APPROVED: 승인, REJECTED: 거절)", example = "APPROVED")
+        private String action;
     }
 
 }

--- a/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
@@ -8,10 +8,12 @@ import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * 펫 도메인과 관련된 응답 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
+ * <p>
+ * 펫 등록, 수정, 조회, 가족 초대 및 승인 등 다양한 API 응답에 사용되는
+ * Inner Static Class들을 포함하고 있습니다.
  */
 @Schema(description = "펫 관련 응답 DTO 그룹")
 public class PetResponse {
@@ -32,10 +34,11 @@ public class PetResponse {
         private String message;
 
         /**
-         * 펫 ID를 사용하여 응답 DTO 객체를 생성하는 정적 팩토리 메서드입니다.
+         * 펫 ID와 메시지를 사용하여 응답 DTO 객체를 생성하는 정적 팩토리 메서드입니다.
          *
-         * @param petId 생성된 펫의 고유 식별자
-         * @return 초기화된 PetRegisterResponse 객체
+         * @param petId   생성된 펫의 고유 식별자
+         * @param message 클라이언트에게 전달할 성공 메시지
+         * @return 초기화된 {@link PetRegisterResponse} 객체
          */
         public static PetRegisterResponse toDto(Long petId, String message) {
             return PetRegisterResponse.builder()
@@ -54,7 +57,7 @@ public class PetResponse {
     @Schema(description = "반려동물 정보 수정 결과 응답")
     public static class PetUpdateResponse {
 
-        @Schema(description = "응답 메시지", example = "새 반려동물을 등록완료했습니다.")
+        @Schema(description = "응답 메시지", example = "반려동물 정보 수정을 완료했습니다.")
         private String message;
 
         @Schema(description = "반려동물 고유 ID", example = "1")
@@ -99,7 +102,7 @@ public class PetResponse {
          * @param breed              변경된 품종
          * @param referenceHeartRate 변경된 심박수 기준
          * @param deviceId           변경된 디바이스 ID
-         * @return 수정 완료 정보가 담긴 PetDetailResponse DTO
+         * @return 수정 완료 정보가 담긴 {@link PetUpdateResponse} DTO
          */
         public static PetUpdateResponse toDto(Long petId, String message, String registrationNumber,
                                               String sex, Integer age, String petName,
@@ -135,56 +138,31 @@ public class PetResponse {
     }
 
     /**
-     * 가족 초대 코드를 통해 그룹에 성공적으로 참여했을 때 반환되는 응답 DTO입니다.
-     * <p>
-     * 참여한 반려동물의 정보와 현재 가족 구성원 목록을 포함합니다.
+     * 가족 초대 코드를 통해 등록 신청을 완료했을 때 반환되는 응답 DTO입니다.
      */
     @Getter
     @Builder
     @AllArgsConstructor
-    @Schema(description = "가족 초대 수락 및 멤버 조회 응답")
-    public static class PetFamilyJoinResponse {
+    @Schema(description = "가족 초대 신청 결과 응답")
+    public static class PetFamilyJoinRequestResponse {
 
-        @Schema(description = "반려동물 ID", example = "101")
+        @Schema(description = "신청한 반려동물 ID", example = "101")
         private Long petId;
 
-        @Schema(description = "반려동물 이름", example = "보리")
-        private String petName;
-
-        @Schema(description = "가족 구성원 목록")
-        private List<FamilyMemberList> familyMembers;
+        @Schema(description = "처리 결과 메시지", example = "가족 등록을 신청했습니다. 승인을 기다려주세요.")
+        private String message;
 
         /**
-         * 가족 구성원의 간략한 프로필 정보를 담는 내부 DTO 클래스입니다.
-         */
-        @Getter
-        @Builder
-        @AllArgsConstructor
-        @Schema(description = "가족 구성원 정보")
-        public static class FamilyMemberList {
-            @Schema(description = "사용자 ID", example = "a1b2c3d4-...")
-            private UUID userId;
-
-            @Schema(description = "프로필 이미지 URL", example = "https://i.pravatar.cc/150?img=3")
-            private String profileUrl;
-
-            @Schema(description = "닉네임", example = "이순재")
-            private String nickname;
-        }
-
-        /**
-         * 펫 정보와 가족 목록을 받아 응답 DTO를 생성하는 정적 팩토리 메서드입니다.
+         * 펫 ID와 메시지를 받아 응답 DTO를 생성합니다.
          *
-         * @param petId         반려동물 ID
-         * @param petName       반려동물 이름
-         * @param familyMembers 변환된 가족 구성원 목록 DTO
-         * @return 초기화된 PetFamilyJoinResponse 객체
+         * @param petId   신청된 반려동물 ID
+         * @param message 처리 결과 메시지
+         * @return 초기화된 {@link PetFamilyJoinRequestResponse} 객체
          */
-        public static PetFamilyJoinResponse toDto(Long petId, String petName, List<FamilyMemberList> familyMembers) {
-            return PetFamilyJoinResponse.builder()
+        public static PetFamilyJoinRequestResponse toDto(Long petId, String message) {
+            return PetFamilyJoinRequestResponse.builder()
                     .petId(petId)
-                    .petName(petName)
-                    .familyMembers(familyMembers)
+                    .message(message)
                     .build();
         }
     }
@@ -268,6 +246,36 @@ public class PetResponse {
 
             @Schema(description = "등록번호", example = "4102020001231")
             private String registrationNumber;
+        }
+    }
+
+    /**
+     * 가족 승인/거절 처리가 완료되었을 때 반환되는 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "가족 승인/거절 처리 결과 응답")
+    public static class PetFamilyApprovalResponse {
+
+        @Schema(description = "대상 반려동물 ID", example = "101")
+        private Long petId;
+
+        @Schema(description = "처리 결과 메시지", example = "가족 신청을 승인했습니다.")
+        private String message;
+
+        /**
+         * 펫 ID와 처리 메시지를 받아 응답 DTO를 생성합니다.
+         *
+         * @param petId   처리된 반려동물 ID
+         * @param message 처리 결과 메시지 (승인/거절 여부 포함)
+         * @return 초기화된 {@link PetFamilyApprovalResponse} 객체
+         */
+        public static PetFamilyApprovalResponse toDto(Long petId, String message) {
+            return PetFamilyApprovalResponse.builder()
+                    .petId(petId)
+                    .message(message)
+                    .build();
         }
     }
 }

--- a/src/main/java/com/dodo/backend/pet/service/PetService.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetService.java
@@ -3,9 +3,7 @@ package com.dodo.backend.pet.service;
 import com.dodo.backend.pet.dto.request.PetRequest.PetFamilyJoinRequest;
 import com.dodo.backend.pet.dto.request.PetRequest.PetRegisterRequest;
 import com.dodo.backend.pet.dto.request.PetRequest.PetUpdateRequest;
-import com.dodo.backend.pet.dto.response.PetResponse;
 import com.dodo.backend.pet.dto.response.PetResponse.*;
-import com.dodo.backend.pet.entity.Pet;
 import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
@@ -26,8 +24,6 @@ public interface PetService {
 
     /**
      * 반려동물의 정보를 선택적으로 수정합니다.
-     * <p>
-     * MyBatis의 동적 쿼리를 호출하여 값이 존재하는 필드만 업데이트합니다.
      *
      * @param petId  수정할 반려동물의 고유 ID
      * @param request 수정할 정보를 담은 요청 객체
@@ -37,9 +33,6 @@ public interface PetService {
 
     /**
      * 반려동물 가족 초대를 위한 코드를 발급합니다.
-     * <p>
-     * 반려동물의 존재 여부를 검증한 후, 실제 코드 생성 및 저장 로직은
-     * {@link com.dodo.backend.userpet.service.UserPetService}에 위임합니다.
      *
      * @param userId 요청한 사용자 ID
      * @param petId  반려동물 ID
@@ -48,35 +41,31 @@ public interface PetService {
     PetInvitationResponse issueInvitationCode(UUID userId, Long petId);
 
     /**
-     * 사용자가 입력한 초대 코드를 통해 반려동물 가족 그룹에 참여합니다.
-     * <p>
-     * 실제 등록 로직은 {@link com.dodo.backend.userpet.service.UserPetService}에서 수행하며,
-     * 결과 데이터를 응답 DTO로 변환하여 반환합니다.
+     * 사용자가 입력한 초대 코드를 통해 반려동물 가족 그룹 참여를 신청합니다.
      *
      * @param userId  요청한 사용자의 ID
-     * @param request 초대 코드가 포함된 요청 DTO (PetFamilyJoinRequest)
-     * @return 펫 정보와 가족 구성원 목록이 담긴 응답 DTO
+     * @param request 초대 코드가 포함된 요청 DTO
+     * @return 신청된 펫 ID와 처리 결과 메시지
      */
-    PetFamilyJoinResponse joinFamily(UUID userId, PetFamilyJoinRequest request);
-
-    /**
-     * 반려동물 ID를 기반으로 Pet 엔티티를 조회합니다.
-     * <p>
-     * 다른 도메인 서비스(UserPet 등)에서 Pet 엔티티가 필요할 때
-     * 리포지토리를 직접 호출하지 않고 이 메소드를 사용합니다.
-     *
-     * @param petId 조회할 반려동물의 ID
-     * @return 조회된 Pet 엔티티
-     * @throws com.dodo.backend.pet.exception.PetException 해당 ID의 반려동물이 존재하지 않을 경우
-     */
-    Pet getPet(Long petId);
+    PetFamilyJoinRequestResponse applyForFamily(UUID userId, PetFamilyJoinRequest request);
 
     /**
      * 사용자의 반려동물 목록을 페이징하여 조회합니다.
      *
      * @param userId   조회할 사용자의 ID
-     * @param pageable 페이징 요청 정보 (page, size)
+     * @param pageable 페이징 요청 정보
      * @return 페이징 처리된 반려동물 목록 응답 DTO
      */
     PetListResponse getPetList(UUID userId, Pageable pageable);
+
+    /**
+     * 대기 중인 가족 등록 요청을 승인하거나 거절합니다.
+     *
+     * @param requesterId  요청을 수행하는 관리자(기존 가족) ID
+     * @param petId        반려동물 ID
+     * @param targetUserId 승인/거절 대상 유저 ID
+     * @param action       처리할 상태 문자열 ("APPROVED" 또는 "REJECTED")
+     * @return 펫 ID와 처리 결과 메시지
+     */
+    PetFamilyApprovalResponse manageFamily(UUID requesterId, Long petId, UUID targetUserId, String action);
 }

--- a/src/main/java/com/dodo/backend/user/service/UserService.java
+++ b/src/main/java/com/dodo/backend/user/service/UserService.java
@@ -1,17 +1,13 @@
 package com.dodo.backend.user.service;
 
-import com.dodo.backend.user.dto.request.UserRequest;
 import com.dodo.backend.user.dto.request.UserRequest.UserRegisterRequest;
-import com.dodo.backend.user.dto.response.UserResponse;
+import com.dodo.backend.user.dto.request.UserRequest.UserUpdateRequest;
 import com.dodo.backend.user.dto.response.UserResponse.UserInfoResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserRegisterResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserUpdateResponse;
-import com.dodo.backend.user.entity.User;
 
 import java.util.Map;
 import java.util.UUID;
-
-import static com.dodo.backend.user.dto.request.UserRequest.*;
 
 /**
  * 사용자 정보 관리 및 회원 관련 비즈니스 로직을 담당하는 서비스 인터페이스입니다.
@@ -23,9 +19,6 @@ public interface UserService {
 
     /**
      * 회원가입 시 수집되는 사용자의 추가 정보를 시스템에 등록합니다.
-     * <p>
-     * 소셜 로그인 이후 서비스 이용에 필요한 최소한의 프로필 정보를 저장하고,
-     * 정식 회원으로의 전환 처리를 수행합니다.
      *
      * @param request 등록할 사용자 추가 정보 DTO
      * @param email 정보를 등록할 대상 사용자의 이메일 주소
@@ -35,9 +28,6 @@ public interface UserService {
 
     /**
      * 외부 소셜 제공자로부터 전달받은 정보를 기반으로 유저를 조회하거나 신규 등록합니다.
-     * <p>
-     * 시스템에 이미 존재하는 이메일인 경우 해당 유저 정보를 반환하며,
-     * 존재하지 않는 경우 신규 유저로 생성하여 데이터베이스에 영속화합니다.
      *
      * @param email 소셜 계정의 이메일 주소
      * @param name 사용자의 이름 또는 별명
@@ -56,9 +46,6 @@ public interface UserService {
 
     /**
      * 계정 탈퇴를 위한 본인 확인 인증 메일 발송을 요청합니다.
-     * <p>
-     * 내부적으로 메일 서비스를 호출하여 보안 인증 코드를 발송하며,
-     * 탈퇴 절차의 첫 번째 단계인 본인 확인 프로세스를 시작합니다.
      *
      * @param userId 탈퇴 인증을 진행할 사용자의 아이디
      */
@@ -74,9 +61,6 @@ public interface UserService {
 
     /**
      * 기존 사용자의 프로필 정보(닉네임, 지역, 가족 여부)를 수정합니다.
-     * <p>
-     * 변경을 원하는 항목만 선택적으로 업데이트할 수 있으며,
-     * 닉네임 변경 시 시스템 내 중복 여부를 사전에 검증합니다.
      *
      * @param userId  정보를 수정할 사용자의 고유 ID
      * @param request 수정할 항목들이 담긴 DTO 객체
@@ -86,8 +70,6 @@ public interface UserService {
 
     /**
      * 사용자의 알림 수신 설정(ON/OFF)을 변경합니다.
-     * <p>
-     * 변경하고자 하는 알림 수신 여부 값을 받아, 해당 사용자의 설정 상태를 즉시 갱신합니다.
      *
      * @param userId  설정을 변경할 사용자의 고유 식별자(UUID)
      * @param enabled 변경할 알림 수신 여부 (true: 수신 허용, false: 수신 거부)
@@ -96,24 +78,9 @@ public interface UserService {
 
     /**
      * 사용자의 존재 여부를 검증합니다.
-     * <p>
-     * 반환값 없이 단순히 해당 ID를 가진 사용자가 DB에 존재하는지만 확인하며,
-     * 존재하지 않을 경우 예외를 발생시킵니다.
-     * 타 도메인(Pet 등)에서 유저 ID의 유효성을 검사할 때 사용합니다.
      *
      * @param userId 검증할 사용자의 고유 식별자(UUID)
      * @throws com.dodo.backend.user.exception.UserException 유저가 존재하지 않을 경우 (USER_NOT_FOUND)
      */
     void validateUserExists(UUID userId);
-
-    /**
-     * 내부 로직 처리를 위해 User 엔티티 객체를 직접 조회합니다.
-     * <p>
-     * DTO가 아닌 엔티티 객체가 필요한 경우(예: JPA 연관관계 매핑)에 사용됩니다.
-     *
-     * @param userId 조회할 사용자의 고유 식별자(UUID)
-     * @return 조회된 User 엔티티 객체
-     * @throws com.dodo.backend.user.exception.UserException 유저가 존재하지 않을 경우 (USER_NOT_FOUND)
-     */
-    User getUserEntity(UUID userId);
 }

--- a/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
@@ -292,16 +292,4 @@ public class UserServiceImpl implements UserService {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * JPA 영속성 컨텍스트가 관리하는 엔티티를 반환하여,
-     * 다른 도메인(Pet, UserPet 등)에서 연관관계를 맺을 때 사용하도록 합니다.
-     */
-    @Transactional(readOnly = true)
-    @Override
-    public User getUserEntity(UUID userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
-    }
 }

--- a/src/main/java/com/dodo/backend/userpet/mapper/UserPetMapper.java
+++ b/src/main/java/com/dodo/backend/userpet/mapper/UserPetMapper.java
@@ -1,0 +1,22 @@
+package com.dodo.backend.userpet.mapper;
+
+import com.dodo.backend.userpet.entity.RegistrationStatus;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.data.repository.query.Param;
+
+import java.util.UUID;
+
+@Mapper
+public interface UserPetMapper {
+
+    /**
+     * 특정 유저와 펫의 관계 상태(RegistrationStatus)를 변경합니다.
+     *
+     * @param userId 유저 UUID
+     * @param petId  펫 ID
+     * @param status 변경할 상태 (APPROVED 등)
+     */
+    void updateRegistrationStatus(@Param("userId") UUID userId,
+                                  @Param("petId") Long petId,
+                                  @Param("status") String status);
+}

--- a/src/main/java/com/dodo/backend/userpet/repository/UserPetRepository.java
+++ b/src/main/java/com/dodo/backend/userpet/repository/UserPetRepository.java
@@ -1,5 +1,6 @@
 package com.dodo.backend.userpet.repository;
 
+import com.dodo.backend.userpet.entity.RegistrationStatus;
 import com.dodo.backend.userpet.entity.UserPet;
 import com.dodo.backend.userpet.entity.UserPet.UserPetId;
 import org.springframework.data.domain.Page;
@@ -21,23 +22,21 @@ import java.util.UUID;
 @Repository
 public interface UserPetRepository extends JpaRepository<UserPet, UserPetId> {
 
-    /**
-     * 특정 펫의 모든 가족 구성원(UserPet)을 조회합니다.
-     * <p>
-     * N+1 문제를 방지하기 위해 User 엔티티를 Fetch Join으로 함께 가져옵니다.
-     */
-    @Query("SELECT up FROM UserPet up JOIN FETCH up.user WHERE up.pet.petId = :petId")
-    List<UserPet> findAllByPetId(@Param("petId") Long petId);
 
     /**
-     * 특정 사용자가 속한 반려동물 목록을 페이징하여 조회합니다.
+     * 특정 사용자가 속한 반려동물 목록 중, 지정된 상태(예: APPROVED)인 데이터만 페이징하여 조회합니다.
      * <p>
      * {@code @EntityGraph}를 사용하여 연관된 Pet 엔티티를 함께 로딩(Fetch Join 효과)합니다.
      *
      * @param userId   사용자 ID
+     * @param status   가족 등록 상태 (APPROVED 등)
      * @param pageable 페이징 정보
-     * @return 페이징된 UserPet 목록
+     * @return 상태 조건에 맞는 페이징된 UserPet 목록
      */
     @EntityGraph(attributePaths = "pet")
-    Page<UserPet> findAllByUser_UsersId(UUID userId, Pageable pageable);
+    Page<UserPet> findAllByUser_UsersIdAndRegistrationStatus(
+            UUID userId,
+            RegistrationStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
@@ -1,10 +1,7 @@
 package com.dodo.backend.userpet.service;
 
 import com.dodo.backend.pet.entity.Pet;
-import com.dodo.backend.user.entity.User;
 import com.dodo.backend.userpet.entity.RegistrationStatus;
-import com.dodo.backend.userpet.entity.UserPet;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Map;
@@ -38,19 +35,13 @@ public interface UserPetService {
     Map<String, Object> generateInvitationCode(UUID userId, Long petId);
 
     /**
-     * 사용자가 입력한 초대 코드를 검증하고, 유효한 경우 해당 반려동물의 가족 구성원으로 등록합니다.
-     * <p>
-     * 1. Redis에서 초대 코드를 조회하여 유효성을 검증하고 반려동물 ID를 획득합니다.<br>
-     * 2. 요청한 사용자가 이미 해당 반려동물의 가족인지 중복 여부를 확인합니다.<br>
-     * 3. 검증이 완료되면 {@link #registerUserPet}을 호출하여 가족 관계를 생성(APPROVED)합니다.<br>
-     * 4. 갱신된 가족 구성원 목록과 펫 정보를 반환하여 응답 데이터를 구성할 수 있도록 합니다.
+     * 초대 코드를 검증하고, 해당 사용자를 가족 구성원(PENDING)으로 등록합니다.
      *
      * @param userId 초대 코드를 입력한 사용자의 고유 식별자(UUID)
-     * @param code   사용자가 입력한 6자리 대문자/숫자 조합의 초대 코드
-     * @return 펫 엔티티("pet")와 최신 가족 구성원 목록("members")을 포함하는 Map 객체
-     * @throws com.dodo.backend.userpet.exception.UserPetException 코드가 유효하지 않거나, 이미 가족인 경우 발생
+     * @param code   사용자가 입력한 6자리 초대 코드
+     * @return 등록 신청된 반려동물의 ID (Long)
      */
-    Map<String, Object> joinFamilyByCode(UUID userId, String code);
+    Long registerByInvitation(UUID userId, String code);
 
     /**
      * 사용자가 속한 반려동물 목록을 페이징하여 조회합니다.
@@ -63,4 +54,15 @@ public interface UserPetService {
      * @return 페이징 결과가 담긴 Map
      */
     Map<String, Object> getUserPets(UUID userId, Pageable pageable);
+
+    /**
+     * 대기 중인(PENDING) 가족 등록 요청을 승인하거나 거절합니다.
+     *
+     * @param requesterId 요청을 수행하는 관리자(기존 가족) ID
+     * @param petId       반려동물 ID
+     * @param targetUserId 승인/거절 대상 유저 ID
+     * @param action      처리할 상태 문자열 ("APPROVED" 또는 "REJECTED")
+     * @return 처리 결과 메시지
+     */
+    String approveOrRejectFamilyMember(UUID requesterId, Long petId, UUID targetUserId, String action);
 }

--- a/src/main/resources/com/dodo/backend/userpet/mapper/UserPetMapper.xml
+++ b/src/main/resources/com/dodo/backend/userpet/mapper/UserPetMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.dodo.backend.userpet.mapper.UserPetMapper">
+
+    <!-- 특정 유저의 반려동물 등록 상태를 변경합니다.
+         1.registration_status : 반려동물 등록 진행 상태
+           APPROVED / REJECTED 등 상태값 관리
+         2. user_id : 반려동물 소유 유저 식별자
+         3. pet_id : 등록 대상 반려동물 식별자
+         4. WHERE 조건을 통해 특정 유저의 특정 반려동물만 업데이트 -->
+    <update id="updateRegistrationStatus">
+        UPDATE users_animals
+        SET registration_status = #{status}
+        WHERE user_id = #{userId}
+          AND pet_id = #{petId}
+    </update>
+</mapper>

--- a/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
+++ b/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
@@ -13,7 +13,6 @@ import com.dodo.backend.user.exception.UserErrorCode;
 import com.dodo.backend.user.exception.UserException;
 import com.dodo.backend.user.service.UserService;
 import com.dodo.backend.userpet.entity.RegistrationStatus;
-import com.dodo.backend.userpet.entity.UserPet;
 import com.dodo.backend.userpet.service.UserPetService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -61,12 +59,11 @@ class PetServiceTest {
 
     /**
      * 펫 등록 성공 시나리오를 테스트합니다.
-     * <p>
-     * 유효한 사용자 ID와 펫 정보를 전달했을 때, 펫이 정상적으로 저장되고 유저와의 관계(UserPet)가 생성되는지 검증합니다.
      */
     @Test
     @DisplayName("펫 등록 성공: 정상적인 요청 시 펫이 저장되고 유저와 연결된다.")
     void registerPet_Success() {
+        log.info("테스트 시작: 펫 등록 성공 시나리오");
 
         // given
         UUID userId = UUID.randomUUID();
@@ -97,16 +94,17 @@ class PetServiceTest {
         verify(userService, times(1)).validateUserExists(userId);
         verify(petRepository, times(1)).save(any(Pet.class));
         verify(userPetService, times(1)).registerUserPet(userId, savedPet, RegistrationStatus.APPROVED);
+
+        log.info("테스트 종료: 펫 등록 성공 시나리오");
     }
 
     /**
      * 존재하지 않는 유저 ID로 펫 등록을 시도할 때 예외 발생을 테스트합니다.
-     * <p>
-     * {@link UserErrorCode#USER_NOT_FOUND} 예외가 발생하는지 검증합니다.
      */
     @Test
     @DisplayName("펫 등록 실패: 존재하지 않는 유저 ID인 경우 예외가 발생한다.")
     void registerPet_Fail_UserNotFound() {
+        log.info("테스트 시작: 펫 등록 실패 (유저 없음)");
 
         // given
         UUID userId = UUID.randomUUID();
@@ -122,16 +120,17 @@ class PetServiceTest {
 
         // then
         assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+
+        log.info("테스트 종료: 펫 등록 실패 (유저 없음)");
     }
 
     /**
      * 이미 등록된 펫 등록번호로 등록을 시도할 때 예외 발생을 테스트합니다.
-     * <p>
-     * {@link PetErrorCode#REGISTRATION_NUMBER_DUPLICATED} 예외가 발생하며, 저장 로직이 호출되지 않는지 검증합니다.
      */
     @Test
     @DisplayName("펫 등록 실패: 이미 존재하는 등록번호인 경우 예외가 발생한다.")
     void registerPet_Fail_DuplicateRegistrationNumber() {
+        log.info("테스트 시작: 펫 등록 실패 (등록번호 중복)");
 
         // given
         UUID userId = UUID.randomUUID();
@@ -149,6 +148,8 @@ class PetServiceTest {
         // then
         assertEquals(PetErrorCode.REGISTRATION_NUMBER_DUPLICATED, exception.getErrorCode());
         verify(petRepository, times(0)).save(any(Pet.class));
+
+        log.info("테스트 종료: 펫 등록 실패 (등록번호 중복)");
     }
 
     /**
@@ -157,6 +158,7 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 수정 성공: 등록번호를 변경해도 중복이 없으면 정상적으로 수정된다.")
     void updatePet_Success_NewRegistrationNumber() {
+        log.info("테스트 시작: 펫 수정 성공 (등록번호 변경)");
 
         // given
         Long petId = 1L;
@@ -187,6 +189,8 @@ class PetServiceTest {
         assertEquals("FEMALE", response.getSex());
 
         verify(petMapper, times(1)).updatePetProfileInfo(request, petId);
+
+        log.info("테스트 종료: 펫 수정 성공 (등록번호 변경)");
     }
 
     /**
@@ -195,6 +199,7 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 수정 성공: 기존 등록번호가 null이어도 Objects.equals 덕분에 NPE 없이 수정된다.")
     void updatePet_Success_WhenOldRegistrationNumberIsNull() {
+        log.info("테스트 시작: 펫 수정 성공 (기존 번호 없음)");
 
         // given
         Long petId = 1L;
@@ -218,6 +223,8 @@ class PetServiceTest {
 
         // then
         verify(petMapper, times(1)).updatePetProfileInfo(request, petId);
+
+        log.info("테스트 종료: 펫 수정 성공 (기존 번호 없음)");
     }
 
     /**
@@ -226,6 +233,7 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 수정 실패: 존재하지 않는 펫 ID인 경우 예외가 발생한다.")
     void updatePet_Fail_NotFound() {
+        log.info("테스트 시작: 펫 수정 실패 (ID 없음)");
 
         // given
         Long petId = 999L;
@@ -241,6 +249,8 @@ class PetServiceTest {
         // then
         assertEquals(PetErrorCode.PET_NOT_FOUND, exception.getErrorCode());
         verify(petMapper, times(0)).updatePetProfileInfo(any(), any());
+
+        log.info("테스트 종료: 펫 수정 실패 (ID 없음)");
     }
 
     /**
@@ -249,6 +259,7 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 수정 실패: 변경하려는 등록번호가 중복인 경우 예외가 발생한다.")
     void updatePet_Fail_DuplicateRegistrationNumber() {
+        log.info("테스트 시작: 펫 수정 실패 (번호 중복)");
 
         // given
         Long petId = 1L;
@@ -272,18 +283,17 @@ class PetServiceTest {
         // then
         assertEquals(PetErrorCode.REGISTRATION_NUMBER_DUPLICATED, exception.getErrorCode());
         verify(petMapper, times(0)).updatePetProfileInfo(any(), any());
+
+        log.info("테스트 종료: 펫 수정 실패 (번호 중복)");
     }
 
     /**
      * 가족 초대 코드 발급 성공 시나리오를 테스트합니다.
-     * <p>
-     * 1. 펫 존재 여부를 확인합니다.<br>
-     * 2. UserPetService를 통해 코드 발급 로직이 호출되는지 검증합니다.<br>
-     * 3. 반환된 DTO에 코드와 만료시간(expiresIn)이 정상적으로 매핑되었는지 확인합니다.
      */
     @Test
     @DisplayName("초대 코드 발급 성공: 펫이 존재하면 UserPetService를 통해 코드가 발급된다.")
     void issueInvitationCode_Success() {
+        log.info("테스트 시작: 초대 코드 발급 성공 시나리오");
 
         // given
         UUID userId = UUID.randomUUID();
@@ -309,16 +319,17 @@ class PetServiceTest {
 
         verify(petRepository, times(1)).existsById(petId);
         verify(userPetService, times(1)).generateInvitationCode(userId, petId);
+
+        log.info("테스트 종료: 초대 코드 발급 성공 시나리오");
     }
 
     /**
      * 존재하지 않는 펫 ID로 초대 코드를 요청할 때 예외 발생을 테스트합니다.
-     * <p>
-     * {@link PetErrorCode#PET_NOT_FOUND} 예외가 발생하는지 검증합니다.
      */
     @Test
     @DisplayName("초대 코드 발급 실패: 펫이 존재하지 않으면 예외가 발생한다.")
     void issueInvitationCode_Fail_PetNotFound() {
+        log.info("테스트 시작: 초대 코드 발급 실패 (펫 없음)");
 
         // given
         UUID userId = UUID.randomUUID();
@@ -334,76 +345,46 @@ class PetServiceTest {
         // then
         assertEquals(PetErrorCode.PET_NOT_FOUND, exception.getErrorCode());
         verify(userPetService, times(0)).generateInvitationCode(any(), any());
+
+        log.info("테스트 종료: 초대 코드 발급 실패 (펫 없음)");
     }
 
     /**
      * 가족 초대 코드 입력 및 참여 성공 시나리오를 테스트합니다.
-     * <p>
-     * 1. UserPetService를 통해 검증 및 등록이 완료된 결과(Pet 엔티티, 가족 목록)를 받습니다.<br>
-     * 2. 반환된 DTO에 펫 정보와 가족 구성원 목록이 올바르게 매핑되었는지 검증합니다.
      */
     @Test
-    @DisplayName("가족 참여 성공: 유효한 코드로 요청 시 펫 정보와 가족 목록을 반환한다.")
-    void joinFamily_Success() {
+    @DisplayName("가족 참여 신청 성공: 유효한 코드로 요청 시 펫 ID와 성공 메시지를 반환한다.")
+    void applyForFamily_Success() {
+        log.info("테스트 시작: 가족 참여 신청 성공 시나리오");
 
         // given
         UUID userId = UUID.randomUUID();
         String invitationCode = "7X9K2P";
+        Long petId = 100L;
         PetRequest.PetFamilyJoinRequest request = new PetRequest.PetFamilyJoinRequest(invitationCode);
 
-        Pet pet = Pet.builder()
-                .petId(100L)
-                .petName("보리")
-                .build();
-
-        com.dodo.backend.user.entity.User user1 = com.dodo.backend.user.entity.User.builder()
-                .usersId(UUID.randomUUID())
-                .nickname("아빠")
-                .profileUrl("http://img1.com")
-                .build();
-
-        com.dodo.backend.user.entity.User user2 = com.dodo.backend.user.entity.User.builder()
-                .usersId(userId)
-                .nickname("나")
-                .profileUrl("http://img2.com")
-                .build();
-
-        UserPet member1 = UserPet.builder().user(user1).build();
-        UserPet member2 = UserPet.builder().user(user2).build();
-
-        List<UserPet> familyMembers = List.of(member1, member2);
-
-        // UserPetService의 리턴값 (Map 대신 DTO/Record를 쓰기로 했지만, 현재 코드 기준으로는 Map일 수 있음.
-        // 만약 DTO 리팩토링 전이라면 Map, 후라면 객체에 맞게 수정 필요. 여기선 Map 기준으로 작성)
-        Map<String, Object> serviceResult = Map.of(
-                "pet", pet,
-                "members", familyMembers
-        );
-
-        given(userPetService.joinFamilyByCode(userId, invitationCode)).willReturn(serviceResult);
+        given(userPetService.registerByInvitation(userId, invitationCode)).willReturn(petId);
 
         // when
-        PetResponse.PetFamilyJoinResponse response = petService.joinFamily(userId, request);
+        PetResponse.PetFamilyJoinRequestResponse response = petService.applyForFamily(userId, request);
 
         // then
         assertNotNull(response);
-        assertEquals(pet.getPetId(), response.getPetId());
-        assertEquals(pet.getPetName(), response.getPetName());
-        assertEquals(2, response.getFamilyMembers().size());
-        assertEquals(user1.getUsersId(), response.getFamilyMembers().get(0).getUserId());
-        assertEquals("아빠", response.getFamilyMembers().get(0).getNickname());
+        assertEquals(petId, response.getPetId());
+        assertEquals("가족 등록을 신청했습니다. 승인을 기다려주세요.", response.getMessage());
 
-        verify(userPetService, times(1)).joinFamilyByCode(userId, invitationCode);
+        verify(userPetService, times(1)).registerByInvitation(userId, invitationCode);
+
+        log.info("테스트 종료: 가족 참여 신청 성공 시나리오");
     }
 
     /**
      * UserPetService에서 예외 발생 시 PetService에서도 그대로 예외가 전파되는지 테스트합니다.
-     * <p>
-     * 예: 코드가 틀렸거나(INVITATION_NOT_FOUND), 이미 가족인 경우(ALREADY_FAMILY_MEMBER) 등
      */
     @Test
-    @DisplayName("가족 참여 실패: 하위 서비스에서 예외 발생 시 그대로 전파된다.")
-    void joinFamily_Fail_PropagateException() {
+    @DisplayName("가족 참여 신청 실패: 하위 서비스에서 예외 발생 시 그대로 전파된다.")
+    void applyForFamily_Fail_PropagateException() {
+        log.info("테스트 시작: 가족 참여 신청 실패 (예외 전파)");
 
         // given
         UUID userId = UUID.randomUUID();
@@ -412,13 +393,15 @@ class PetServiceTest {
 
         willThrow(new com.dodo.backend.userpet.exception.UserPetException(
                 com.dodo.backend.userpet.exception.UserPetErrorCode.INVITATION_NOT_FOUND)
-        ).given(userPetService).joinFamilyByCode(userId, invalidCode);
+        ).given(userPetService).registerByInvitation(userId, invalidCode);
 
         // when & then
         assertThrows(com.dodo.backend.userpet.exception.UserPetException.class, () ->
-                petService.joinFamily(userId, request)
+                petService.applyForFamily(userId, request)
         );
 
-        verify(userPetService, times(1)).joinFamilyByCode(userId, invalidCode);
+        verify(userPetService, times(1)).registerByInvitation(userId, invalidCode);
+
+        log.info("테스트 종료: 가족 참여 신청 실패 (예외 전파)");
     }
 }

--- a/src/test/java/com/dodo/backend/userpet/mapper/UserPetMapperTest.java
+++ b/src/test/java/com/dodo/backend/userpet/mapper/UserPetMapperTest.java
@@ -1,0 +1,164 @@
+package com.dodo.backend.userpet.mapper;
+
+import com.dodo.backend.pet.entity.Pet;
+import com.dodo.backend.pet.entity.PetSex;
+import com.dodo.backend.pet.entity.PetSpecies;
+import com.dodo.backend.pet.repository.PetRepository;
+import com.dodo.backend.user.entity.User;
+import com.dodo.backend.user.entity.UserRole;
+import com.dodo.backend.user.entity.UserStatus;
+import com.dodo.backend.user.repository.UserRepository;
+import com.dodo.backend.userpet.entity.RegistrationStatus;
+import com.dodo.backend.userpet.entity.UserPet;
+import com.dodo.backend.userpet.entity.UserPet.UserPetId;
+import com.dodo.backend.userpet.repository.UserPetRepository;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * MyBatis 매퍼인 {@link UserPetMapper}의 SQL 실행 결과를 검증하는 통합 테스트 클래스입니다.
+ * <p>
+ * MyBatis와 JPA가 동일한 데이터베이스 세션을 공유하므로,
+ * MyBatis를 통한 데이터 변경 후 영속성 컨텍스트(1차 캐시)를 초기화하여
+ * 정합성을 검증합니다.
+ */
+@SpringBootTest
+@Transactional
+@Slf4j
+class UserPetMapperTest {
+
+    @Autowired
+    private UserPetMapper userPetMapper;
+
+    @Autowired
+    private UserPetRepository userPetRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private User testUser;
+    private Pet testPet;
+    private UserPet testUserPet;
+
+    /**
+     * 테스트 수행 전 기초 데이터를 생성합니다.
+     * <p>
+     * 유저와 펫을 생성하고, 둘 사이의 관계를 대기(PENDING) 상태로 초기화하여 저장합니다.
+     * 이후 영속성 컨텍스트를 반영(flush) 및 초기화(clear)하여 순수 DB 상태와 동기화합니다.
+     */
+    @BeforeEach
+    void setUp() {
+
+        testUser = User.builder()
+                .email("pet_mapper_test@example.com")
+                .name("펫매퍼테스터")
+                .nickname("집사")
+                .region("서울")
+                .hasFamily(true)
+                .userStatus(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .notificationEnabled(true)
+                .userCreatedAt(LocalDateTime.now())
+                .profileUrl("https://example.com/default_profile.jpg")
+                .build();
+        userRepository.save(testUser);
+
+        testPet = Pet.builder()
+                .petName("테스트멍")
+                .species(PetSpecies.CANINE)
+                .breed("말티즈")
+                .age(2)
+                .sex(PetSex.MALE)
+                .birth(LocalDateTime.now())
+                .registrationNumber("9999999999")
+                .deviceId("TEST_DEV_001")
+                .build();
+        petRepository.save(testPet);
+
+        UserPetId id = new UserPetId(testUser.getUsersId(), testPet.getPetId());
+        testUserPet = UserPet.builder()
+                .id(id)
+                .user(testUser)
+                .pet(testPet)
+                .registrationStatus(RegistrationStatus.PENDING)
+                .build();
+        userPetRepository.save(testUserPet);
+
+        em.flush();
+        em.clear();
+        log.info("기초 데이터(User, Pet, UserPet-PENDING) 저장 및 영속성 컨텍스트 초기화 수행 완료");
+    }
+
+    /**
+     * 매퍼를 통해 가족 등록 상태를 'APPROVED'로 변경하는 SQL이 정상적으로 실행되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("매퍼를 통한 가족 등록 상태 변경 (PENDING -> APPROVED)")
+    void updateRegistrationStatusTest() {
+        // given
+        UserPetId targetId = new UserPetId(testUser.getUsersId(), testPet.getPetId());
+        String targetStatus = "APPROVED";
+
+        log.info("가족 상태 변경 매퍼 테스트 시작 - User: {}, Pet: {}, 변경할 상태: {}",
+                testUser.getUsersId(), testPet.getPetId(), targetStatus);
+
+        // when
+        userPetMapper.updateRegistrationStatus(
+                testUser.getUsersId(),
+                testPet.getPetId(),
+                targetStatus
+        );
+
+        // then
+        em.clear();
+        UserPet updatedUserPet = userPetRepository.findById(targetId).orElseThrow();
+
+        assertThat(updatedUserPet.getRegistrationStatus()).isEqualTo(RegistrationStatus.APPROVED);
+
+        log.info("가족 상태 변경 SQL 실행 결과 검증 성공");
+    }
+
+    /**
+     * 매퍼를 통해 가족 등록 상태를 'REJECTED'로 변경하는 SQL이 정상적으로 실행되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("매퍼를 통한 가족 등록 상태 변경 (PENDING -> REJECTED)")
+    void updateRegistrationStatusToRejectTest() {
+        // given
+        UserPetId targetId = new UserPetId(testUser.getUsersId(), testPet.getPetId());
+        String targetStatus = "REJECTED";
+
+        log.info("가족 상태 변경 매퍼 테스트 시작 - 변경할 상태: {}", targetStatus);
+
+        // when
+        userPetMapper.updateRegistrationStatus(
+                testUser.getUsersId(),
+                testPet.getPetId(),
+                targetStatus
+        );
+
+        // then
+        em.clear();
+        UserPet updatedUserPet = userPetRepository.findById(targetId).orElseThrow();
+
+        assertThat(updatedUserPet.getRegistrationStatus()).isEqualTo(RegistrationStatus.REJECTED);
+
+        log.info("가족 거절 상태 변경 SQL 실행 결과 검증 성공");
+    }
+}

--- a/src/test/java/com/dodo/backend/userpet/service/UserPetServiceTest.java
+++ b/src/test/java/com/dodo/backend/userpet/service/UserPetServiceTest.java
@@ -1,14 +1,14 @@
 package com.dodo.backend.userpet.service;
 
 import com.dodo.backend.pet.entity.Pet;
-import com.dodo.backend.pet.service.PetService;
 import com.dodo.backend.user.entity.User;
-import com.dodo.backend.user.service.UserService;
+import com.dodo.backend.user.repository.UserRepository;
 import com.dodo.backend.userpet.entity.RegistrationStatus;
 import com.dodo.backend.userpet.entity.UserPet;
 import com.dodo.backend.userpet.entity.UserPet.UserPetId;
 import com.dodo.backend.userpet.exception.UserPetErrorCode;
 import com.dodo.backend.userpet.exception.UserPetException;
+import com.dodo.backend.userpet.mapper.UserPetMapper;
 import com.dodo.backend.userpet.repository.UserPetRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -24,7 +24,6 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,6 +31,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,8 +39,8 @@ import static org.mockito.Mockito.verify;
 /**
  * {@link UserPetService}의 비즈니스 로직을 검증하는 테스트 클래스입니다.
  * <p>
- * 유저와 펫 사이의 멤버십 관계(UserPet) 생성 및
- * 가족 초대 코드 발급/수락 로직을 단위 테스트로 확인합니다.
+ * 유저와 펫 사이의 멤버십 관계(UserPet) 생성, 가족 초대 코드 발급,
+ * 목록 조회 및 승인/거절 프로세스를 단위 테스트로 검증합니다.
  */
 @Slf4j
 @ExtendWith(MockitoExtension.class)
@@ -53,22 +53,19 @@ class UserPetServiceTest {
     private UserPetRepository userPetRepository;
 
     @Mock
+    private UserPetMapper userPetMapper;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private RedisTemplate<String, Object> redisTemplate;
 
     @Mock
     private ValueOperations<String, Object> valueOperations;
 
-    @Mock
-    private UserService userService;
-
-    @Mock
-    private PetService petService;
-
     /**
      * UserPet 관계 등록 성공 시나리오를 테스트합니다.
-     * <p>
-     * 전달받은 User, Pet 엔티티와 등록 상태(APPROVED)가
-     * 올바르게 매핑되어 Repository에 저장되는지 검증합니다.
      */
     @Test
     @DisplayName("UserPet 등록 성공: 유저와 펫의 관계 엔티티가 올바르게 생성되어 저장된다.")
@@ -85,19 +82,16 @@ class UserPetServiceTest {
 
         RegistrationStatus status = RegistrationStatus.APPROVED;
 
-        given(userService.getUserEntity(userId)).willReturn(user);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
-        userPetService.registerUserPet(user.getUsersId(), pet, status);
+        userPetService.registerUserPet(userId, pet, status);
 
         // then
         ArgumentCaptor<UserPet> captor = ArgumentCaptor.forClass(UserPet.class);
         verify(userPetRepository).save(captor.capture());
 
         UserPet savedUserPet = captor.getValue();
-        log.info("저장된 UserPet 식별자 - 유저ID: {}, 펫ID: {}",
-                savedUserPet.getId().getUserId(), savedUserPet.getId().getPetId());
-
         assertEquals(user, savedUserPet.getUser());
         assertEquals(pet, savedUserPet.getPet());
         assertEquals(status, savedUserPet.getRegistrationStatus());
@@ -108,15 +102,11 @@ class UserPetServiceTest {
 
     /**
      * 가족 초대 코드 발급 성공 시나리오를 테스트합니다.
-     * <p>
-     * 1. 요청자가 해당 펫의 승인된(APPROVED) 멤버인지 확인합니다.
-     * 2. Redis에 중복된 키가 없는지 확인합니다.
-     * 3. 랜덤 코드가 생성되고 Redis에 2회(초대용, 중복방지용) 저장되는지 검증합니다.
      */
     @Test
     @DisplayName("초대 코드 발급 성공: 승인된 멤버라면 코드가 생성되고 Redis에 저장된다.")
     void generateInvitationCode_Success() {
-        log.info("테스트 시작: 초대 코드 발급 성공");
+        log.info("테스트 시작: 초대 코드 발급 성공 시나리오");
 
         // given
         UUID userId = UUID.randomUUID();
@@ -133,19 +123,16 @@ class UserPetServiceTest {
         Map<String, Object> result = userPetService.generateInvitationCode(userId, petId);
 
         // then
-        log.info("생성된 초대 코드: {}", result.get("code"));
         assertNotNull(result.get("code"));
         assertNotNull(result.get("expiresIn"));
 
         verify(valueOperations, times(2)).set(anyString(), anyString(), any(Duration.class));
 
-        log.info("테스트 종료: 초대 코드 발급 성공");
+        log.info("테스트 종료: 초대 코드 발급 성공 시나리오");
     }
 
     /**
      * 가족 구성원이 아닌 유저가 초대를 시도할 때 예외 발생을 테스트합니다.
-     * <p>
-     * {@link UserPetErrorCode#INVITE_PERMISSION_DENIED} 예외가 발생하는지 검증합니다.
      */
     @Test
     @DisplayName("초대 코드 발급 실패: 해당 펫의 멤버가 아니면 권한 없음 예외가 발생한다.")
@@ -164,13 +151,12 @@ class UserPetServiceTest {
         );
 
         assertEquals(UserPetErrorCode.INVITE_PERMISSION_DENIED, exception.getErrorCode());
+
         log.info("테스트 종료: 초대 코드 발급 실패 (멤버 아님)");
     }
 
     /**
      * 승인되지 않은(PENDING) 멤버가 초대를 시도할 때 예외 발생을 테스트합니다.
-     * <p>
-     * {@link UserPetErrorCode#INVITE_PERMISSION_DENIED} 예외가 발생하는지 검증합니다.
      */
     @Test
     @DisplayName("초대 코드 발급 실패: 승인되지 않은 멤버는 권한 없음 예외가 발생한다.")
@@ -192,19 +178,17 @@ class UserPetServiceTest {
         );
 
         assertEquals(UserPetErrorCode.INVITE_PERMISSION_DENIED, exception.getErrorCode());
+
         log.info("테스트 종료: 초대 코드 발급 실패 (미승인 상태)");
     }
 
     /**
      * 이미 유효한 초대 코드가 존재하는 경우 예외 발생을 테스트합니다.
-     * <p>
-     * Redis에 해당 펫의 키가 존재할 때,
-     * {@link UserPetErrorCode#INVITATION_ALREADY_EXISTS} 예외가 발생하는지 검증합니다.
      */
     @Test
-    @DisplayName("초대 코드 발급 실패: 이미 유효한 코드가 존재하면 중복(Conflict) 예외가 발생한다.")
+    @DisplayName("초대 코드 발급 실패: 이미 유효한 코드가 존재하면 중복 예외가 발생한다.")
     void generateInvitationCode_Fail_AlreadyExists() {
-        log.info("테스트 시작: 초대 코드 발급 실패 (중복 발급)");
+        log.info("테스트 시작: 초대 코드 발급 실패 (코드 중복)");
 
         // given
         UUID userId = UUID.randomUUID();
@@ -222,33 +206,24 @@ class UserPetServiceTest {
         );
 
         assertEquals(UserPetErrorCode.INVITATION_ALREADY_EXISTS, exception.getErrorCode());
-
         verify(redisTemplate, times(0)).opsForValue();
 
-        log.info("테스트 종료: 초대 코드 발급 실패 (중복 발급)");
+        log.info("테스트 종료: 초대 코드 발급 실패 (코드 중복)");
     }
 
     /**
-     * 초대 코드 입력 및 가족 수락 성공 시나리오를 테스트합니다.
-     * <p>
-     * 1. Redis에서 코드로 petId를 조회합니다.
-     * 2. 이미 가족인지 중복 검사를 수행합니다.
-     * 3. PetService를 통해 펫 정보를 조회합니다.
-     * 4. registerUserPet을 호출하여 저장하고, 최종 가족 목록을 반환하는지 검증합니다.
+     * 초대 코드 입력 및 가족 신청(대기) 성공 시나리오를 테스트합니다.
      */
     @Test
-    @DisplayName("초대 수락 성공: 유효한 코드 입력 시 가족으로 등록되고 목록을 반환한다.")
-    void joinFamilyByCode_Success() {
-        log.info("테스트 시작: 초대 수락 성공");
+    @DisplayName("초대 수락 성공: 유효한 코드 입력 시 대기(PENDING) 상태로 등록하고 펫 ID를 반환한다.")
+    void registerByInvitation_Success() {
+        log.info("테스트 시작: 초대 수락 및 등록 성공 시나리오");
 
         // given
         UUID userId = UUID.randomUUID();
         String invitationCode = "7X9K2P";
         String petIdStr = "100";
         Long petId = 100L;
-
-        Pet pet = Pet.builder().build();
-        ReflectionTestUtils.setField(pet, "petId", petId);
 
         User user = User.builder().build();
         ReflectionTestUtils.setField(user, "usersId", userId);
@@ -257,31 +232,30 @@ class UserPetServiceTest {
         given(valueOperations.get(anyString())).willReturn(petIdStr);
 
         given(userPetRepository.existsById(any(UserPetId.class))).willReturn(false);
-        given(petService.getPet(petId)).willReturn(pet);
-        given(userService.getUserEntity(userId)).willReturn(user);
-        given(userPetRepository.findAllByPetId(petId)).willReturn(List.of());
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
-        Map<String, Object> result = userPetService.joinFamilyByCode(userId, invitationCode);
+        Long resultPetId = userPetService.registerByInvitation(userId, invitationCode);
 
         // then
-        assertNotNull(result);
-        assertEquals(pet, result.get("pet"));
-        assertNotNull(result.get("members"));
+        assertEquals(petId, resultPetId);
 
-        verify(userPetRepository).save(any(UserPet.class));
-        log.info("테스트 종료: 초대 수락 성공");
+        ArgumentCaptor<UserPet> captor = ArgumentCaptor.forClass(UserPet.class);
+        verify(userPetRepository).save(captor.capture());
+
+        assertEquals(RegistrationStatus.PENDING, captor.getValue().getRegistrationStatus());
+        assertEquals(petId, captor.getValue().getPet().getPetId());
+
+        log.info("테스트 종료: 초대 수락 및 등록 성공 시나리오");
     }
 
     /**
      * 만료되거나 존재하지 않는 초대 코드를 입력했을 때 예외 발생을 테스트합니다.
-     * <p>
-     * Redis에서 null이 반환될 때 {@link UserPetErrorCode#INVITATION_NOT_FOUND}가 발생하는지 검증합니다.
      */
     @Test
     @DisplayName("초대 수락 실패: 코드가 존재하지 않거나 만료된 경우 예외가 발생한다.")
-    void joinFamilyByCode_Fail_InvalidCode() {
-        log.info("테스트 시작: 초대 수락 실패 (코드 없음)");
+    void registerByInvitation_Fail_InvalidCode() {
+        log.info("테스트 시작: 초대 수락 실패 (코드 없음/만료)");
 
         // given
         UUID userId = UUID.randomUUID();
@@ -292,28 +266,26 @@ class UserPetServiceTest {
 
         // when & then
         UserPetException exception = assertThrows(UserPetException.class, () ->
-                userPetService.joinFamilyByCode(userId, invalidCode)
+                userPetService.registerByInvitation(userId, invalidCode)
         );
 
         assertEquals(UserPetErrorCode.INVITATION_NOT_FOUND, exception.getErrorCode());
-        log.info("테스트 종료: 초대 수락 실패 (코드 없음)");
+
+        log.info("테스트 종료: 초대 수락 실패 (코드 없음/만료)");
     }
 
     /**
      * 이미 가족으로 등록된 사용자가 초대를 수락하려 할 때 예외 발생을 테스트합니다.
-     * <p>
-     * {@link UserPetErrorCode#ALREADY_FAMILY_MEMBER} 예외가 발생하는지 검증합니다.
      */
     @Test
     @DisplayName("초대 수락 실패: 이미 가족 멤버인 경우 예외가 발생한다.")
-    void joinFamilyByCode_Fail_AlreadyMember() {
-        log.info("테스트 시작: 초대 수락 실패 (이미 멤버)");
+    void registerByInvitation_Fail_AlreadyMember() {
+        log.info("테스트 시작: 초대 수락 실패 (이미 가족 멤버)");
 
         // given
         UUID userId = UUID.randomUUID();
         String invitationCode = "7X9K2P";
         String petIdStr = "100";
-        Long petId = 100L;
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(anyString())).willReturn(petIdStr);
@@ -322,49 +294,169 @@ class UserPetServiceTest {
 
         // when & then
         UserPetException exception = assertThrows(UserPetException.class, () ->
-                userPetService.joinFamilyByCode(userId, invitationCode)
+                userPetService.registerByInvitation(userId, invitationCode)
         );
 
         assertEquals(UserPetErrorCode.ALREADY_FAMILY_MEMBER, exception.getErrorCode());
-
         verify(userPetRepository, times(0)).save(any(UserPet.class));
 
-        log.info("테스트 종료: 초대 수락 실패 (이미 멤버)");
+        log.info("테스트 종료: 초대 수락 실패 (이미 가족 멤버)");
     }
 
     /**
-     * 유저의 펫 목록 조회 시나리오를 테스트합니다.
-     * <p>
-     * Repository를 통해 조회된 페이징 결과({@code Page<UserPet>})가
-     * 결과 Map에 "userPetPage"라는 키로 올바르게 담기는지 검증합니다.
+     * 유저의 펫 목록 조회 시나리오를 테스트합니다. (수정됨: APPROVED 상태 필터링)
      */
     @Test
-    @DisplayName("유저 펫 목록 조회 성공: 페이징된 펫 목록이 Map에 담겨 반환된다.")
+    @DisplayName("유저 펫 목록 조회 성공: 승인된(APPROVED) 펫 목록만 페이징되어 반환된다.")
     void getUserPets_Success() {
-        log.info("테스트 시작: 유저 펫 목록 조회 성공");
+        log.info("테스트 시작: 유저 펫 목록 조회 성공 시나리오");
 
         // given
         UUID userId = UUID.randomUUID();
         Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 10);
-        
-        List<UserPet> emptyList = java.util.Collections.emptyList();
+
+        java.util.List<UserPet> emptyList = java.util.Collections.emptyList();
         org.springframework.data.domain.Page<UserPet> mockPage =
                 new org.springframework.data.domain.PageImpl<>(emptyList, pageable, 0);
 
-        given(userPetRepository.findAllByUser_UsersId(userId, pageable)).willReturn(mockPage);
+        given(userPetRepository.findAllByUser_UsersIdAndRegistrationStatus(
+                userId,
+                RegistrationStatus.APPROVED,
+                pageable
+        )).willReturn(mockPage);
 
         // when
         Map<String, Object> result = userPetService.getUserPets(userId, pageable);
 
         // then
-        log.info("조회된 결과 Map Key Set: {}", result.keySet());
-
         assertNotNull(result);
         assertTrue(result.containsKey("userPetPage"));
         assertEquals(mockPage, result.get("userPetPage"));
 
-        verify(userPetRepository).findAllByUser_UsersId(userId, pageable);
+        verify(userPetRepository).findAllByUser_UsersIdAndRegistrationStatus(
+                userId,
+                RegistrationStatus.APPROVED,
+                pageable
+        );
 
-        log.info("테스트 종료: 유저 펫 목록 조회 성공");
+        log.info("테스트 종료: 유저 펫 목록 조회 성공 시나리오");
+    }
+
+    /**
+     * 가족 승인 요청 성공 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("가족 요청 처리 성공: 승인(APPROVED) 요청 시 Mapper를 통해 상태가 업데이트된다.")
+    void approveFamilyMember_Success() {
+        log.info("테스트 시작: 가족 요청 처리 성공 (승인)");
+
+        // given
+        UUID requesterId = UUID.randomUUID();
+        UUID targetUserId = UUID.randomUUID();
+        Long petId = 100L;
+        String action = "APPROVED";
+
+        UserPet requester = UserPet.builder().registrationStatus(RegistrationStatus.APPROVED).build();
+        UserPet target = UserPet.builder().registrationStatus(RegistrationStatus.PENDING).build();
+
+        given(userPetRepository.findById(new UserPetId(requesterId, petId))).willReturn(Optional.of(requester));
+        given(userPetRepository.findById(new UserPetId(targetUserId, petId))).willReturn(Optional.of(target));
+
+        // when
+        String result = userPetService.approveOrRejectFamilyMember(requesterId, petId, targetUserId, action);
+
+        // then
+        assertEquals("가족 신청을 승인했습니다.", result);
+        verify(userPetMapper).updateRegistrationStatus(targetUserId, petId, "APPROVED");
+
+        log.info("테스트 종료: 가족 요청 처리 성공 (승인)");
+    }
+
+    /**
+     * 가족 거절 요청 성공 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("가족 요청 처리 성공: 거절(REJECTED) 요청 시 Mapper를 통해 상태가 REJECTED로 업데이트된다.")
+    void rejectFamilyMember_Success() {
+        log.info("테스트 시작: 가족 요청 처리 성공 (거절)");
+
+        // given
+        UUID requesterId = UUID.randomUUID();
+        UUID targetUserId = UUID.randomUUID();
+        Long petId = 100L;
+        String action = "REJECTED";
+
+        UserPet requester = UserPet.builder().registrationStatus(RegistrationStatus.APPROVED).build();
+        UserPet target = UserPet.builder().registrationStatus(RegistrationStatus.PENDING).build();
+
+        given(userPetRepository.findById(new UserPetId(requesterId, petId))).willReturn(Optional.of(requester));
+        given(userPetRepository.findById(new UserPetId(targetUserId, petId))).willReturn(Optional.of(target));
+
+        // when
+        String result = userPetService.approveOrRejectFamilyMember(requesterId, petId, targetUserId, action);
+
+        // then
+        assertEquals("가족 신청을 거절했습니다.", result);
+        verify(userPetMapper).updateRegistrationStatus(targetUserId, petId, "REJECTED");
+
+        log.info("테스트 종료: 가족 요청 처리 성공 (거절)");
+    }
+
+    /**
+     * 권한 없는 유저(가족 구성원이 아니거나 PENDING 상태)가 승인을 시도할 때 예외를 테스트합니다.
+     */
+    @Test
+    @DisplayName("가족 요청 처리 실패: 요청자가 승인 권한이 없으면 예외가 발생한다.")
+    void approveFamilyMember_Fail_NoPermission() {
+        log.info("테스트 시작: 가족 요청 처리 실패 (권한 없음)");
+
+        // given
+        UUID requesterId = UUID.randomUUID();
+        UUID targetUserId = UUID.randomUUID();
+        Long petId = 100L;
+        String action = "APPROVED";
+
+        // PENDING 상태인 유저(권한 없음)
+        UserPet requester = UserPet.builder().registrationStatus(RegistrationStatus.PENDING).build();
+
+        given(userPetRepository.findById(new UserPetId(requesterId, petId))).willReturn(Optional.of(requester));
+
+        // when & then
+        UserPetException exception = assertThrows(UserPetException.class, () ->
+                userPetService.approveOrRejectFamilyMember(requesterId, petId, targetUserId, action)
+        );
+
+        assertEquals(UserPetErrorCode.INVITE_PERMISSION_DENIED, exception.getErrorCode());
+
+        log.info("테스트 종료: 가족 요청 처리 실패 (권한 없음)");
+    }
+
+    /**
+     * 존재하지 않는 대상을 승인/거절하려고 할 때 예외를 테스트합니다.
+     */
+    @Test
+    @DisplayName("가족 요청 처리 실패: 대상 유저가 존재하지 않거나 PENDING 상태가 아니면 예외가 발생한다.")
+    void approveFamilyMember_Fail_TargetNotFound() {
+        log.info("테스트 시작: 가족 요청 처리 실패 (대상 없음)");
+
+        // given
+        UUID requesterId = UUID.randomUUID();
+        UUID targetUserId = UUID.randomUUID();
+        Long petId = 100L;
+        String action = "APPROVED";
+
+        UserPet requester = UserPet.builder().registrationStatus(RegistrationStatus.APPROVED).build();
+
+        given(userPetRepository.findById(new UserPetId(requesterId, petId))).willReturn(Optional.of(requester));
+        given(userPetRepository.findById(new UserPetId(targetUserId, petId))).willReturn(Optional.empty());
+
+        // when & then
+        UserPetException exception = assertThrows(UserPetException.class, () ->
+                userPetService.approveOrRejectFamilyMember(requesterId, petId, targetUserId, action)
+        );
+
+        assertEquals(UserPetErrorCode.INVITEE_NOT_FOUND, exception.getErrorCode());
+
+        log.info("테스트 종료: 가족 요청 처리 실패 (대상 없음)");
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 가족 등록 방식을 '초대(Redis) -> 대기(PENDING) -> 승인/거절' 단계로 분리
- UserPetMapper(MyBatis) 도입하여 상태 변경(Update) 쿼리 명시적 처리
- 펫 목록 조회 시 승인된(APPROVED) 펫만 노출되도록 필터링 로직 개선
- Mapper 통합 테스트 및 Service 단위 테스트 작성
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #56

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 원래는 코드만 입력하면 바로 승인 되서 펫을 불러올 수 있었으나 펫 가족이 아닌경우에도 그 코드를 입력하면 가족으로 승인이되어서 그 펫에 대한 정보를 접근할 수 있어서 이를 막고자 초대 코드를 보내면 그 펫 가족으로 등록된 사람들중 아무나 한명이 수락을 하면 그때 이제 APPROVED 상태로 바뀌어서 가족으로 등록되게 변경했습니다.
- 펫 리스트 조회 같은 경우에도 APPROVED인 펫에 대해서만 조회가 가능하게 변경했습니다.
- 이제 펫 수락 승인 리스트 같은 경우는 곧 개발 예정입니다.
