### PR TITLE
✨ Feat: 활동 기록 생성 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
+++ b/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
@@ -1,0 +1,91 @@
+package com.dodo.backend.activityhistory.controller;
+
+import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityCreateResponse;
+import com.dodo.backend.activityhistory.service.ActivityHistoryService;
+import com.dodo.backend.common.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Activity History API", description = "활동 기록 관련 API")
+@RequestMapping("/activities/history")
+@Slf4j
+public class ActivityHistoryController {
+
+    private final ActivityHistoryService activityHistoryService;
+
+    /**
+     * 새로운 활동(산책, 수면 등) 기록을 생성합니다.
+     * <p>
+     * 이 API는 활동의 '시작 전' 단계에서 호출되며, DB에 초기 상태(BEFORE)로 기록을 생성합니다.
+     * 실제 활동 시작은 추후 별도의 API를 통해 처리될 수 있습니다.
+     *
+     * @param userDetails SecurityContext에서 추출한 인증 객체 (로그인한 유저)
+     * @param request     생성할 활동 정보(반려동물 ID, 활동 유형)가 담긴 요청 DTO
+     * @return 생성된 활동 기록의 ID와 유형이 포함된 응답 객체 (HTTP 201 Created)
+     */
+    @Operation(summary = "활동 기록 생성",
+            description = "새로운 활동 기록을 생성합니다. 초기 상태는 '시작 전(BEFORE)'으로 설정됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "활동 기록이 성공적으로 생성되었습니다.",
+                    content = @Content(schema = @Schema(implementation = ActivityCreateResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "활동을 기록할 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"활동을 기록할 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "진행 중인 활동 기록이 이미 존재합니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "409 Conflict", value = "{\"status\": 409, \"message\": \"진행 중인 활동 기록이 이미 존재합니다.\"}"))),
+            @ApiResponse(responseCode = "429", description = "잠시 후 다시 시도해주세요.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "429 Too Many Requests", value = "{\"status\": 429, \"message\": \"잠시 후 다시 시도해주세요.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @PostMapping
+    public ResponseEntity<ActivityCreateResponse> createActivityHistory(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid ActivityCreateRequest request
+    ) {
+
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        log.info("활동 기록 생성 요청 - User: {}, PetId: {}, Type: {}", userId, request.getPetId(), request.getActivityType());
+
+        ActivityCreateResponse response = activityHistoryService.createActivity(userId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/dodo/backend/activityhistory/dto/request/ActivityHistoryRequest.java
+++ b/src/main/java/com/dodo/backend/activityhistory/dto/request/ActivityHistoryRequest.java
@@ -1,0 +1,58 @@
+package com.dodo.backend.activityhistory.dto.request;
+
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.activityhistory.entity.ActivityHistoryStatus;
+import com.dodo.backend.activityhistory.entity.ActivityType;
+import com.dodo.backend.pet.entity.Pet;
+import com.dodo.backend.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 활동기록 도메인과 관련된 요청 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
+ */
+@Schema(description = "활동기록 관련 요청 DTO 그룹")
+public class ActivityHistoryRequest {
+
+    /**
+     * 새로운 활동 기록 생성을 위해 클라이언트로부터 전달받는 요청 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "활동 기록 생성 요청")
+    public static class ActivityCreateRequest {
+
+        @Schema(description = "반려동물 ID", example = "1")
+        @NotNull(message = "반려동물 ID는 필수입니다.")
+        private Long petId;
+
+        @Schema(description = "활동 유형 (WALKING, SLEEPING)", example = "WALKING")
+        @NotNull(message = "활동 유형은 필수입니다.")
+        private ActivityType activityType;
+
+        /**
+         * 요청 DTO의 데이터를 기반으로 새로운 {@link ActivityHistory} 엔티티를 생성합니다.
+         * <p>
+         * 초기 상태는 '시작 전(BEFORE)'으로 설정되며, 시작 시간 등은 추후 업데이트됩니다.
+         * </p>
+         *
+         * @param user 활동을 생성하는 사용자 엔티티
+         * @param pet  활동 대상 반려동물 엔티티
+         * @return 초기화된 ActivityHistory 엔티티 (상태: BEFORE)
+         */
+        public ActivityHistory toEntity(User user, Pet pet) {
+            return ActivityHistory.builder()
+                    .user(user)
+                    .pet(pet)
+                    .activityType(this.activityType)
+                    .activityHistoryStatus(ActivityHistoryStatus.BEFORE)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
+++ b/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
@@ -1,0 +1,48 @@
+package com.dodo.backend.activityhistory.dto.response;
+
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.activityhistory.entity.ActivityType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 활동기록 도메인과 관련된 응답 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
+ */
+@Schema(description = "활동기록 관련 응답 DTO 그룹")
+public class ActivityHistoryResponse {
+
+    /**
+     * 활동 기록 생성 성공 시 반환되는 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "활동 기록 생성 성공 응답")
+    public static class ActivityCreateResponse {
+
+        @Schema(description = "응답 메시지", example = "회원가입이 완료되었습니다.")
+        private String message;
+
+        @Schema(description = "생성된 활동 기록 ID", example = "1234")
+        private Long historyId;
+
+        @Schema(description = "활동 유형", example = "WALKING")
+        private ActivityType activityType;
+
+        /**
+         * {@link ActivityHistory} 엔티티를 생성 응답 DTO로 변환합니다.
+         *
+         * @param activityHistory 변환할 활동 기록 엔티티
+         * @return 변환된 ActivityCreateResponse 객체
+         */
+        public static ActivityCreateResponse toDto(ActivityHistory activityHistory, String message) {
+            return ActivityCreateResponse.builder()
+                    .message(message)
+                    .historyId(activityHistory.getHistoryId())
+                    .activityType(activityHistory.getActivityType())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dodo/backend/activityhistory/entity/ActivityHistory.java
+++ b/src/main/java/com/dodo/backend/activityhistory/entity/ActivityHistory.java
@@ -1,0 +1,60 @@
+package com.dodo.backend.activityhistory.entity;
+
+import com.dodo.backend.pet.entity.Pet;
+import com.dodo.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 반려동물의 활동 기록을 저장하는 엔티티 클래스입니다.
+ * <p>
+ * 산책, 수면 등의 활동에 대한 거리, 위치, 시간 정보를 포함합니다.
+ */
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "activity_history")
+public class ActivityHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "history_id")
+    private Long historyId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    private Pet pet;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "distance", precision = 10, scale = 3)
+    private BigDecimal distance;
+
+    @Column(name = "activity_history_start_at")
+    private LocalDateTime activityHistoryStartAt;
+
+    @Column(name = "activity_history_end_at")
+    private LocalDateTime activityHistoryEndAt;
+
+    @Column(name = "start_latitude", precision = 10, scale = 8)
+    private BigDecimal startLatitude;
+
+    @Column(name = "start_longitude", precision = 11, scale = 8)
+    private BigDecimal startLongitude;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "activity_history_status", nullable = false)
+    private ActivityHistoryStatus activityHistoryStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "activity_type", nullable = false)
+    private ActivityType activityType;
+
+}

--- a/src/main/java/com/dodo/backend/activityhistory/entity/ActivityHistoryStatus.java
+++ b/src/main/java/com/dodo/backend/activityhistory/entity/ActivityHistoryStatus.java
@@ -1,0 +1,18 @@
+package com.dodo.backend.activityhistory.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 활동 기록(ActivityHistory)의 진행 상태를 정의하는 Enum 클래스입니다.
+ * <p>
+ * 시작 전(BEFORE), 진행 중(IN_PROGRESS), 취소(CANCELED), 완료(COMPLETED) 생명주기 상태를 포함합니다.
+ */
+@AllArgsConstructor
+@Getter
+public enum ActivityHistoryStatus {
+    BEFORE,
+    IN_PROGRESS,
+    CANCELED,
+    COMPLETED
+}

--- a/src/main/java/com/dodo/backend/activityhistory/entity/ActivityType.java
+++ b/src/main/java/com/dodo/backend/activityhistory/entity/ActivityType.java
@@ -1,0 +1,15 @@
+package com.dodo.backend.activityhistory.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 반려동물의 활동 종류를 정의하는 Enum 클래스입니다.
+ * <p>
+ * 산책(WALKING), 수면(SLEEPING) 등의 활동 유형을 포함합니다.
+ */
+@AllArgsConstructor
+@Getter
+public enum ActivityType {
+    WALKING, SLEEPING
+}

--- a/src/main/java/com/dodo/backend/activityhistory/exception/ActivityHistoryErrorCode.java
+++ b/src/main/java/com/dodo/backend/activityhistory/exception/ActivityHistoryErrorCode.java
@@ -1,0 +1,124 @@
+package com.dodo.backend.activityhistory.exception;
+
+import com.dodo.backend.common.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 활동 기록(ActivityHistory) 도메인에서 발생하는 예외 상황을 관리하는 에러 코드 정의 클래스입니다.
+ * <p>
+ * HTTP 상태 코드와 클라이언트에게 전달할 메시지를 {@code Key-Value} 형태로 관리합니다.
+ */
+@AllArgsConstructor
+@Getter
+public enum ActivityHistoryErrorCode implements BaseErrorCode {
+
+    /**
+     * 클라이언트의 요청 형식이 잘못되었거나 파라미터가 유효하지 않을 때 사용합니다.
+     * <p>
+     * HTTP {@code 400 Bad Request}를 반환합니다.
+     */
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    /**
+     * 인증되지 않은 사용자가 로그인이 필요한 기능을 요청했을 때 사용합니다.
+     * <p>
+     * HTTP {@code 401 Unauthorized}를 반환합니다.
+     */
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 기능입니다."),
+
+    /**
+     * 반려동물의 주인이 아니거나 권한이 없는 사용자가 활동 기록을 생성하려 할 때 사용합니다.
+     * <p>
+     * HTTP {@code 403 Forbidden}을 반환합니다.
+     */
+    CREATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "활동을 기록할 권한이 없습니다."),
+
+    /**
+     * 권한이 없는 사용자가 활동 기록을 시작(START)하려 할 때 사용합니다.
+     * <p>
+     * HTTP {@code 403 Forbidden}을 반환합니다.
+     */
+    START_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "활동을 시작할 권한이 없습니다."),
+
+    /**
+     * 권한이 없는 사용자가 진행 중인 활동을 중단(STOP)하려 할 때 사용합니다.
+     * <p>
+     * HTTP {@code 403 Forbidden}을 반환합니다.
+     */
+    STOP_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 활동 기록을 중단할 권한이 없습니다."),
+
+    /**
+     * 다른 사용자의 활동 기록을 조회하려 할 때 사용합니다.
+     * <p>
+     * HTTP {@code 403 Forbidden}을 반환합니다.
+     */
+    VIEW_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 활동 기록을 조회할 권한이 없습니다."),
+
+    /**
+     * 권한이 없는 사용자가 활동 기록을 삭제하려 할 때 사용합니다.
+     * <p>
+     * HTTP {@code 403 Forbidden}을 반환합니다.
+     */
+    DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 활동 기록을 삭제할 권한이 없습니다."),
+
+    /**
+     * 사용자가 해당 활동 알림이나 데이터를 수신할 권한이 없을 때 사용합니다.
+     * <p>
+     * HTTP {@code 403 Forbidden}을 반환합니다.
+     */
+    RECEIVE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 활동을 수신받을 권한이 없습니다."),
+
+    /**
+     * 요청한 ID에 해당하는 활동 기록이 존재하지 않을 때 사용합니다.
+     * <p>
+     * HTTP {@code 404 Not Found}를 반환합니다.
+     */
+    HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 활동 기록을 찾을 수 없습니다."),
+
+    /**
+     * 이미 진행 중인 활동(IN_PROGRESS)이 있는데 새로운 활동을 시작하려 할 때 사용합니다.
+     * <p>
+     * HTTP {@code 409 Conflict}를 반환합니다.
+     */
+    ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "진행 중인 활동 기록이 이미 존재합니다."),
+
+    /**
+     * 이미 종료(COMPLETED)되거나 취소(CANCELED)된 활동을 변경하려 할 때 사용합니다.
+     * <p>
+     * HTTP {@code 409 Conflict}를 반환합니다.
+     */
+    ALREADY_COMPLETED(HttpStatus.CONFLICT, "이미 종료된 활동 기록입니다."),
+
+    /**
+     * 이미 이미 생성되어 시작 대기 중인 활동이 있을 때 사용합니다.
+     * <p>
+     * HTTP {@code 409 Conflict}를 반환합니다.
+     */
+    ALREADY_EXISTS_BEFORE(HttpStatus.CONFLICT, "이미 시작 전인 활동 기록이 존재합니다."),
+
+    /**
+     * 단시간에 과도한 요청이 발생하여 요청을 제한할 때 사용합니다.
+     * <p>
+     * HTTP {@code 429 Too Many Requests}를 반환합니다.
+     */
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요."),
+
+    /**
+     * 서버 내부에서 예상치 못한 오류가 발생했을 때 사용합니다.
+     * <p>
+     * HTTP {@code 500 Internal Server Error}를 반환합니다.
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    /**
+     * 에러 상황에 해당하는 HTTP 상태 코드입니다.
+     */
+    private final HttpStatus httpStatus;
+
+    /**
+     * 클라이언트에게 전달할 상세 에러 메시지입니다.
+     */
+    private final String message;
+}

--- a/src/main/java/com/dodo/backend/activityhistory/exception/ActivityHistoryException.java
+++ b/src/main/java/com/dodo/backend/activityhistory/exception/ActivityHistoryException.java
@@ -1,0 +1,20 @@
+package com.dodo.backend.activityhistory.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 활동 기록(ActivityHistory) 도메인 비즈니스 로직 수행 중 발생하는 전용 예외 클래스입니다.
+ * <p>
+ * 활동 생성, 시작, 종료, 조회 등 서비스 로직에서 예외 상황 발생 시 이 클래스를 throw 합니다.
+ * {@code GlobalExceptionHandler}에서 이 예외를 가로채어 {@link ActivityHistoryErrorCode}에 정의된 표준 응답으로 변환합니다.
+ */
+@AllArgsConstructor
+@Getter
+public class ActivityHistoryException extends RuntimeException {
+
+    /**
+     * 발생한 예외의 구체적인 종류(상태 코드, 메시지)를 담고 있는 Enum입니다.
+     */
+    private final ActivityHistoryErrorCode errorCode;
+}

--- a/src/main/java/com/dodo/backend/activityhistory/repository/ActivityHistoryRepository.java
+++ b/src/main/java/com/dodo/backend/activityhistory/repository/ActivityHistoryRepository.java
@@ -1,0 +1,26 @@
+package com.dodo.backend.activityhistory.repository;
+
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.activityhistory.entity.ActivityHistoryStatus;
+import com.dodo.backend.pet.entity.Pet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * {@link ActivityHistory} 엔티티의 데이터베이스 접근을 담당하는 리포지토리 인터페이스입니다.
+ */
+@Repository
+public interface ActivityHistoryRepository extends JpaRepository<ActivityHistory, Long> {
+
+    /**
+     * 특정 반려동물의 활동 상태가 주어진 상태(status)와 일치하는 기록이 존재하는지 확인합니다.
+     * <p>
+     * 주로 이미 진행 중인 활동(IN_PROGRESS)이 있는지 중복 체크할 때 사용됩니다.
+     * </p>
+     *
+     * @param pet    확인할 반려동물 엔티티
+     * @param status 확인할 활동 상태 (예: IN_PROGRESS)
+     * @return 해당 상태의 활동 기록이 존재하면 true, 그렇지 않으면 false
+     */
+    boolean existsByPetAndActivityHistoryStatus(Pet pet, ActivityHistoryStatus status);
+}

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
@@ -1,0 +1,31 @@
+package com.dodo.backend.activityhistory.service;
+
+import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest;
+import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityCreateResponse;
+import com.dodo.backend.user.entity.User;
+
+import java.util.UUID;
+
+/**
+ * 활동 기록(ActivityHistory) 관련 비즈니스 로직을 처리하는 서비스 인터페이스입니다.
+ */
+public interface ActivityHistoryService {
+
+    /**
+     * 새로운 활동 기록을 생성합니다.
+     * <p>
+     * <ol>
+     * <li>사용자(User) 및 반려동물(Pet) 존재 여부 검증</li>
+     * <li>소유권(UserPet) 검증</li>
+     * <li>이미 진행 중인 활동(IN_PROGRESS) 여부 확인</li>
+     * <li>활동 기록 엔티티 생성 및 저장 (초기 상태: BEFORE)</li>
+     * </ol>
+     *
+     * @param userId  요청한 사용자의 UUID
+     * @param request 활동 생성 요청 정보 (petId, activityType)
+     * @return 생성된 활동 기록의 응답 DTO (HistoryId 포함)
+     */
+    ActivityCreateResponse createActivity(UUID userId, ActivityCreateRequest request);
+}

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
@@ -1,0 +1,92 @@
+package com.dodo.backend.activityhistory.service;
+
+import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest;
+import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityCreateResponse;
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.activityhistory.entity.ActivityHistoryStatus;
+import com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCode;
+import com.dodo.backend.activityhistory.exception.ActivityHistoryException;
+import com.dodo.backend.activityhistory.repository.ActivityHistoryRepository;
+import com.dodo.backend.pet.entity.Pet;
+import com.dodo.backend.pet.service.PetService;
+import com.dodo.backend.user.entity.User;
+import com.dodo.backend.user.service.UserService;
+import com.dodo.backend.userpet.service.UserPetService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCode.*;
+
+/**
+ * {@link ActivityHistoryService} 인터페이스의 구현체 클래스입니다.
+ * <p>
+ * 반려동물의 활동 기록(ActivityHistory) 생성 및 관리를 담당하는 비즈니스 로직을 수행합니다.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ActivityHistoryServiceImpl implements ActivityHistoryService {
+
+    private final ActivityHistoryRepository activityHistoryRepository;
+    private final PetService petService;
+    private final UserPetService userPetService;
+    private final UserService userService;
+
+    /**
+     * 새로운 활동 기록을 생성합니다.
+     * <p>
+     * <ol>
+     * <li>{@link UserService}를 통해 요청된 User ID로 사용자 정보를 조회합니다. (실패 시 예외 발생)</li>
+     * <li>{@link PetService}를 통해 요청된 Pet ID로 반려동물 정보를 조회합니다. (실패 시 예외 발생)</li>
+     * <li>{@link UserPetService}를 통해 요청한 유저가 해당 반려동물의 승인된(APPROVED) 주인인지 검증합니다.</li>
+     * <li>해당 반려동물이 이미 진행 중인 활동(IN_PROGRESS)이 있는지 확인하여 중복 생성을 방지합니다.</li>
+     * <li>검증이 완료되면, 활동 상태를 '시작 전(BEFORE)'으로 설정하여 DB에 저장합니다.</li>
+     * </ol>
+     *
+     * @param userId  요청을 수행하는 사용자의 UUID
+     * @param request 생성할 활동 정보가 담긴 요청 DTO (petId, activityType)
+     * @return 생성된 활동 기록의 ID와 유형을 포함한 응답 DTO
+     * @throws ActivityHistoryException 권한이 없거나({@code CREATE_PERMISSION_DENIED}),
+     * 이미 진행 중인 활동이 존재할 경우({@code ALREADY_IN_PROGRESS}) 발생
+     */
+    @Transactional
+    @Override
+    public ActivityCreateResponse createActivity(
+            UUID userId,
+            ActivityCreateRequest request) {
+
+        User user = userService.getUserById(userId);
+
+        Pet pet = petService.getPetById(request.getPetId());
+
+        boolean isOwner = userPetService.isApprovedPetOwner(user.getUsersId(), pet.getPetId());
+
+        if (!isOwner) {
+            throw new ActivityHistoryException(CREATE_PERMISSION_DENIED);
+        }
+
+        if (activityHistoryRepository.existsByPetAndActivityHistoryStatus(pet, ActivityHistoryStatus.IN_PROGRESS)) {
+            throw new ActivityHistoryException(ALREADY_IN_PROGRESS);
+        }
+
+        if (activityHistoryRepository.existsByPetAndActivityHistoryStatus(pet, ActivityHistoryStatus.BEFORE)) {
+            throw new ActivityHistoryException(ALREADY_EXISTS_BEFORE);
+        }
+
+        ActivityHistory activityHistory = request.toEntity(user, pet);
+
+        ActivityHistory savedHistory = activityHistoryRepository.save(activityHistory);
+
+        log.info("활동 기록 생성 완료 - HistoryId: {}, PetId: {}, User: {}",
+                savedHistory.getHistoryId(), pet.getPetId(), userId);
+
+        return ActivityCreateResponse.toDto(savedHistory, "활동 기록이 성공적으로 생성되었습니다.");
+    }
+}

--- a/src/main/java/com/dodo/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dodo/backend/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.dodo.backend.common.exception;
 
+import com.dodo.backend.activityhistory.exception.ActivityHistoryException;
 import com.dodo.backend.auth.exception.AuthException;
 import com.dodo.backend.pet.exception.PetException;
 import com.dodo.backend.user.exception.UserErrorCode;
@@ -59,6 +60,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UserPetException.class)
     protected ResponseEntity<ErrorResponse> handleUserPetException(UserPetException e) {
         log.error("UserPetException occurred: {}", e.getErrorCode());
+        return toResponseEntity(e.getErrorCode());
+    }
+
+    /**
+     * 활동 기록(ActivityHistory) 도메인 비즈니스 로직에서 발생하는 {@link ActivityHistoryException}을 처리합니다.
+     */
+    @ExceptionHandler(ActivityHistoryException.class)
+    protected ResponseEntity<ErrorResponse> handleActivityHistoryException(ActivityHistoryException e) {
+        log.error("ActivityHistoryException occurred: {}", e.getErrorCode());
         return toResponseEntity(e.getErrorCode());
     }
 

--- a/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
@@ -12,9 +12,6 @@ import java.util.UUID;
 
 /**
  * 펫 도메인과 관련된 응답 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
- * <p>
- * 펫 등록, 수정, 조회, 가족 초대 및 승인, 삭제 등 다양한 API 응답에 사용되는
- * Inner Static Class들을 포함하고 있습니다.
  */
 @Schema(description = "펫 관련 응답 DTO 그룹")
 public class PetResponse {

--- a/src/main/java/com/dodo/backend/pet/service/PetService.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetService.java
@@ -2,6 +2,7 @@ package com.dodo.backend.pet.service;
 
 import com.dodo.backend.pet.dto.request.PetRequest.*;
 import com.dodo.backend.pet.dto.response.PetResponse.*;
+import com.dodo.backend.pet.entity.Pet;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
@@ -111,4 +112,15 @@ public interface PetService {
      * @return 펫 ID (존재하지 않으면 Optional.empty())
      */
     Optional<Long> findPetIdByDeviceId(String deviceId);
+
+    /**
+     * ID로 펫을 조회합니다.
+     * <p>
+     * 존재하지 않을 경우 {@link com.dodo.backend.pet.exception.PetException} (PET_NOT_FOUND)를 던집니다.
+     * </p>
+     *
+     * @param petId 조회할 펫 ID
+     * @return 조회된 Pet 엔티티
+     */
+    Pet getPetById(Long petId);
 }

--- a/src/main/java/com/dodo/backend/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetServiceImpl.java
@@ -437,4 +437,15 @@ public class PetServiceImpl implements PetService {
         return petRepository.findByDeviceId(deviceId)
                 .map(Pet::getPetId);
     }
+
+    /**
+     * ID로 펫 엔티티를 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public Pet getPetById(Long petId) {
+        return petRepository.findById(petId)
+                .orElseThrow(() -> new PetException(PET_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/com/dodo/backend/user/service/UserService.java
+++ b/src/main/java/com/dodo/backend/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.dodo.backend.user.dto.request.UserRequest.UserUpdateRequest;
 import com.dodo.backend.user.dto.response.UserResponse.UserInfoResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserRegisterResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserUpdateResponse;
+import com.dodo.backend.user.entity.User;
 
 import java.util.Map;
 import java.util.UUID;
@@ -75,5 +76,16 @@ public interface UserService {
      * @param enabled 변경할 알림 수신 여부 (true: 수신 허용, false: 수신 거부)
      */
     void updateNotification(UUID userId, Boolean enabled);
+
+    /**
+     * ID로 사용자 엔티티를 조회합니다.
+     * <p>
+     * 존재하지 않을 경우 {@link com.dodo.backend.user.exception.UserException} (USER_NOT_FOUND)를 던집니다.
+     * </p>
+     *
+     * @param userId 조회할 사용자의 UUID
+     * @return 조회된 User 엔티티
+     */
+    User getUserById(UUID userId);
 
 }

--- a/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
@@ -174,6 +174,7 @@ public class UserServiceImpl implements UserService {
      *
      * @param userId 탈퇴 인증을 진행할 사용자의 Id
      */
+    @Transactional
     @Override
     public void requestWithdrawal(UUID userId) {
 
@@ -280,5 +281,13 @@ public class UserServiceImpl implements UserService {
         userMapper.updateNotificationStatus(userId, enabled);
     }
 
-
+    /**
+     * ID로 사용자 엔티티 조회 (예외 처리 포함)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public User getUserById(UUID userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
@@ -111,4 +111,16 @@ public interface UserPetService {
      * @return 가족이 남아있다면 true
      */
     boolean existsFamilyMember(Long petId);
+
+    /**
+     * 해당 유저가 특정 펫의 '승인된(APPROVED)' 주인인지 확인합니다.
+     * <p>
+     * ID 기반의 효율적인 조회를 통해 소유권을 검증합니다.
+     * </p>
+     *
+     * @param userId 확인할 유저 ID
+     * @param petId  확인할 펫 ID
+     * @return 승인된 주인이라면 true, 그렇지 않다면 false
+     */
+    boolean isApprovedPetOwner(UUID userId, Long petId);
 }

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetServiceImpl.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetServiceImpl.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -337,5 +336,26 @@ public class UserPetServiceImpl implements UserPetService {
     @Override
     public boolean existsFamilyMember(Long petId) {
         return userPetRepository.existsByPet_PetId(petId);
+    }
+
+    /**
+     * ID 기반으로 해당 유저가 특정 펫의 '승인된(APPROVED)' 주인인지 효율적으로 검증합니다.
+     * <p>
+     * 엔티티 조회 없이 ID만으로 존재 여부를 확인하므로 성능상 이점이 있습니다.
+     * 주로 다른 도메인 서비스(ActivityHistory 등)에서 권한 체크 용도로 호출합니다.
+     * </p>
+     *
+     * @param userId 확인할 유저 ID
+     * @param petId  확인할 펫 ID
+     * @return 승인된 주인이라면 true, 그렇지 않다면 false
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public boolean isApprovedPetOwner(UUID userId, Long petId) {
+        return userPetRepository.existsByUser_UsersIdAndPet_PetIdAndRegistrationStatus(
+                userId,
+                petId,
+                RegistrationStatus.APPROVED
+        );
     }
 }

--- a/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
+++ b/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
@@ -1,0 +1,215 @@
+package com.dodo.backend.activityhistory.service;
+
+import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.activityhistory.entity.ActivityHistoryStatus;
+import com.dodo.backend.activityhistory.entity.ActivityType;
+import com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCode;
+import com.dodo.backend.activityhistory.exception.ActivityHistoryException;
+import com.dodo.backend.activityhistory.repository.ActivityHistoryRepository;
+import com.dodo.backend.pet.entity.Pet;
+import com.dodo.backend.pet.service.PetService;
+import com.dodo.backend.user.entity.User;
+import com.dodo.backend.user.service.UserService;
+import com.dodo.backend.userpet.service.UserPetService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@link ActivityHistoryService}의 비즈니스 로직을 검증하는 테스트 클래스입니다.
+ */
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class ActivityHistoryServiceTest {
+
+    @InjectMocks
+    private ActivityHistoryServiceImpl activityHistoryService;
+
+    @Mock
+    private ActivityHistoryRepository activityHistoryRepository;
+
+    @Mock
+    private PetService petService;
+
+    @Mock
+    private UserPetService userPetService;
+
+    @Mock
+    private UserService userService;
+
+    /**
+     * 활동 기록 생성 성공 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("활동 기록 생성 성공: 정상적인 요청 시 상태가 BEFORE인 기록이 생성된다.")
+    void createActivity_Success() {
+        log.info("활동 기록 생성 성공 케이스 테스트를 시작합니다.");
+        // given
+        UUID userId = UUID.randomUUID();
+        Long petId = 1L;
+
+        User user = User.builder().usersId(userId).build();
+        Pet pet = Pet.builder().petId(petId).build();
+
+        ActivityCreateRequest request = ActivityCreateRequest.builder()
+                .petId(petId)
+                .activityType(ActivityType.WALKING)
+                .build();
+
+        ActivityHistory savedHistory = request.toEntity(user, pet);
+        ReflectionTestUtils.setField(savedHistory, "historyId", 100L);
+
+        log.info("유저와 펫이 존재하고, 권한이 있으며, 중복된 활동이 없는 상황을 설정합니다.");
+        given(userService.getUserById(userId)).willReturn(user);
+        given(petService.getPetById(petId)).willReturn(pet);
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
+        given(activityHistoryRepository.existsByPetAndActivityHistoryStatus(pet, ActivityHistoryStatus.IN_PROGRESS)).willReturn(false);
+        given(activityHistoryRepository.existsByPetAndActivityHistoryStatus(pet, ActivityHistoryStatus.BEFORE)).willReturn(false);
+        given(activityHistoryRepository.save(any(ActivityHistory.class))).willReturn(savedHistory);
+
+        // when
+        log.info("활동 기록 생성 서비스 로직을 호출합니다.");
+        ActivityHistoryResponse.ActivityCreateResponse response = activityHistoryService.createActivity(userId, request);
+
+        // then
+        log.info("생성된 History ID가 반환되었는지 확인하고, 저장 로직이 호출되었는지 검증합니다.");
+        assertNotNull(response);
+        assertEquals(100L, response.getHistoryId());
+        assertEquals(ActivityType.WALKING, response.getActivityType());
+
+        verify(userService, times(1)).getUserById(userId);
+        verify(petService, times(1)).getPetById(petId);
+        verify(userPetService, times(1)).isApprovedPetOwner(userId, petId);
+        verify(activityHistoryRepository, times(1)).save(any(ActivityHistory.class));
+        log.info("활동 기록 생성 성공 테스트가 통과되었습니다.");
+    }
+
+    /**
+     * 권한이 없는 사용자가 활동 기록 생성을 시도할 때 예외 발생을 테스트합니다.
+     */
+    @Test
+    @DisplayName("활동 기록 생성 실패: 펫의 소유자가 아닌 경우 권한 예외가 발생한다.")
+    void createActivity_Fail_PermissionDenied() {
+        log.info("권한 없음으로 인한 활동 생성 실패 테스트를 시작합니다.");
+        // given
+        UUID userId = UUID.randomUUID();
+        Long petId = 1L;
+
+        User user = User.builder().usersId(userId).build();
+        Pet pet = Pet.builder().petId(petId).build();
+
+        ActivityCreateRequest request = ActivityCreateRequest.builder()
+                .petId(petId)
+                .activityType(ActivityType.WALKING)
+                .build();
+
+        log.info("유저와 펫은 존재하지만, 소유자가 아니라고 설정합니다.");
+        given(userService.getUserById(userId)).willReturn(user);
+        given(petService.getPetById(petId)).willReturn(pet);
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(false);
+
+        // when
+        log.info("생성 요청 시 예외가 발생하는지 확인합니다.");
+        ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
+                activityHistoryService.createActivity(userId, request)
+        );
+
+        // then
+        log.info("발생한 예외 코드가 CREATE_PERMISSION_DENIED인지 검증합니다.");
+        assertEquals(ActivityHistoryErrorCode.CREATE_PERMISSION_DENIED, exception.getErrorCode());
+        verify(activityHistoryRepository, times(0)).save(any(ActivityHistory.class));
+        log.info("권한 없음 실패 테스트가 통과되었습니다.");
+    }
+
+    /**
+     * 이미 진행 중(IN_PROGRESS)인 활동이 있을 때 생성 시도를 테스트합니다.
+     */
+    @Test
+    @DisplayName("활동 기록 생성 실패: 이미 진행 중인 활동이 있는 경우 예외가 발생한다.")
+    void createActivity_Fail_AlreadyInProgress() {
+        log.info("중복 활동(진행 중)으로 인한 생성 실패 테스트를 시작합니다.");
+        // given
+        UUID userId = UUID.randomUUID();
+        Long petId = 1L;
+
+        User user = User.builder().usersId(userId).build();
+        Pet pet = Pet.builder().petId(petId).build();
+
+        ActivityCreateRequest request = ActivityCreateRequest.builder()
+                .petId(petId)
+                .activityType(ActivityType.WALKING)
+                .build();
+
+        log.info("소유자 권한은 있으나, 이미 진행 중인 활동이 존재한다고 설정합니다.");
+        given(userService.getUserById(userId)).willReturn(user);
+        given(petService.getPetById(petId)).willReturn(pet);
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
+        given(activityHistoryRepository.existsByPetAndActivityHistoryStatus(pet, ActivityHistoryStatus.IN_PROGRESS)).willReturn(true);
+
+        // when
+        log.info("생성 요청 시 예외가 발생하는지 확인합니다.");
+        ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
+                activityHistoryService.createActivity(userId, request)
+        );
+
+        // then
+        log.info("발생한 예외 코드가 ALREADY_IN_PROGRESS인지 검증합니다.");
+        assertEquals(ActivityHistoryErrorCode.ALREADY_IN_PROGRESS, exception.getErrorCode());
+        verify(activityHistoryRepository, times(0)).save(any(ActivityHistory.class));
+        log.info("진행 중인 활동 중복 실패 테스트가 통과되었습니다.");
+    }
+
+    /**
+     * 이미 시작 대기 중(BEFORE)인 활동이 있을 때 생성 시도를 테스트합니다.
+     */
+    @Test
+    @DisplayName("활동 기록 생성 실패: 이미 시작 대기 중인 활동이 있는 경우 예외가 발생한다.")
+    void createActivity_Fail_AlreadyExistsBefore() {
+        log.info("중복 활동(시작 대기 중)으로 인한 생성 실패 테스트를 시작합니다.");
+        // given
+        UUID userId = UUID.randomUUID();
+        Long petId = 1L;
+
+        User user = User.builder().usersId(userId).build();
+        Pet pet = Pet.builder().petId(petId).build();
+
+        ActivityCreateRequest request = ActivityCreateRequest.builder()
+                .petId(petId)
+                .activityType(ActivityType.WALKING)
+                .build();
+
+        log.info("진행 중인 활동은 없으나, 이미 시작 대기 중(BEFORE)인 활동이 존재한다고 설정합니다.");
+        given(userService.getUserById(userId)).willReturn(user);
+        given(petService.getPetById(petId)).willReturn(pet);
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
+        given(activityHistoryRepository.existsByPetAndActivityHistoryStatus(pet, ActivityHistoryStatus.IN_PROGRESS)).willReturn(false);
+        given(activityHistoryRepository.existsByPetAndActivityHistoryStatus(pet, ActivityHistoryStatus.BEFORE)).willReturn(true);
+
+        // when
+        log.info("생성 요청 시 예외가 발생하는지 확인합니다.");
+        ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
+                activityHistoryService.createActivity(userId, request)
+        );
+
+        // then
+        log.info("발생한 예외 코드가 ALREADY_EXISTS_BEFORE인지 검증합니다.");
+        assertEquals(ActivityHistoryErrorCode.ALREADY_EXISTS_BEFORE, exception.getErrorCode());
+        verify(activityHistoryRepository, times(0)).save(any(ActivityHistory.class));
+        log.info("시작 대기 중 활동 중복 실패 테스트가 통과되었습니다.");
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 반려동물 활동 기록 생성 기능 구현 (POST /activities/history)
- 활동 생성 비즈니스 로직 추가 (초기 상태: BEFORE)
  - 유저 및 펫 존재 여부 확인
  - UserPetService를 통한 소유권(APPROVED) 검증
  - 진행 중(IN_PROGRESS) 또는 시작 대기 중(BEFORE)인 활동 중복 생성 방지 로직 적용
- 중복 생성 방지를 위한 ALREADY_EXISTS_BEFORE 에러 코드 추가
- ActivityHistoryService 단위 테스트 코드 작성 (성공 및 예외 케이스 검증)
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #68 

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

활동 기록 생성 기능을 구현했는데 이미 기록을 생성해서 진행중이거나 아니면 그냥 BEFORE이거나 할결우에는 만들어지지 않는데 무조건 한개의 활동기록만 생성해서 그거 다 돌아가면 그때 가능하게 해놨습니다.