### PR TITLE
✨ Feat: 반려동물 디바이스 재등록 기능 구현 및 단위 테스트 구현

### DIFF
--- a/src/main/java/com/dodo/backend/pet/dto/request/PetRequest.java
+++ b/src/main/java/com/dodo/backend/pet/dto/request/PetRequest.java
@@ -165,4 +165,17 @@ public class PetRequest {
         private String action;
     }
 
+    /**
+     * 펫 디바이스 재등록 요청 DTO입니다.
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PetDeviceUpdateRequest {
+        @NotBlank(message = "디바이스 ID는 필수입니다.")
+        @Schema(description = "새로운 디바이스 ID", example = "NEW_ABC123XYZ")
+        private String deviceId;
+    }
+
 }

--- a/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
@@ -468,4 +468,42 @@ public class PetResponse {
                     .build();
         }
     }
+
+    /**
+     * 펫 디바이스 재등록 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "디바이스 재등록 결과 응답")
+    public static class PetDeviceUpdateResponse {
+
+        @Schema(description = "처리 결과 메시지", example = "디바이스가 성공적으로 재등록되었습니다.")
+        private String message;
+
+        @Schema(description = "반려동물 ID", example = "101")
+        private Long petId;
+
+        @Schema(description = "반려동물 이름", example = "보리")
+        private String petName;
+
+        @Schema(description = "이전 디바이스 ID", example = "OLD_ABC123XYZ")
+        private String previousDeviceId;
+
+        @Schema(description = "새로운 디바이스 ID", example = "NEW_ABC123XYZ")
+        private String newDeviceId;
+
+        /**
+         * 엔티티를 직접 받지 않고, 필요한 필드만 전달받아 DTO를 생성합니다.
+         */
+        public static PetDeviceUpdateResponse toDto(Long petId, String petName, String oldDeviceId, String newDeviceId, String message) {
+            return PetDeviceUpdateResponse.builder()
+                    .message(message)
+                    .petId(petId)
+                    .petName(petName)
+                    .previousDeviceId(oldDeviceId)
+                    .newDeviceId(newDeviceId)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/dodo/backend/pet/mapper/PetMapper.java
+++ b/src/main/java/com/dodo/backend/pet/mapper/PetMapper.java
@@ -17,4 +17,12 @@ public interface PetMapper {
      * @param petId   수정할 반려동물의 식별자
      */
     void updatePetProfileInfo(@Param("request") PetUpdateRequest request, @Param("petId") Long petId);
+
+    /**
+     * 펫의 디바이스 ID를 업데이트합니다.
+     *
+     * @param petId    업데이트할 펫 ID
+     * @param deviceId 새로운 디바이스 ID
+     */
+    void updatePetDevice(@Param("petId") Long petId, @Param("deviceId") String deviceId);
 }

--- a/src/main/java/com/dodo/backend/pet/repository/PetRepository.java
+++ b/src/main/java/com/dodo/backend/pet/repository/PetRepository.java
@@ -20,4 +20,11 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
      * @return 등록번호가 존재하면 true, 그렇지 않으면 false
      */
     boolean existsByRegistrationNumber(String registrationNumber);
+
+    /**
+     * 디바이스 ID 중복 여부 확인
+     * @param deviceId 확인할 디바이스 ID
+     * @return 존재하면 true, 없으면 false
+     */
+    boolean existsByDeviceId(String deviceId);
 }

--- a/src/main/java/com/dodo/backend/pet/service/PetService.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetService.java
@@ -1,8 +1,6 @@
 package com.dodo.backend.pet.service;
 
-import com.dodo.backend.pet.dto.request.PetRequest.PetFamilyJoinRequest;
-import com.dodo.backend.pet.dto.request.PetRequest.PetRegisterRequest;
-import com.dodo.backend.pet.dto.request.PetRequest.PetUpdateRequest;
+import com.dodo.backend.pet.dto.request.PetRequest.*;
 import com.dodo.backend.pet.dto.response.PetResponse.*;
 import org.springframework.data.domain.Pageable;
 
@@ -94,4 +92,14 @@ public interface PetService {
      * @param petId  삭제할 반려동물 ID
      */
     void deletePet(UUID userId, Long petId);
+
+    /**
+     * 반려동물의 디바이스를 재등록(수정)합니다.
+     *
+     * @param userId  요청한 사용자 ID
+     * @param petId   반려동물 ID
+     * @param request 디바이스 변경 요청 정보
+     * @return 변경된 디바이스 정보 응답
+     */
+    PetDeviceUpdateResponse updateDevice(UUID userId, Long petId, PetDeviceUpdateRequest request);
 }

--- a/src/main/resources/com/dodo/backend/pet/mapper/PetMapper.xml
+++ b/src/main/resources/com/dodo/backend/pet/mapper/PetMapper.xml
@@ -17,4 +17,14 @@
         </set>
         WHERE pet_id = #{petId}
     </update>
+
+    <!-- 특정 애완동물의 디바이스 정보를 변경합니다.
+         1. device_id : 새로 연결할 디바이스 ID
+         2. updated_at : 디바이스 변경 시점 기록
+         3. WHERE pet_id : petId를 기준으로 특정 애완동물을 식별 -->
+    <update id="updatePetDevice">
+    UPDATE pet
+    SET device_id = #{deviceId}
+    WHERE pet_id = #{petId}
+    </update>
 </mapper>

--- a/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
+++ b/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
@@ -56,12 +56,19 @@ class PetServiceTest {
     @Mock
     private PetMapper petMapper;
 
+    @Mock
+    private PetWeightService petWeightService;
+
+    @Mock
+    private ImageFileService imageFileService;
+
     /**
      * 펫 등록 성공 시나리오를 테스트합니다.
      */
     @Test
     @DisplayName("펫 등록 성공: 정상적인 요청 시 펫이 저장되고 유저와 연결된다.")
     void registerPet_Success() {
+        log.info("펫 등록 성공 케이스 테스트를 시작합니다.");
         // given
         UUID userId = UUID.randomUUID();
         PetRequest.PetRegisterRequest request = PetRequest.PetRegisterRequest.builder()
@@ -78,20 +85,24 @@ class PetServiceTest {
         Pet savedPet = request.toEntity();
         ReflectionTestUtils.setField(savedPet, "petId", 1L);
 
+        log.info("사용자가 존재하고 등록번호가 중복되지 않는 상황을 설정합니다.");
         given(userRepository.existsById(userId)).willReturn(true);
         given(petRepository.existsByRegistrationNumber(request.getRegistrationNumber())).willReturn(false);
         given(petRepository.save(any(Pet.class))).willReturn(savedPet);
 
         // when
+        log.info("펫 등록 서비스 로직을 호출합니다.");
         PetResponse.PetRegisterResponse response = petService.registerPet(userId, request);
 
         // then
+        log.info("등록된 펫 ID가 반환되었는지 확인하고, 관련 서비스가 호출되었는지 검증합니다.");
         assertNotNull(response);
         assertEquals(1L, response.getPetId());
 
         verify(userRepository, times(1)).existsById(userId);
         verify(petRepository, times(1)).save(any(Pet.class));
         verify(userPetService, times(1)).registerUserPet(userId, savedPet, RegistrationStatus.APPROVED);
+        log.info("펫 등록 성공 테스트가 통과되었습니다.");
     }
 
     /**
@@ -100,19 +111,24 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 등록 실패: 존재하지 않는 유저 ID인 경우 예외가 발생한다.")
     void registerPet_Fail_UserNotFound() {
+        log.info("존재하지 않는 유저로 인한 펫 등록 실패 테스트를 시작합니다.");
         // given
         UUID userId = UUID.randomUUID();
         PetRequest.PetRegisterRequest request = PetRequest.PetRegisterRequest.builder().build();
 
+        log.info("유저가 존재하지 않는 상황을 설정합니다.");
         given(userRepository.existsById(userId)).willReturn(false);
 
         // when
+        log.info("펫 등록 요청 시 예외가 발생하는지 확인합니다.");
         PetException exception = assertThrows(PetException.class, () ->
                 petService.registerPet(userId, request)
         );
 
         // then
+        log.info("발생한 예외 코드가 USER_NOT_FOUND인지 검증합니다.");
         assertEquals(PetErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        log.info("유저 미발견 실패 테스트가 통과되었습니다.");
     }
 
     /**
@@ -121,23 +137,28 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 등록 실패: 이미 존재하는 등록번호인 경우 예외가 발생한다.")
     void registerPet_Fail_DuplicateRegistrationNumber() {
+        log.info("등록번호 중복으로 인한 펫 등록 실패 테스트를 시작합니다.");
         // given
         UUID userId = UUID.randomUUID();
         PetRequest.PetRegisterRequest request = PetRequest.PetRegisterRequest.builder()
                 .registrationNumber("1234567890")
                 .build();
 
+        log.info("이미 존재하는 등록번호라고 가정합니다.");
         given(userRepository.existsById(userId)).willReturn(true);
         given(petRepository.existsByRegistrationNumber(request.getRegistrationNumber())).willReturn(true);
 
         // when
+        log.info("중복된 등록번호로 요청 시 예외가 발생하는지 확인합니다.");
         PetException exception = assertThrows(PetException.class, () ->
                 petService.registerPet(userId, request)
         );
 
         // then
+        log.info("발생한 예외 코드가 REGISTRATION_NUMBER_DUPLICATED인지 검증합니다.");
         assertEquals(PetErrorCode.REGISTRATION_NUMBER_DUPLICATED, exception.getErrorCode());
         verify(petRepository, times(0)).save(any(Pet.class));
+        log.info("등록번호 중복 실패 테스트가 통과되었습니다.");
     }
 
     /**
@@ -146,6 +167,7 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 수정 성공: 소유자가 요청하고 중복이 없으면 정상적으로 수정된다.")
     void updatePet_Success() {
+        log.info("펫 정보 수정 성공 테스트를 시작합니다.");
         // given
         Long petId = 1L;
         UUID userId = UUID.randomUUID();
@@ -164,18 +186,22 @@ class PetServiceTest {
                 .age(5)
                 .build();
 
+        log.info("펫이 존재하고 요청자가 소유자이며, 새 등록번호가 중복되지 않음을 설정합니다.");
         given(petRepository.findById(petId)).willReturn(Optional.of(existingPet));
         given(userPetService.isUserPetOwner(userId, petId)).willReturn(true);
         given(petRepository.existsByRegistrationNumber("NEW-999")).willReturn(false);
 
         // when
+        log.info("펫 수정 서비스 로직을 호출합니다.");
         PetResponse.PetUpdateResponse response = petService.updatePet(petId, request, userId);
 
         // then
+        log.info("반환된 펫 이름이 수정된 이름과 일치하는지, 업데이트 Mapper가 호출되었는지 검증합니다.");
         assertNotNull(response);
         assertEquals("새로운초코", response.getPetName());
 
         verify(petMapper, times(1)).updatePetProfileInfo(request, petId);
+        log.info("펫 수정 성공 테스트가 통과되었습니다.");
     }
 
     /**
@@ -184,6 +210,7 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 수정 실패: 소유자가 아닌 경우 권한 없음 예외가 발생한다.")
     void updatePet_Fail_PermissionDenied() {
+        log.info("권한 없음으로 인한 펫 수정 실패 테스트를 시작합니다.");
         // given
         Long petId = 1L;
         UUID userId = UUID.randomUUID();
@@ -191,17 +218,21 @@ class PetServiceTest {
 
         Pet existingPet = Pet.builder().petId(petId).build();
 
+        log.info("요청자가 해당 펫의 소유자가 아니라고 설정합니다.");
         given(petRepository.findById(petId)).willReturn(Optional.of(existingPet));
         given(userPetService.isUserPetOwner(userId, petId)).willReturn(false);
 
         // when
+        log.info("수정 요청 시 권한 예외가 발생하는지 확인합니다.");
         PetException exception = assertThrows(PetException.class, () ->
                 petService.updatePet(petId, request, userId)
         );
 
         // then
+        log.info("발생한 예외 코드가 UPDATE_PERMISSION_DENIED인지 검증합니다.");
         assertEquals(PetErrorCode.UPDATE_PERMISSION_DENIED, exception.getErrorCode());
         verify(petMapper, times(0)).updatePetProfileInfo(any(), any());
+        log.info("권한 없음 실패 테스트가 통과되었습니다.");
     }
 
     /**
@@ -210,21 +241,26 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 수정 실패: 존재하지 않는 펫 ID인 경우 예외가 발생한다.")
     void updatePet_Fail_NotFound() {
+        log.info("존재하지 않는 펫 수정 시도 실패 테스트를 시작합니다.");
         // given
         Long petId = 999L;
         UUID userId = UUID.randomUUID();
         PetRequest.PetUpdateRequest request = PetRequest.PetUpdateRequest.builder().build();
 
+        log.info("해당 ID의 펫이 존재하지 않는다고 설정합니다.");
         given(petRepository.findById(petId)).willReturn(Optional.empty());
 
         // when
+        log.info("수정 요청 시 예외가 발생하는지 확인합니다.");
         PetException exception = assertThrows(PetException.class, () ->
                 petService.updatePet(petId, request, userId)
         );
 
         // then
+        log.info("발생한 예외 코드가 PET_NOT_FOUND인지 검증합니다.");
         assertEquals(PetErrorCode.PET_NOT_FOUND, exception.getErrorCode());
         verify(petMapper, times(0)).updatePetProfileInfo(any(), any());
+        log.info("펫 미발견 실패 테스트가 통과되었습니다.");
     }
 
     /**
@@ -233,6 +269,7 @@ class PetServiceTest {
     @Test
     @DisplayName("초대 코드 발급 성공: 펫이 존재하면 UserPetService를 통해 코드가 발급된다.")
     void issueInvitationCode_Success() {
+        log.info("가족 초대 코드 발급 성공 테스트를 시작합니다.");
         // given
         UUID userId = UUID.randomUUID();
         Long petId = 1L;
@@ -244,19 +281,23 @@ class PetServiceTest {
                 "expiresIn", expectedExpiresIn
         );
 
+        log.info("펫이 존재하고, 초대 코드 생성 서비스가 정상 결과를 반환한다고 설정합니다.");
         given(petRepository.existsById(petId)).willReturn(true);
         given(userPetService.generateInvitationCode(userId, petId)).willReturn(serviceResult);
 
         // when
+        log.info("초대 코드 발급 메서드를 호출합니다.");
         PetResponse.PetInvitationResponse response = petService.issueInvitationCode(userId, petId);
 
         // then
+        log.info("반환된 코드와 만료 시간이 예상값과 일치하는지 검증합니다.");
         assertNotNull(response);
         assertEquals(expectedCode, response.getCode());
         assertEquals(expectedExpiresIn, response.getExpiresIn());
 
         verify(petRepository, times(1)).existsById(petId);
         verify(userPetService, times(1)).generateInvitationCode(userId, petId);
+        log.info("초대 코드 발급 성공 테스트가 통과되었습니다.");
     }
 
     /**
@@ -265,20 +306,25 @@ class PetServiceTest {
     @Test
     @DisplayName("초대 코드 발급 실패: 펫이 존재하지 않으면 예외가 발생한다.")
     void issueInvitationCode_Fail_PetNotFound() {
+        log.info("존재하지 않는 펫에 대한 초대 코드 발급 실패 테스트를 시작합니다.");
         // given
         UUID userId = UUID.randomUUID();
         Long petId = 999L;
 
+        log.info("펫이 존재하지 않는다고 설정합니다.");
         given(petRepository.existsById(petId)).willReturn(false);
 
         // when
+        log.info("발급 요청 시 예외가 발생하는지 확인합니다.");
         PetException exception = assertThrows(PetException.class, () ->
                 petService.issueInvitationCode(userId, petId)
         );
 
         // then
+        log.info("발생한 예외 코드가 PET_NOT_FOUND인지 검증합니다.");
         assertEquals(PetErrorCode.PET_NOT_FOUND, exception.getErrorCode());
         verify(userPetService, times(0)).generateInvitationCode(any(), any());
+        log.info("초대 코드 발급 실패 테스트가 통과되었습니다.");
     }
 
     /**
@@ -287,44 +333,56 @@ class PetServiceTest {
     @Test
     @DisplayName("가족 참여 신청 성공: 유효한 코드로 요청 시 펫 ID와 성공 메시지를 반환한다.")
     void applyForFamily_Success() {
+        log.info("가족 참여 신청 성공 테스트를 시작합니다.");
         // given
         UUID userId = UUID.randomUUID();
         String invitationCode = "7X9K2P";
         Long petId = 100L;
         PetRequest.PetFamilyJoinRequest request = new PetRequest.PetFamilyJoinRequest(invitationCode);
 
+        log.info("초대 코드가 유효하여 펫 ID를 반환한다고 설정합니다.");
         given(userPetService.registerByInvitation(userId, invitationCode)).willReturn(petId);
 
         // when
+        log.info("가족 신청 메서드를 호출합니다.");
         PetResponse.PetFamilyJoinRequestResponse response = petService.applyForFamily(userId, request);
 
         // then
+        log.info("응답에 펫 ID와 성공 메시지가 포함되어 있는지 검증합니다.");
         assertNotNull(response);
         assertEquals(petId, response.getPetId());
         assertEquals("가족 등록을 신청했습니다. 승인을 기다려주세요.", response.getMessage());
 
         verify(userPetService, times(1)).registerByInvitation(userId, invitationCode);
+        log.info("가족 참여 신청 성공 테스트가 통과되었습니다.");
     }
 
     /**
      * 펫 삭제 성공 시나리오를 테스트합니다.
+     * (가족 나가기 로직 반영: UserPet 관계 삭제)
      */
     @Test
-    @DisplayName("펫 삭제 성공: 소유자인 경우 펫 정보를 삭제한다.")
+    @DisplayName("펫 삭제 성공: 소유자가 나갈 경우 UserPet 관계가 삭제된다.")
     void deletePet_Success() {
+        log.info("펫 가족 나가기 성공 테스트를 시작합니다.");
         // given
         Long petId = 1L;
         UUID userId = UUID.randomUUID();
-        Pet pet = Pet.builder().petId(petId).build();
 
-        given(petRepository.findById(petId)).willReturn(Optional.of(pet));
+        log.info("펫이 존재하고 요청자가 소유자이며, 다른 가족이 남아있다고 설정합니다.");
+        given(petRepository.existsById(petId)).willReturn(true);
         given(userPetService.isUserPetOwner(userId, petId)).willReturn(true);
+        given(userPetService.existsFamilyMember(petId)).willReturn(true);
 
         // when
+        log.info("펫 삭제(가족 나가기) 메서드를 호출합니다.");
         petService.deletePet(userId, petId);
 
         // then
-        verify(petRepository, times(1)).delete(pet);
+        log.info("관계 삭제 로직이 호출되었는지, 펫 정보 삭제는 호출되지 않았는지 검증합니다.");
+        verify(userPetService, times(1)).deleteUserPetRelation(userId, petId);
+        verify(petRepository, times(0)).deleteById(petId);
+        log.info("가족 나가기 성공 테스트가 통과되었습니다.");
     }
 
     /**
@@ -333,22 +391,26 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 삭제 실패: 소유자가 아닌 경우 예외가 발생한다.")
     void deletePet_Fail_PermissionDenied() {
+        log.info("권한 없음으로 인한 펫 삭제 실패 테스트를 시작합니다.");
         // given
         Long petId = 1L;
         UUID userId = UUID.randomUUID();
-        Pet pet = Pet.builder().petId(petId).build();
 
-        given(petRepository.findById(petId)).willReturn(Optional.of(pet));
+        log.info("펫은 존재하지만 요청자가 소유자가 아니라고 설정합니다.");
+        given(petRepository.existsById(petId)).willReturn(true);
         given(userPetService.isUserPetOwner(userId, petId)).willReturn(false);
 
         // when
+        log.info("삭제 요청 시 예외가 발생하는지 확인합니다.");
         PetException exception = assertThrows(PetException.class, () ->
                 petService.deletePet(userId, petId)
         );
 
         // then
+        log.info("발생한 예외 코드가 ACTION_PERMISSION_DENIED인지 검증합니다.");
         assertEquals(PetErrorCode.ACTION_PERMISSION_DENIED, exception.getErrorCode());
-        verify(petRepository, times(0)).delete(any());
+        verify(userPetService, times(0)).deleteUserPetRelation(any(), any());
+        log.info("권한 없음 삭제 실패 테스트가 통과되었습니다.");
     }
 
     /**
@@ -357,19 +419,141 @@ class PetServiceTest {
     @Test
     @DisplayName("펫 삭제 실패: 펫이 존재하지 않는 경우 예외가 발생한다.")
     void deletePet_Fail_NotFound() {
+        log.info("존재하지 않는 펫 삭제 실패 테스트를 시작합니다.");
         // given
         Long petId = 999L;
         UUID userId = UUID.randomUUID();
 
-        given(petRepository.findById(petId)).willReturn(Optional.empty());
+        log.info("펫이 존재하지 않는다고 설정합니다.");
+        given(petRepository.existsById(petId)).willReturn(false);
 
         // when
+        log.info("삭제 요청 시 예외가 발생하는지 확인합니다.");
         PetException exception = assertThrows(PetException.class, () ->
                 petService.deletePet(userId, petId)
         );
 
         // then
+        log.info("발생한 예외 코드가 PET_NOT_FOUND인지 검증합니다.");
         assertEquals(PetErrorCode.PET_NOT_FOUND, exception.getErrorCode());
-        verify(userPetService, times(0)).isUserPetOwner(any(), any());
+        verify(userPetService, times(0)).deleteUserPetRelation(any(), any());
+        log.info("펫 미발견 삭제 실패 테스트가 통과되었습니다.");
+    }
+
+    /**
+     * 펫 디바이스 재등록 성공 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("디바이스 재등록 성공: 중복되지 않은 새 ID로 요청 시 정상적으로 업데이트된다.")
+    void updateDevice_Success() {
+        log.info("디바이스 재등록 성공 테스트를 시작합니다.");
+        // given
+        Long petId = 1L;
+        UUID userId = UUID.randomUUID();
+        String oldDeviceId = "OLD_DEV";
+        String newDeviceId = "NEW_DEV";
+
+        Pet pet = Pet.builder()
+                .petId(petId)
+                .petName("나비")
+                .deviceId(oldDeviceId)
+                .build();
+
+        PetRequest.PetDeviceUpdateRequest request = PetRequest.PetDeviceUpdateRequest.builder()
+                .deviceId(newDeviceId)
+                .build();
+
+        log.info("펫이 존재하고 소유자 권한이 있으며, 새 디바이스 ID가 중복되지 않는다고 설정합니다.");
+        given(petRepository.findById(petId)).willReturn(Optional.of(pet));
+        given(userPetService.isUserPetOwner(userId, petId)).willReturn(true);
+        given(petRepository.existsByDeviceId(newDeviceId)).willReturn(false);
+
+        // when
+        log.info("디바이스 업데이트 메서드를 호출합니다.");
+        PetResponse.PetDeviceUpdateResponse response = petService.updateDevice(userId, petId, request);
+
+        // then
+        log.info("반환된 디바이스 정보가 새 ID와 일치하는지, 업데이트 Mapper가 호출되었는지 검증합니다.");
+        assertNotNull(response);
+        assertEquals(petId, response.getPetId());
+        assertEquals(oldDeviceId, response.getPreviousDeviceId());
+        assertEquals(newDeviceId, response.getNewDeviceId());
+
+        verify(petMapper, times(1)).updatePetDevice(petId, newDeviceId);
+        log.info("디바이스 재등록 성공 테스트가 통과되었습니다.");
+    }
+
+    /**
+     * 펫 디바이스 재등록 실패: 권한 없음 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("디바이스 재등록 실패: 소유자가 아닌 경우 예외가 발생한다.")
+    void updateDevice_Fail_PermissionDenied() {
+        log.info("권한 없음으로 인한 디바이스 재등록 실패 테스트를 시작합니다.");
+        // given
+        Long petId = 1L;
+        UUID userId = UUID.randomUUID();
+        String newDeviceId = "NEW_DEV";
+
+        Pet pet = Pet.builder().petId(petId).build();
+        PetRequest.PetDeviceUpdateRequest request = PetRequest.PetDeviceUpdateRequest.builder()
+                .deviceId(newDeviceId)
+                .build();
+
+        log.info("요청자가 해당 펫의 소유자가 아니라고 설정합니다.");
+        given(petRepository.findById(petId)).willReturn(Optional.of(pet));
+        given(userPetService.isUserPetOwner(userId, petId)).willReturn(false);
+
+        // when
+        log.info("업데이트 요청 시 예외가 발생하는지 확인합니다.");
+        PetException exception = assertThrows(PetException.class, () ->
+                petService.updateDevice(userId, petId, request)
+        );
+
+        // then
+        log.info("발생한 예외 코드가 ACTION_PERMISSION_DENIED인지 검증합니다.");
+        assertEquals(PetErrorCode.ACTION_PERMISSION_DENIED, exception.getErrorCode());
+        verify(petMapper, times(0)).updatePetDevice(any(), any());
+        log.info("권한 없음 재등록 실패 테스트가 통과되었습니다.");
+    }
+
+    /**
+     * 펫 디바이스 재등록 실패: 이미 사용 중인 ID 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("디바이스 재등록 실패: 이미 다른 펫이 사용 중인 디바이스 ID면 예외가 발생한다.")
+    void updateDevice_Fail_DuplicateDeviceId() {
+        log.info("디바이스 ID 중복으로 인한 재등록 실패 테스트를 시작합니다.");
+        // given
+        Long petId = 1L;
+        UUID userId = UUID.randomUUID();
+        String oldDeviceId = "OLD_DEV";
+        String duplicateDeviceId = "DUPLICATE_DEV";
+
+        Pet pet = Pet.builder()
+                .petId(petId)
+                .deviceId(oldDeviceId)
+                .build();
+
+        PetRequest.PetDeviceUpdateRequest request = PetRequest.PetDeviceUpdateRequest.builder()
+                .deviceId(duplicateDeviceId)
+                .build();
+
+        log.info("요청한 디바이스 ID가 이미 존재한다고 설정합니다.");
+        given(petRepository.findById(petId)).willReturn(Optional.of(pet));
+        given(userPetService.isUserPetOwner(userId, petId)).willReturn(true);
+        given(petRepository.existsByDeviceId(duplicateDeviceId)).willReturn(true);
+
+        // when
+        log.info("업데이트 요청 시 예외가 발생하는지 확인합니다.");
+        PetException exception = assertThrows(PetException.class, () ->
+                petService.updateDevice(userId, petId, request)
+        );
+
+        // then
+        log.info("발생한 예외 코드가 DEVICE_ID_DUPLICATED인지 검증합니다.");
+        assertEquals(PetErrorCode.DEVICE_ID_DUPLICATED, exception.getErrorCode());
+        verify(petMapper, times(0)).updatePetDevice(any(), any());
+        log.info("ID 중복 재등록 실패 테스트가 통과되었습니다.");
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- PUT /pets/{petId}/device 엔드포인트 및 비즈니스 로직 구현
- 디바이스 ID 중복 방지 로직(본인 기기 제외) 및 에러 코드(DEVICE_ID_DUPLICATED) 추가
- MyBatis Mapper를 활용한 device_id 부분 업데이트 쿼리 작성
- DTO와 Entity 간 결합도를 낮추기 위해 Response DTO 생성 방식 리팩토링
- PetService 단위 테스트(성공/실패 케이스) 작성 및 테스트 가독성을 위한 상세 로그(log.info) 추가


<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #62

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.
deviceId 이미 등록된 pet이 있다면 등록못하게 했고 등록되지 않는 디바이스면 재 등록 기능 사용할 수 있게 해놨습니다.
