### PR TITLE
✨ Feat: 펫 가족 나가기 및 삭제 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 /**
  * 펫 도메인과 관련된 응답 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
  * <p>
- * 펫 등록, 수정, 조회, 가족 초대 및 승인 등 다양한 API 응답에 사용되는
+ * 펫 등록, 수정, 조회, 가족 초대 및 승인, 삭제 등 다양한 API 응답에 사용되는
  * Inner Static Class들을 포함하고 있습니다.
  */
 @Schema(description = "펫 관련 응답 DTO 그룹")
@@ -442,6 +442,30 @@ public class PetResponse {
                         .requestedAt(requestedAt)
                         .build();
             }
+        }
+    }
+
+    /**
+     * 반려동물 정보가 삭제되었을 때 반환되는 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "반려동물 삭제 결과 응답")
+    public static class PetDeleteResponse {
+
+        @Schema(description = "처리 결과 메시지", example = "반려동물 목록에서 삭제되었습니다.")
+        private String message;
+
+        /**
+         * 성공 메시지를 담은 응답 DTO를 생성합니다.
+         *
+         * @return 초기화된 {@link PetDeleteResponse} 객체
+         */
+        public static PetDeleteResponse toDto(String message) {
+            return PetDeleteResponse.builder()
+                    .message(message)
+                    .build();
         }
     }
 }

--- a/src/main/java/com/dodo/backend/pet/service/PetService.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetService.java
@@ -29,7 +29,7 @@ public interface PetService {
      * @param request 수정할 정보를 담은 요청 객체
      * @return 수정이 완료된 후의 최신 반려동물 상세 정보 응답 객체
      */
-    PetUpdateResponse updatePet(Long petId, PetUpdateRequest request);
+    PetUpdateResponse updatePet(Long petId, PetUpdateRequest request, UUID userId);
 
     /**
      * 반려동물 가족 초대를 위한 코드를 발급합니다.
@@ -86,4 +86,12 @@ public interface PetService {
      * @return 페이징된 신청 내역 목록 응답 DTO
      */
     PetApplicationListResponse getMyPendingApplications(UUID userId, Pageable pageable);
+
+    /**
+     * 반려동물 정보를 삭제합니다.
+     *
+     * @param userId 요청한 사용자의 ID (권한 검증용)
+     * @param petId  삭제할 반려동물 ID
+     */
+    void deletePet(UUID userId, Long petId);
 }

--- a/src/main/java/com/dodo/backend/userpet/repository/UserPetRepository.java
+++ b/src/main/java/com/dodo/backend/userpet/repository/UserPetRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -59,4 +59,34 @@ public interface UserPetRepository extends JpaRepository<UserPet, UserPetId> {
             "   WHERE my.user.usersId = :managerId AND my.registrationStatus = 'APPROVED'" +
             ")")
     Page<UserPet> findAllPendingRequestsByManager(@Param("managerId") UUID managerId, Pageable pageable);
+
+    /**
+     * 특정 유저가 특정 반려동물의 소유자(APPROVED 상태)인지 확인합니다.
+     * Spring Data JPA의 쿼리 메서드 기능을 사용하여 구현합니다.
+     *
+     * @param userId 유저 ID
+     * @param petId 펫 ID
+     * @param status 등록 상태 (주로 APPROVED)
+     * @return 존재 여부 (true/false)
+     */
+    boolean existsByUser_UsersIdAndPet_PetIdAndRegistrationStatus(UUID userId, Long petId, RegistrationStatus status);
+
+    /**
+     * 유저 ID와 펫 ID를 이용해 특정 UserPet 엔티티(관계 정보)를 조회합니다.
+     * (삭제 대상을 찾을 때 사용)
+     *
+     * @param userId 유저 ID
+     * @param petId  펫 ID
+     * @return UserPet 엔티티 (Optional)
+     */
+    Optional<UserPet> findByUser_UsersIdAndPet_PetId(UUID userId, Long petId);
+
+    /**
+     * 특정 반려동물에게 연결된 가족(UserPet)이 존재하는지 확인합니다.
+     * (마지막 남은 가족인지 확인할 때 사용)
+     *
+     * @param petId 확인할 펫 ID
+     * @return 연결된 데이터가 하나라도 있으면 true, 없으면 false
+     */
+    boolean existsByPet_PetId(Long petId);
 }

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
@@ -85,4 +85,30 @@ public interface UserPetService {
      * @return "pendingPetPage" 키에 Page&lt;UserPet&gt; 엔티티가 담긴 Map 객체
      */
     Map<String, Object> getMyPendingPets(UUID userId, Pageable pageable);
+
+    /**
+     * 해당 유저가 특정 반려동물의 정식 소유자(APPROVED)인지 확인합니다.
+     * 보안 검증(IDOR 방지)을 위해 사용됩니다.
+     *
+     * @param userId 확인할 유저 ID
+     * @param petId 확인할 펫 ID
+     * @return 소유자라면 true, 아니면 false
+     */
+    boolean isUserPetOwner(UUID userId, Long petId);
+
+    /**
+     * 특정 유저와 펫의 연결 관계(UserPet)를 삭제합니다. (가족 나가기)
+     *
+     * @param userId 삭제할 유저 ID
+     * @param petId  삭제할 펫 ID
+     */
+    void deleteUserPetRelation(UUID userId, Long petId);
+
+    /**
+     * 해당 펫에 등록된 가족이 한 명이라도 남아있는지 확인합니다.
+     *
+     * @param petId 확인할 펫 ID
+     * @return 가족이 남아있다면 true
+     */
+    boolean existsFamilyMember(Long petId);
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- DELETE /pets/{petId} 엔드포인트 추가 및 가족 탈퇴 비즈니스 로직 구현
- 마지막 구성원 탈퇴 시 펫 정보도 함께 삭제되도록 고아 객체 처리(Orphan Removal) 로직 추가
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #60

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 가족으로 추가 된 인원이 있을때 삭제 api를 호출하면 그 사람만 없어지고 다른 사람은 남아있습니다.
- 나중에 다른 사람도 삭제 했을때는 아예 pet에 대한 정보 자체가 사라집니다.
