### PR TITLE
✨ Feat: 활동 기록 시작 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/activityhistory/dto/request/ActivityHistoryRequest.java
+++ b/src/main/java/com/dodo/backend/activityhistory/dto/request/ActivityHistoryRequest.java
@@ -12,6 +12,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 /**
  * 활동기록 도메인과 관련된 요청 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
  */
@@ -44,7 +46,7 @@ public class ActivityHistoryRequest {
          *
          * @param user 활동을 생성하는 사용자 엔티티
          * @param pet  활동 대상 반려동물 엔티티
-         * @return 초기화된 ActivityHistory 엔티티 (상태: BEFORE)
+         * @return 초기화된 ActivityHistory 엔티티 (상태: BEFORE)f
          */
         public ActivityHistory toEntity(User user, Pet pet) {
             return ActivityHistory.builder()
@@ -54,5 +56,27 @@ public class ActivityHistoryRequest {
                     .activityHistoryStatus(ActivityHistoryStatus.BEFORE)
                     .build();
         }
+    }
+
+    /**
+     * 생성된 활동 기록을 시작(IN_PROGRESS)하기 위해 클라이언트로부터 전달받는 요청 DTO입니다.
+     * <p>
+     * 활동 시작 시점의 필수 GPS 위치 정보(위도, 경도)를 포함합니다.
+     * </p>
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "활동 시작 요청 데이터 (위치 정보 포함)")
+    public static class ActivityStartRequest {
+
+        @Schema(description = "시작 위도", example = "37.5665")
+        @NotNull(message = "시작 위도는 필수입니다.")
+        private BigDecimal startLatitude;
+
+        @Schema(description = "시작 경도", example = "126.9780")
+        @NotNull(message = "시작 경도는 필수입니다.")
+        private BigDecimal startLongitude;
     }
 }

--- a/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
+++ b/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
@@ -45,4 +45,29 @@ public class ActivityHistoryResponse {
                     .build();
         }
     }
+
+    /**
+     * 데이터 없이 성공 메시지만 반환할 때 사용하는 간단한 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "활동 관련 작업 성공 응답 (메시지 전용)")
+    public static class ActivitySimpleResponse {
+
+        @Schema(description = "응답 메시지", example = "요청이 성공적으로 처리되었습니다.")
+        private String message;
+
+        /**
+         * 전달받은 메시지를 포함하는 단순 응답 DTO를 생성합니다.
+         *
+         * @param message 클라이언트에게 전달할 처리 결과 메시지
+         * @return 메시지가 설정된 {@link ActivitySimpleResponse} 객체
+         */
+        public static ActivitySimpleResponse toDto(String message) {
+            return ActivitySimpleResponse.builder()
+                    .message(message)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.java
+++ b/src/main/java/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.java
@@ -1,0 +1,23 @@
+package com.dodo.backend.activityhistory.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.math.BigDecimal;
+
+@Mapper
+public interface ActivityHistoryMapper {
+
+    /**
+     * 활동 기록을 시작 상태로 변경하고, 시작 시간(NOW()) 및 위치 정보를 기록합니다.
+     *
+     * @param historyId      활동 기록 ID
+     * @param status         변경할 상태 (IN_PROGRESS)
+     * @param startLatitude  시작 위도
+     * @param startLongitude 시작 경도
+     */
+    void startActivity(@Param("historyId") Long historyId,
+                       @Param("status") String status,
+                       @Param("startLatitude") BigDecimal startLatitude,
+                       @Param("startLongitude") BigDecimal startLongitude);
+}

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
@@ -2,6 +2,7 @@ package com.dodo.backend.activityhistory.service;
 
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
+import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityStartRequest;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityCreateResponse;
 import com.dodo.backend.user.entity.User;
@@ -28,4 +29,13 @@ public interface ActivityHistoryService {
      * @return 생성된 활동 기록의 응답 DTO (HistoryId 포함)
      */
     ActivityCreateResponse createActivity(UUID userId, ActivityCreateRequest request);
+
+    /**
+     * 활동 기록을 시작(IN_PROGRESS)합니다.
+     *
+     * @param userId    요청한 사용자의 UUID
+     * @param historyId 활동 기록 ID
+     * @param request   시작 위치 정보(위도, 경도)가 담긴 요청 DTO
+     */
+    void startActivity(UUID userId, Long historyId, ActivityStartRequest request);
 }

--- a/src/main/resources/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.xml
+++ b/src/main/resources/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.dodo.backend.activityhistory.mapper.ActivityHistoryMapper">
+
+    <!-- 활동 기록을 '진행 중(IN_PROGRESS)' 상태로 변경하고 활동 시작 시간 및 시작 위치 좌표를 기록합니다.
+            1. activity_history_status : 활동 상태를 IN_PROGRESS로 변경
+            2. activity_history_start_at : 활동 시작 시간을 현재 시간(NOW())으로 기록
+            3. start_latitude : 활동 시작 위치의 위도
+            4. start_longitude : 활동 시작 위치의 경도
+            5. WHERE history_id : historyId를 기준으로 특정 활동 기록을 식별 -->
+    <update id="startActivity">
+        UPDATE activity_history
+        SET activity_history_status = #{status},
+            activity_history_start_at = NOW(),
+            start_latitude = #{startLatitude},
+            start_longitude = #{startLongitude}
+        WHERE history_id = #{historyId}
+    </update>
+</mapper>


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 활동 시작 비즈니스 로직 추가
  - MyBatis Mapper를 활용한 상태(IN_PROGRESS), 시작 시간(NOW()), 위치 정보 업데이트
  - 활동 기록 조회 및 소유자 권한(User ID 일치) 검증

활동 상태 검증 (BEFORE 상태일 때만 시작 가능)
  - ActivityHistoryService 단위 테스트 코드 작성 (성공 및 예외 케이스)
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #70

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 나중에 웹소켓 구현되면 이제 활동 기록 시작 누르고 나서 웹소켓 구독하면 그때 통로 열려서 거기다가 데이터 값 계속 보내면 됩니다.
- 이거는 처음 위치랑 IN_PROGRESS로 변경하는겁니다.