### PR TITLE
✨ Feat: 활동 기록 중단(취소) 및 재개 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.java
+++ b/src/main/java/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.java
@@ -20,4 +20,20 @@ public interface ActivityHistoryMapper {
                        @Param("status") String status,
                        @Param("startLatitude") BigDecimal startLatitude,
                        @Param("startLongitude") BigDecimal startLongitude);
+
+    /**
+     * 중단된 활동을 다시 진행 중으로 변경합니다. (재개)
+     * 종료 시간(endAt)은 초기화하고 상태를 변경합니다.
+     */
+    void resumeActivity(@Param("historyId") Long historyId,
+                        @Param("status") String status);
+
+    /**
+     * 활동을 중단(취소) 상태로 변경하고 종료 시간을 기록합니다.
+     *
+     * @param historyId 활동 기록 ID
+     * @param status    변경할 상태 (CANCELED)
+     */
+    void cancelActivity(@Param("historyId") Long historyId,
+                        @Param("status") String status);
 }

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
@@ -5,6 +5,7 @@ import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.Activ
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityStartRequest;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityCreateResponse;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivitySimpleResponse;
 import com.dodo.backend.user.entity.User;
 
 import java.util.UUID;
@@ -31,11 +32,22 @@ public interface ActivityHistoryService {
     ActivityCreateResponse createActivity(UUID userId, ActivityCreateRequest request);
 
     /**
-     * 활동 기록을 시작(IN_PROGRESS)합니다.
+     * 활동 기록을 시작(IN_PROGRESS)하거나, 중단된 활동을 재개합니다.
      *
      * @param userId    요청한 사용자의 UUID
      * @param historyId 활동 기록 ID
-     * @param request   시작 위치 정보(위도, 경도)가 담긴 요청 DTO
+     * @param request   시작 위치 정보
+     * @return 성공 메시지가 담긴 단순 응답 DTO
      */
-    void startActivity(UUID userId, Long historyId, ActivityStartRequest request);
+    ActivitySimpleResponse startActivity(UUID userId, Long historyId, ActivityStartRequest request);
+
+    /**
+     * 진행 중인 활동 기록을 취소(중단)합니다.
+     *
+     * @param userId    요청한 사용자의 UUID
+     * @param historyId 활동 기록 ID
+     * @return 성공 메시지가 담긴 단순 응답 DTO
+     */
+    ActivitySimpleResponse cancelActivity(UUID userId, Long historyId);
+
 }

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
@@ -1,13 +1,11 @@
 package com.dodo.backend.activityhistory.service;
 
-import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityStartRequest;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityCreateResponse;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivitySimpleResponse;
 import com.dodo.backend.activityhistory.entity.ActivityHistory;
 import com.dodo.backend.activityhistory.entity.ActivityHistoryStatus;
-import com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCode;
 import com.dodo.backend.activityhistory.exception.ActivityHistoryException;
 import com.dodo.backend.activityhistory.mapper.ActivityHistoryMapper;
 import com.dodo.backend.activityhistory.repository.ActivityHistoryRepository;
@@ -28,7 +26,8 @@ import static com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCod
 /**
  * {@link ActivityHistoryService} 인터페이스의 구현체 클래스입니다.
  * <p>
- * 반려동물의 활동 기록(ActivityHistory) 생성 및 관리를 담당하는 비즈니스 로직을 수행합니다.
+ * 반려동물의 활동 기록(ActivityHistory)의 생성(Create), 시작(Start/Resume), 중단(Cancel) 등
+ * 활동 생명주기를 관리하는 핵심 비즈니스 로직을 수행합니다.
  * </p>
  */
 @Service
@@ -46,10 +45,9 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
      * 새로운 활동 기록을 생성합니다.
      * <p>
      * <ol>
-     * <li>{@link UserService}를 통해 요청된 User ID로 사용자 정보를 조회합니다. (실패 시 예외 발생)</li>
-     * <li>{@link PetService}를 통해 요청된 Pet ID로 반려동물 정보를 조회합니다. (실패 시 예외 발생)</li>
-     * <li>{@link UserPetService}를 통해 요청한 유저가 해당 반려동물의 승인된(APPROVED) 주인인지 검증합니다.</li>
-     * <li>해당 반려동물이 이미 진행 중인 활동(IN_PROGRESS)이 있는지 확인하여 중복 생성을 방지합니다.</li>
+     * <li>사용자(User) 및 반려동물(Pet) 정보를 조회합니다.</li>
+     * <li>요청한 유저가 해당 반려동물의 승인된(APPROVED) 주인인지 검증합니다.</li>
+     * <li>해당 반려동물이 이미 진행 중(IN_PROGRESS)이거나 대기 중(BEFORE)인 활동이 있는지 확인하여 중복 생성을 방지합니다.</li>
      * <li>검증이 완료되면, 활동 상태를 '시작 전(BEFORE)'으로 설정하여 DB에 저장합니다.</li>
      * </ol>
      *
@@ -57,7 +55,7 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
      * @param request 생성할 활동 정보가 담긴 요청 DTO (petId, activityType)
      * @return 생성된 활동 기록의 ID와 유형을 포함한 응답 DTO
      * @throws ActivityHistoryException 권한이 없거나({@code CREATE_PERMISSION_DENIED}),
-     * 이미 진행 중인 활동이 존재할 경우({@code ALREADY_IN_PROGRESS}) 발생
+     * 이미 진행 중({@code ALREADY_IN_PROGRESS}) 또는 대기 중({@code ALREADY_EXISTS_BEFORE})인 활동이 존재할 경우
      */
     @Transactional
     @Override
@@ -66,7 +64,6 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
             ActivityCreateRequest request) {
 
         User user = userService.getUserById(userId);
-
         Pet pet = petService.getPetById(request.getPetId());
 
         boolean isOwner = userPetService.isApprovedPetOwner(user.getUsersId(), pet.getPetId());
@@ -84,7 +81,6 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         }
 
         ActivityHistory activityHistory = request.toEntity(user, pet);
-
         ActivityHistory savedHistory = activityHistoryRepository.save(activityHistory);
 
         log.info("활동 기록 생성 완료 - HistoryId: {}, PetId: {}, User: {}",
@@ -94,22 +90,28 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * 활동 기록을 시작 상태(IN_PROGRESS)로 변경합니다.
+     * 활동 기록을 시작(IN_PROGRESS)하거나, 중단된 활동을 재개합니다.
      * <p>
-     * <ol>
-     * <li>요청된 History ID로 활동 기록을 조회합니다. (존재하지 않을 경우 {@code HISTORY_NOT_FOUND} 발생)</li>
-     * <li>해당 활동 기록의 소유자(User)인지 검증합니다. (권한 없을 경우 {@code START_PERMISSION_DENIED} 발생)</li>
-     * <li>활동 상태가 '시작 전(BEFORE)'인지 확인합니다. (이미 진행 중이거나 종료된 경우 {@code ALREADY_IN_PROGRESS} 발생)</li>
-     * <li>시작 시간(현재)과 상태(IN_PROGRESS)를 업데이트합니다.</li>
-     * </ol>
+     * 활동의 현재 상태에 따라 두 가지 로직으로 분기됩니다:
+     * <ul>
+     * <li><b>시작 전(BEFORE):</b> 최초 시작으로 간주하여 시작 시간과 위치 정보를 기록하고 상태를 변경합니다.</li>
+     * <li><b>취소됨(CANCELED):</b> 활동 재개로 간주하여 상태를 변경하고 종료 시간을 초기화합니다. (기존 시작 정보 유지)</li>
+     * </ul>
      *
      * @param userId    요청한 사용자의 UUID
      * @param historyId 활동 기록 ID
-     * @throws ActivityHistoryException 권한이 없거나, 상태가 올바르지 않은 경우 발생
+     * @param request   시작 시점의 GPS 위치 정보(위도, 경도)
+     * @return 처리 결과 메시지가 담긴 단순 응답 DTO
+     * @throws ActivityHistoryException
+     * <ul>
+     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 없는 경우</li>
+     * <li>{@code START_PERMISSION_DENIED}: 활동 기록의 소유자가 아닌 경우</li>
+     * <li>{@code ALREADY_IN_PROGRESS}: 이미 진행 중이거나 종료된 활동인 경우</li>
+     * </ul>
      */
     @Transactional
     @Override
-    public void startActivity(UUID userId, Long historyId, ActivityStartRequest request) {
+    public ActivitySimpleResponse startActivity(UUID userId, Long historyId, ActivityStartRequest request) {
 
         ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
                 .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
@@ -118,18 +120,68 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
             throw new ActivityHistoryException(START_PERMISSION_DENIED);
         }
 
-        if (activityHistory.getActivityHistoryStatus() != ActivityHistoryStatus.BEFORE) {
+        ActivityHistoryStatus status = activityHistory.getActivityHistoryStatus();
+        String message;
+
+        if (status == ActivityHistoryStatus.BEFORE) {
+            activityHistoryMapper.startActivity(
+                    historyId,
+                    ActivityHistoryStatus.IN_PROGRESS.name(),
+                    request.getStartLatitude(),
+                    request.getStartLongitude()
+            );
+            log.info("활동 최초 시작 - HistoryId: {}, User: {}", historyId, userId);
+            message = "활동 기록이 시작되었습니다.";
+
+        } else if (status == ActivityHistoryStatus.CANCELED) {
+            activityHistoryMapper.resumeActivity(
+                    historyId,
+                    ActivityHistoryStatus.IN_PROGRESS.name()
+            );
+            log.info("활동 재개 - HistoryId: {}, User: {}", historyId, userId);
+            message = "활동 기록이 재개되었습니다.";
+        } else {
             throw new ActivityHistoryException(ALREADY_IN_PROGRESS);
         }
 
-        activityHistoryMapper.startActivity(
-                historyId,
-                "IN_PROGRESS",
-                request.getStartLatitude(),
-                request.getStartLongitude()
-        );
+        return ActivitySimpleResponse.toDto(message);
+    }
 
-        log.info("활동 시작 처리 완료 - HistoryId: {}, User: {}, Lat: {}, Lon: {}",
-                historyId, userId, request.getStartLatitude(), request.getStartLongitude());
+    /**
+     * 진행 중인 활동을 취소(중단) 상태로 변경합니다.
+     * <p>
+     * 활동 상태를 '취소됨(CANCELED)'으로 변경하고, 중단된 시점(종료 시간)을 기록합니다.
+     * </p>
+     *
+     * @param userId    요청한 사용자의 UUID
+     * @param historyId 활동 기록 ID
+     * @return 처리 결과 메시지가 담긴 단순 응답 DTO
+     * @throws ActivityHistoryException
+     * <ul>
+     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 없는 경우</li>
+     * <li>{@code STOP_PERMISSION_DENIED}: 활동 기록의 소유자가 아닌 경우</li>
+     * <li>{@code ALREADY_COMPLETED}: 진행 중인 활동(IN_PROGRESS)이 아닌 경우</li>
+     * </ul>
+     */
+    @Transactional
+    @Override
+    public ActivitySimpleResponse cancelActivity(UUID userId, Long historyId) {
+
+        ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
+
+        if (!activityHistory.getUser().getUsersId().equals(userId)) {
+            throw new ActivityHistoryException(STOP_PERMISSION_DENIED);
+        }
+
+        if (activityHistory.getActivityHistoryStatus() != ActivityHistoryStatus.IN_PROGRESS) {
+            throw new ActivityHistoryException(ALREADY_COMPLETED);
+        }
+
+        activityHistoryMapper.cancelActivity(historyId, ActivityHistoryStatus.CANCELED.name());
+
+        log.info("활동 중단(취소) 완료 - HistoryId: {}, User: {}", historyId, userId);
+
+        return ActivitySimpleResponse.toDto("활동 기록이 성공적으로 중단되었습니다.");
     }
 }

--- a/src/main/resources/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.xml
+++ b/src/main/resources/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.xml
@@ -16,4 +16,26 @@
             start_longitude = #{startLongitude}
         WHERE history_id = #{historyId}
     </update>
+
+    <!-- 취소된 활동 기록을 다시 '진행 중(IN_PROGRESS)' 상태로 변경합니다.
+         1. activity_history_status : 활동 상태를 IN_PROGRESS로 변경
+         2. activity_history_end_at : 일시정지 시 기록된 종료 시간을 NULL로 초기화
+         3. WHERE history_id : historyId를 기준으로 특정 활동 기록을 식별 -->
+    <update id="resumeActivity">
+        UPDATE activity_history
+        SET activity_history_status = #{status},
+            activity_history_end_at = NULL
+        WHERE history_id = #{historyId}
+    </update>
+
+    <!-- 진행 중인 활동 기록을 '취소(CANCELED)' 상태로 변경합니다.
+        1. activity_history_status : 활동 상태를 CANCELED로 변경
+        2. activity_history_end_at : 활동 취소 시점을 현재 시간(NOW())으로 기록
+        3. WHERE history_id : historyId를 기준으로 특정 활동 기록을 식별 -->
+    <update id="cancelActivity">
+        UPDATE activity_history
+        SET activity_history_status = #{status},
+            activity_history_end_at = NOW()
+        WHERE history_id = #{historyId}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 활동 기록 중단 기능 구현 (PATCH /activities/history/{historyId}/cancel)
- 활동 재개 로직 추가 (PATCH /activities/history/{historyId}/start 수정)
  - 기존 시작 API를 고도화하여 중단된(CANCELED) 활동 재개 기능 지원
  - 재개 시 최초 시작 위치와 시간은 유지하고 종료 시간만 초기화하도록 Mapper 구현
- 응답 DTO 리팩터링
  - 활동 시작 및 중단 응답을 메시지 중심의 ActivitySimpleResponse로 통일
- 단위 테스트(Test Code) 작성
  - 활동 중단 및 재개 성공 시나리오 검증
  - 권한 없음, 잘못된 상태 등 예외 케이스 검증
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

- Closes #72
<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

활동 시작 버튼을 눌렀을때 중단된 활동 기록으로 시작했을시에 다시 재개되게 변경해놨고 활동 기록 중단 기능 구현했습니다.