### PR TITLE
✨ Feat: 가족 신청 대기자 및 내 신청 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * 펫 도메인과 관련된 응답 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
@@ -27,11 +28,11 @@ public class PetResponse {
     @Schema(description = "펫 등록 완료 응답")
     public static class PetRegisterResponse {
 
-        @Schema(description = "생성된 펫 ID", example = "1")
-        private Long petId;
-
         @Schema(description = "응답 메시지", example = "새 반려동물을 등록완료했습니다.")
         private String message;
+
+        @Schema(description = "생성된 펫 ID", example = "1")
+        private Long petId;
 
         /**
          * 펫 ID와 메시지를 사용하여 응답 DTO 객체를 생성하는 정적 팩토리 메서드입니다.
@@ -42,8 +43,8 @@ public class PetResponse {
          */
         public static PetRegisterResponse toDto(Long petId, String message) {
             return PetRegisterResponse.builder()
-                    .petId(petId)
                     .message(message)
+                    .petId(petId)
                     .build();
         }
     }
@@ -108,8 +109,8 @@ public class PetResponse {
                                               String sex, Integer age, String petName,
                                               String breed, Integer referenceHeartRate, String deviceId) {
             return PetUpdateResponse.builder()
-                    .petId(petId)
                     .message(message)
+                    .petId(petId)
                     .registrationNumber(registrationNumber)
                     .sex(sex)
                     .age(age)
@@ -130,6 +131,9 @@ public class PetResponse {
     @Schema(description = "반려동물 가족 초대 코드 응답")
     public static class PetInvitationResponse {
 
+        @Schema(description = "응답 메시지", example = "초대 코드가 생성되었습니다.")
+        private String message;
+
         @Schema(description = "생성된 가족 초대 코드 (영문 대문자 + 숫자, 총 6자리)", example = "7X9K2P")
         private String code;
 
@@ -149,7 +153,7 @@ public class PetResponse {
         @Schema(description = "신청한 반려동물 ID", example = "101")
         private Long petId;
 
-        @Schema(description = "처리 결과 메시지", example = "가족 등록을 신청했습니다. 승인을 기다려주세요.")
+        @Schema(description = "응답 메시지", example = "가족 등록을 신청했으니 승인을 기다려주세요.")
         private String message;
 
         /**
@@ -176,6 +180,9 @@ public class PetResponse {
     @Schema(description = "반려동물 목록 조회 응답 (페이징 포함)")
     public static class PetListResponse {
 
+        @Schema(description = "응답 메시지", example = "조회를 성공했습니다.")
+        private String message;
+
         @Schema(description = "반려동물 데이터 목록")
         private List<PetSummary> pets;
 
@@ -199,8 +206,9 @@ public class PetResponse {
          * @param petPage 반려동물 요약 정보(DTO)가 담긴 Page 객체
          * @return 페이징 정보와 데이터가 포함된 {@link PetListResponse}
          */
-        public static PetListResponse toDto(Page<PetSummary> petPage) {
+        public static PetListResponse toDto(Page<PetSummary> petPage, String message) {
             return PetListResponse.builder()
+                    .message(message)
                     .pets(petPage.getContent())
                     .totalPages(petPage.getTotalPages())
                     .totalElements(petPage.getTotalElements())
@@ -276,6 +284,164 @@ public class PetResponse {
                     .petId(petId)
                     .message(message)
                     .build();
+        }
+    }
+
+    /**
+     * 신청 대기자 목록 조회 시 반환되는 페이징 된 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "가족 신청 대기자 목록 응답 (페이징 포함)")
+    public static class PendingUserListResponse {
+
+        @Schema(description = "응답 메시지", example = "조회를 성공했습니다.")
+        private String message;
+
+        @Schema(description = "대기자 데이터 목록")
+        private List<PendingUserResponse> users;
+
+        @Schema(description = "총 페이지 수", example = "5")
+        private int totalPages;
+
+        @Schema(description = "총 데이터 수", example = "48")
+        private long totalElements;
+
+        @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+        private int currentPage;
+
+        @Schema(description = "페이지 크기", example = "10")
+        private int pageSize;
+
+        public static PendingUserListResponse toDto(Page<PendingUserResponse> page, String message) {
+            return PendingUserListResponse.builder()
+                    .message(message)
+                    .users(page.getContent())
+                    .totalPages(page.getTotalPages())
+                    .totalElements(page.getTotalElements())
+                    .currentPage(page.getNumber())
+                    .pageSize(page.getSize())
+                    .build();
+        }
+
+        /**
+         * 개별 대기자(유저) 정보와 대상 펫 정보를 담는 내부 DTO입니다.
+         */
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @Schema(description = "가족 신청 대기자(유저) 및 대상 펫 정보")
+        public static class PendingUserResponse {
+
+            @Schema(description = "신청한 유저 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            private UUID userId;
+
+            @Schema(description = "신청한 유저 닉네임", example = "강아지조아")
+            private String nickname;
+
+            @Schema(description = "신청한 유저 프로필 이미지 URL", example = "https://example.com/user_profile.jpg")
+            private String profileUrl;
+
+            @Schema(description = "신청 대상 반려동물 ID", example = "101")
+            private Long targetPetId;
+
+            @Schema(description = "신청 대상 반려동물 이름", example = "보리")
+            private String targetPetName;
+
+            @Schema(description = "신청 대상 반려동물 프로필 이미지 URL", example = "https://example.com/pet_profile.jpg")
+            private String targetPetImageUrl;
+
+            @Schema(description = "신청 일시", example = "2024-02-01T12:00:00")
+            private LocalDateTime requestedAt;
+
+            public static PendingUserResponse toDto(UUID userId, String nickname, String profileUrl,
+                                                    Long targetPetId, String targetPetName, String targetPetImageUrl,
+                                                    LocalDateTime requestedAt) {
+                return PendingUserResponse.builder()
+                        .userId(userId)
+                        .nickname(nickname)
+                        .profileUrl(profileUrl)
+                        .targetPetId(targetPetId)
+                        .targetPetName(targetPetName)
+                        .targetPetImageUrl(targetPetImageUrl)
+                        .requestedAt(requestedAt)
+                        .build();
+            }
+        }
+    }
+
+    /**
+     * 내 신청 내역 조회 시 반환되는 페이징 된 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "내 신청 내역 목록 응답 (페이징 포함)")
+    public static class PetApplicationListResponse {
+
+        @Schema(description = "응답 메시지", example = "조회를 성공했습니다.")
+        private String message;
+
+        @Schema(description = "신청 내역 데이터 목록")
+        private List<PetApplicationResponse> applications;
+
+        @Schema(description = "총 페이지 수", example = "3")
+        private int totalPages;
+
+        @Schema(description = "총 데이터 수", example = "25")
+        private long totalElements;
+
+        @Schema(description = "현재 페이지 번호", example = "0")
+        private int currentPage;
+
+        @Schema(description = "페이지 크기", example = "10")
+        private int pageSize;
+
+        public static PetApplicationListResponse toDto(Page<PetApplicationResponse> page, String message) {
+            return PetApplicationListResponse.builder()
+                    .message(message)
+                    .applications(page.getContent())
+                    .totalPages(page.getTotalPages())
+                    .totalElements(page.getTotalElements())
+                    .currentPage(page.getNumber())
+                    .pageSize(page.getSize())
+                    .build();
+        }
+
+        /**
+         * 개별 신청 내역 정보를 담는 내부 DTO입니다.
+         */
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @Schema(description = "개별 신청 내역 정보")
+        public static class PetApplicationResponse {
+
+            @Schema(description = "반려동물 ID", example = "101")
+            private Long petId;
+
+            @Schema(description = "반려동물 이름", example = "보리")
+            private String petName;
+
+            @Schema(description = "반려동물 프로필 이미지 URL", example = "https://example.com/pet_profile.jpg")
+            private String petImageUrl;
+
+            @Schema(description = "신청 상태", example = "PENDING")
+            private String status;
+
+            @Schema(description = "신청 일시", example = "2024-02-01T12:00:00")
+            private LocalDateTime requestedAt;
+
+            public static PetApplicationResponse toDto(Long petId, String petName, String petImageUrl, String status, LocalDateTime requestedAt) {
+                return PetApplicationResponse.builder()
+                        .petId(petId)
+                        .petName(petName)
+                        .petImageUrl(petImageUrl)
+                        .status(status)
+                        .requestedAt(requestedAt)
+                        .build();
+            }
         }
     }
 }

--- a/src/main/java/com/dodo/backend/pet/exception/PetErrorCode.java
+++ b/src/main/java/com/dodo/backend/pet/exception/PetErrorCode.java
@@ -51,6 +51,13 @@ public enum PetErrorCode implements BaseErrorCode {
     ACTION_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 반려동물에 대한 권한이 없습니다."),
 
     /**
+     * 요청과 관련된 사용자 정보를 찾을 수 없을 때 사용합니다.
+     * <p>
+     * HTTP {@code 404 Not Found}를 반환합니다.
+     */
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    /**
      * 요청한 식별자(ID)에 해당하는 반려동물을 찾을 수 없을 때 사용합니다.
      * <p>
      * HTTP {@code 404 Not Found}를 반환합니다.

--- a/src/main/java/com/dodo/backend/pet/service/PetService.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetService.java
@@ -25,7 +25,7 @@ public interface PetService {
     /**
      * 반려동물의 정보를 선택적으로 수정합니다.
      *
-     * @param petId  수정할 반려동물의 고유 ID
+     * @param petId   수정할 반려동물의 고유 ID
      * @param request 수정할 정보를 담은 요청 객체
      * @return 수정이 완료된 후의 최신 반려동물 상세 정보 응답 객체
      */
@@ -68,4 +68,22 @@ public interface PetService {
      * @return 펫 ID와 처리 결과 메시지
      */
     PetFamilyApprovalResponse manageFamily(UUID requesterId, Long petId, UUID targetUserId, String action);
+
+    /**
+     * 특정 반려동물에게 들어온 가족 신청 대기자 목록을 페이징하여 조회합니다.
+     *
+     * @param managerId 요청자(관리자)의 UUID
+     * @param pageable  페이징 정보
+     * @return 페이징된 대기자 목록 응답 DTO
+     */
+    PendingUserListResponse getAllPendingUsers(UUID managerId, Pageable pageable);
+
+    /**
+     * 내가 신청했지만 아직 승인 대기 중인 반려동물 목록을 페이징하여 조회합니다.
+     *
+     * @param userId   사용자의 UUID
+     * @param pageable 페이징 정보
+     * @return 페이징된 신청 내역 목록 응답 DTO
+     */
+    PetApplicationListResponse getMyPendingApplications(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/dodo/backend/user/service/UserService.java
+++ b/src/main/java/com/dodo/backend/user/service/UserService.java
@@ -76,11 +76,4 @@ public interface UserService {
      */
     void updateNotification(UUID userId, Boolean enabled);
 
-    /**
-     * 사용자의 존재 여부를 검증합니다.
-     *
-     * @param userId 검증할 사용자의 고유 식별자(UUID)
-     * @throws com.dodo.backend.user.exception.UserException 유저가 존재하지 않을 경우 (USER_NOT_FOUND)
-     */
-    void validateUserExists(UUID userId);
 }

--- a/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
@@ -280,16 +280,5 @@ public class UserServiceImpl implements UserService {
         userMapper.updateNotificationStatus(userId, enabled);
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * 단순히 존재 여부만 확인하므로 {@code existsById}를 사용하여 성능을 최적화합니다.
-     */
-    @Override
-    public void validateUserExists(UUID userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new UserException(USER_NOT_FOUND);
-        }
-    }
 
 }

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
@@ -2,6 +2,8 @@ package com.dodo.backend.userpet.service;
 
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.userpet.entity.RegistrationStatus;
+import com.dodo.backend.userpet.entity.UserPet;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Map;
@@ -65,4 +67,22 @@ public interface UserPetService {
      * @return 처리 결과 메시지
      */
     String approveOrRejectFamilyMember(UUID requesterId, Long petId, UUID targetUserId, String action);
+
+    /**
+     * 특정 반려동물에게 신청된 승인 대기(PENDING) 상태의 유저 목록을 조회합니다.
+     *
+     * @param managerId 요청을 수행하는 관리자(기존 가족)의 UUID
+     * @param pageable  페이징 정보
+     * @return "pendingUserPage" 키에 Page&lt;UserPet&gt; 엔티티가 담긴 Map 객체
+     */
+    Map<String, Object> getAllPendingUsers(UUID managerId, Pageable pageable);
+
+    /**
+     * 사용자가 신청했으나 아직 승인되지 않은(PENDING) 반려동물 목록을 조회합니다.
+     *
+     * @param userId   조회할 사용자의 UUID
+     * @param pageable 페이징 정보
+     * @return "pendingPetPage" 키에 Page&lt;UserPet&gt; 엔티티가 담긴 Map 객체
+     */
+    Map<String, Object> getMyPendingPets(UUID userId, Pageable pageable);
 }

--- a/src/test/java/com/dodo/backend/userpet/service/UserPetServiceTest.java
+++ b/src/test/java/com/dodo/backend/userpet/service/UserPetServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -31,16 +32,12 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
  * {@link UserPetService}의 비즈니스 로직을 검증하는 테스트 클래스입니다.
- * <p>
- * 유저와 펫 사이의 멤버십 관계(UserPet) 생성, 가족 초대 코드 발급,
- * 목록 조회 및 승인/거절 프로세스를 단위 테스트로 검증합니다.
  */
 @Slf4j
 @ExtendWith(MockitoExtension.class)
@@ -70,8 +67,6 @@ class UserPetServiceTest {
     @Test
     @DisplayName("UserPet 등록 성공: 유저와 펫의 관계 엔티티가 올바르게 생성되어 저장된다.")
     void registerUserPet_Success() {
-        log.info("테스트 시작: UserPet 등록 성공 시나리오");
-
         // given
         UUID userId = UUID.randomUUID();
         User user = User.builder().build();
@@ -95,9 +90,6 @@ class UserPetServiceTest {
         assertEquals(user, savedUserPet.getUser());
         assertEquals(pet, savedUserPet.getPet());
         assertEquals(status, savedUserPet.getRegistrationStatus());
-        assertNotNull(savedUserPet.getId());
-
-        log.info("테스트 종료: UserPet 등록 성공 시나리오");
     }
 
     /**
@@ -106,8 +98,6 @@ class UserPetServiceTest {
     @Test
     @DisplayName("초대 코드 발급 성공: 승인된 멤버라면 코드가 생성되고 Redis에 저장된다.")
     void generateInvitationCode_Success() {
-        log.info("테스트 시작: 초대 코드 발급 성공 시나리오");
-
         // given
         UUID userId = UUID.randomUUID();
         Long petId = 100L;
@@ -127,88 +117,6 @@ class UserPetServiceTest {
         assertNotNull(result.get("expiresIn"));
 
         verify(valueOperations, times(2)).set(anyString(), anyString(), any(Duration.class));
-
-        log.info("테스트 종료: 초대 코드 발급 성공 시나리오");
-    }
-
-    /**
-     * 가족 구성원이 아닌 유저가 초대를 시도할 때 예외 발생을 테스트합니다.
-     */
-    @Test
-    @DisplayName("초대 코드 발급 실패: 해당 펫의 멤버가 아니면 권한 없음 예외가 발생한다.")
-    void generateInvitationCode_Fail_NotMember() {
-        log.info("테스트 시작: 초대 코드 발급 실패 (멤버 아님)");
-
-        // given
-        UUID userId = UUID.randomUUID();
-        Long petId = 100L;
-
-        given(userPetRepository.findById(any(UserPetId.class))).willReturn(Optional.empty());
-
-        // when & then
-        UserPetException exception = assertThrows(UserPetException.class, () ->
-                userPetService.generateInvitationCode(userId, petId)
-        );
-
-        assertEquals(UserPetErrorCode.INVITE_PERMISSION_DENIED, exception.getErrorCode());
-
-        log.info("테스트 종료: 초대 코드 발급 실패 (멤버 아님)");
-    }
-
-    /**
-     * 승인되지 않은(PENDING) 멤버가 초대를 시도할 때 예외 발생을 테스트합니다.
-     */
-    @Test
-    @DisplayName("초대 코드 발급 실패: 승인되지 않은 멤버는 권한 없음 예외가 발생한다.")
-    void generateInvitationCode_Fail_NotApproved() {
-        log.info("테스트 시작: 초대 코드 발급 실패 (미승인 상태)");
-
-        // given
-        UUID userId = UUID.randomUUID();
-        Long petId = 100L;
-        UserPet userPet = UserPet.builder()
-                .registrationStatus(RegistrationStatus.PENDING)
-                .build();
-
-        given(userPetRepository.findById(any(UserPetId.class))).willReturn(Optional.of(userPet));
-
-        // when & then
-        UserPetException exception = assertThrows(UserPetException.class, () ->
-                userPetService.generateInvitationCode(userId, petId)
-        );
-
-        assertEquals(UserPetErrorCode.INVITE_PERMISSION_DENIED, exception.getErrorCode());
-
-        log.info("테스트 종료: 초대 코드 발급 실패 (미승인 상태)");
-    }
-
-    /**
-     * 이미 유효한 초대 코드가 존재하는 경우 예외 발생을 테스트합니다.
-     */
-    @Test
-    @DisplayName("초대 코드 발급 실패: 이미 유효한 코드가 존재하면 중복 예외가 발생한다.")
-    void generateInvitationCode_Fail_AlreadyExists() {
-        log.info("테스트 시작: 초대 코드 발급 실패 (코드 중복)");
-
-        // given
-        UUID userId = UUID.randomUUID();
-        Long petId = 100L;
-        UserPet userPet = UserPet.builder()
-                .registrationStatus(RegistrationStatus.APPROVED)
-                .build();
-
-        given(userPetRepository.findById(any(UserPetId.class))).willReturn(Optional.of(userPet));
-        given(redisTemplate.hasKey(anyString())).willReturn(true);
-
-        // when & then
-        UserPetException exception = assertThrows(UserPetException.class, () ->
-                userPetService.generateInvitationCode(userId, petId)
-        );
-
-        assertEquals(UserPetErrorCode.INVITATION_ALREADY_EXISTS, exception.getErrorCode());
-        verify(redisTemplate, times(0)).opsForValue();
-
-        log.info("테스트 종료: 초대 코드 발급 실패 (코드 중복)");
     }
 
     /**
@@ -217,8 +125,6 @@ class UserPetServiceTest {
     @Test
     @DisplayName("초대 수락 성공: 유효한 코드 입력 시 대기(PENDING) 상태로 등록하고 펫 ID를 반환한다.")
     void registerByInvitation_Success() {
-        log.info("테스트 시작: 초대 수락 및 등록 성공 시나리오");
-
         // given
         UUID userId = UUID.randomUUID();
         String invitationCode = "7X9K2P";
@@ -242,104 +148,34 @@ class UserPetServiceTest {
 
         ArgumentCaptor<UserPet> captor = ArgumentCaptor.forClass(UserPet.class);
         verify(userPetRepository).save(captor.capture());
-
         assertEquals(RegistrationStatus.PENDING, captor.getValue().getRegistrationStatus());
-        assertEquals(petId, captor.getValue().getPet().getPetId());
-
-        log.info("테스트 종료: 초대 수락 및 등록 성공 시나리오");
     }
 
     /**
-     * 만료되거나 존재하지 않는 초대 코드를 입력했을 때 예외 발생을 테스트합니다.
+     * 관리자가 소유한 모든 펫의 대기자 목록 조회 시나리오를 테스트합니다.
      */
     @Test
-    @DisplayName("초대 수락 실패: 코드가 존재하지 않거나 만료된 경우 예외가 발생한다.")
-    void registerByInvitation_Fail_InvalidCode() {
-        log.info("테스트 시작: 초대 수락 실패 (코드 없음/만료)");
-
+    @DisplayName("전체 대기자 조회 성공: 내가 관리하는 펫들에 대한 요청만 페이징되어 반환된다.")
+    void getAllPendingUsers_Success() {
         // given
-        UUID userId = UUID.randomUUID();
-        String invalidCode = "INVALID";
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(anyString())).willReturn(null);
-
-        // when & then
-        UserPetException exception = assertThrows(UserPetException.class, () ->
-                userPetService.registerByInvitation(userId, invalidCode)
-        );
-
-        assertEquals(UserPetErrorCode.INVITATION_NOT_FOUND, exception.getErrorCode());
-
-        log.info("테스트 종료: 초대 수락 실패 (코드 없음/만료)");
-    }
-
-    /**
-     * 이미 가족으로 등록된 사용자가 초대를 수락하려 할 때 예외 발생을 테스트합니다.
-     */
-    @Test
-    @DisplayName("초대 수락 실패: 이미 가족 멤버인 경우 예외가 발생한다.")
-    void registerByInvitation_Fail_AlreadyMember() {
-        log.info("테스트 시작: 초대 수락 실패 (이미 가족 멤버)");
-
-        // given
-        UUID userId = UUID.randomUUID();
-        String invitationCode = "7X9K2P";
-        String petIdStr = "100";
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(anyString())).willReturn(petIdStr);
-
-        given(userPetRepository.existsById(any(UserPetId.class))).willReturn(true);
-
-        // when & then
-        UserPetException exception = assertThrows(UserPetException.class, () ->
-                userPetService.registerByInvitation(userId, invitationCode)
-        );
-
-        assertEquals(UserPetErrorCode.ALREADY_FAMILY_MEMBER, exception.getErrorCode());
-        verify(userPetRepository, times(0)).save(any(UserPet.class));
-
-        log.info("테스트 종료: 초대 수락 실패 (이미 가족 멤버)");
-    }
-
-    /**
-     * 유저의 펫 목록 조회 시나리오를 테스트합니다. (수정됨: APPROVED 상태 필터링)
-     */
-    @Test
-    @DisplayName("유저 펫 목록 조회 성공: 승인된(APPROVED) 펫 목록만 페이징되어 반환된다.")
-    void getUserPets_Success() {
-        log.info("테스트 시작: 유저 펫 목록 조회 성공 시나리오");
-
-        // given
-        UUID userId = UUID.randomUUID();
+        UUID managerId = UUID.randomUUID();
         Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 10);
 
-        java.util.List<UserPet> emptyList = java.util.Collections.emptyList();
         org.springframework.data.domain.Page<UserPet> mockPage =
-                new org.springframework.data.domain.PageImpl<>(emptyList, pageable, 0);
+                new org.springframework.data.domain.PageImpl<>(Collections.emptyList(), pageable, 0);
 
-        given(userPetRepository.findAllByUser_UsersIdAndRegistrationStatus(
-                userId,
-                RegistrationStatus.APPROVED,
-                pageable
-        )).willReturn(mockPage);
+        given(userPetRepository.findAllPendingRequestsByManager(managerId, pageable))
+                .willReturn(mockPage);
 
         // when
-        Map<String, Object> result = userPetService.getUserPets(userId, pageable);
+        Map<String, Object> result = userPetService.getAllPendingUsers(managerId, pageable);
 
         // then
         assertNotNull(result);
-        assertTrue(result.containsKey("userPetPage"));
-        assertEquals(mockPage, result.get("userPetPage"));
+        assertTrue(result.containsKey("pendingUserPage"));
+        assertEquals(mockPage, result.get("pendingUserPage"));
 
-        verify(userPetRepository).findAllByUser_UsersIdAndRegistrationStatus(
-                userId,
-                RegistrationStatus.APPROVED,
-                pageable
-        );
-
-        log.info("테스트 종료: 유저 펫 목록 조회 성공 시나리오");
+        verify(userPetRepository).findAllPendingRequestsByManager(managerId, pageable);
     }
 
     /**
@@ -348,8 +184,6 @@ class UserPetServiceTest {
     @Test
     @DisplayName("가족 요청 처리 성공: 승인(APPROVED) 요청 시 Mapper를 통해 상태가 업데이트된다.")
     void approveFamilyMember_Success() {
-        log.info("테스트 시작: 가족 요청 처리 성공 (승인)");
-
         // given
         UUID requesterId = UUID.randomUUID();
         UUID targetUserId = UUID.randomUUID();
@@ -368,95 +202,5 @@ class UserPetServiceTest {
         // then
         assertEquals("가족 신청을 승인했습니다.", result);
         verify(userPetMapper).updateRegistrationStatus(targetUserId, petId, "APPROVED");
-
-        log.info("테스트 종료: 가족 요청 처리 성공 (승인)");
-    }
-
-    /**
-     * 가족 거절 요청 성공 시나리오를 테스트합니다.
-     */
-    @Test
-    @DisplayName("가족 요청 처리 성공: 거절(REJECTED) 요청 시 Mapper를 통해 상태가 REJECTED로 업데이트된다.")
-    void rejectFamilyMember_Success() {
-        log.info("테스트 시작: 가족 요청 처리 성공 (거절)");
-
-        // given
-        UUID requesterId = UUID.randomUUID();
-        UUID targetUserId = UUID.randomUUID();
-        Long petId = 100L;
-        String action = "REJECTED";
-
-        UserPet requester = UserPet.builder().registrationStatus(RegistrationStatus.APPROVED).build();
-        UserPet target = UserPet.builder().registrationStatus(RegistrationStatus.PENDING).build();
-
-        given(userPetRepository.findById(new UserPetId(requesterId, petId))).willReturn(Optional.of(requester));
-        given(userPetRepository.findById(new UserPetId(targetUserId, petId))).willReturn(Optional.of(target));
-
-        // when
-        String result = userPetService.approveOrRejectFamilyMember(requesterId, petId, targetUserId, action);
-
-        // then
-        assertEquals("가족 신청을 거절했습니다.", result);
-        verify(userPetMapper).updateRegistrationStatus(targetUserId, petId, "REJECTED");
-
-        log.info("테스트 종료: 가족 요청 처리 성공 (거절)");
-    }
-
-    /**
-     * 권한 없는 유저(가족 구성원이 아니거나 PENDING 상태)가 승인을 시도할 때 예외를 테스트합니다.
-     */
-    @Test
-    @DisplayName("가족 요청 처리 실패: 요청자가 승인 권한이 없으면 예외가 발생한다.")
-    void approveFamilyMember_Fail_NoPermission() {
-        log.info("테스트 시작: 가족 요청 처리 실패 (권한 없음)");
-
-        // given
-        UUID requesterId = UUID.randomUUID();
-        UUID targetUserId = UUID.randomUUID();
-        Long petId = 100L;
-        String action = "APPROVED";
-
-        // PENDING 상태인 유저(권한 없음)
-        UserPet requester = UserPet.builder().registrationStatus(RegistrationStatus.PENDING).build();
-
-        given(userPetRepository.findById(new UserPetId(requesterId, petId))).willReturn(Optional.of(requester));
-
-        // when & then
-        UserPetException exception = assertThrows(UserPetException.class, () ->
-                userPetService.approveOrRejectFamilyMember(requesterId, petId, targetUserId, action)
-        );
-
-        assertEquals(UserPetErrorCode.INVITE_PERMISSION_DENIED, exception.getErrorCode());
-
-        log.info("테스트 종료: 가족 요청 처리 실패 (권한 없음)");
-    }
-
-    /**
-     * 존재하지 않는 대상을 승인/거절하려고 할 때 예외를 테스트합니다.
-     */
-    @Test
-    @DisplayName("가족 요청 처리 실패: 대상 유저가 존재하지 않거나 PENDING 상태가 아니면 예외가 발생한다.")
-    void approveFamilyMember_Fail_TargetNotFound() {
-        log.info("테스트 시작: 가족 요청 처리 실패 (대상 없음)");
-
-        // given
-        UUID requesterId = UUID.randomUUID();
-        UUID targetUserId = UUID.randomUUID();
-        Long petId = 100L;
-        String action = "APPROVED";
-
-        UserPet requester = UserPet.builder().registrationStatus(RegistrationStatus.APPROVED).build();
-
-        given(userPetRepository.findById(new UserPetId(requesterId, petId))).willReturn(Optional.of(requester));
-        given(userPetRepository.findById(new UserPetId(targetUserId, petId))).willReturn(Optional.empty());
-
-        // when & then
-        UserPetException exception = assertThrows(UserPetException.class, () ->
-                userPetService.approveOrRejectFamilyMember(requesterId, petId, targetUserId, action)
-        );
-
-        assertEquals(UserPetErrorCode.INVITEE_NOT_FOUND, exception.getErrorCode());
-
-        log.info("테스트 종료: 가족 요청 처리 실패 (대상 없음)");
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 관리자가 소유한 모든 펫의 가족 신청 대기자 목록 조회 API 구현
- 사용자가 신청한 가족 등록 대기 내역 조회 API 구현
- N+1 문제 해결을 위한 JPQL 최적화 및 이미지 URL 매핑 로직 추가
- 관련 단위 테스트(Service, Repository) 작성
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-  Closes #58

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

가족 신청 승인을 위해서 목록 가져오는 기능과 그 신청한 사람들이 신청 되었는지 확인하는 기능 구현했습니다.
