### PR TITLE
✨ Feat: 활동 기록 삭제(Delete) 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
+++ b/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
@@ -257,4 +257,57 @@ public class ActivityHistoryController {
 
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 활동 기록을 삭제합니다.
+     * <p>
+     * 해당 활동 기록을 영구적으로 삭제하며, 삭제 권한이 없는 경우 403 에러를 반환합니다.
+     * 성공 시 200 OK와 함께 성공 메시지를 반환합니다.
+     * </p>
+     *
+     * @param historyId   삭제할 활동 기록 ID (Path Variable)
+     * @param userDetails 인증 객체
+     * @return 성공 메시지가 담긴 단순 응답 객체
+     */
+    @Operation(summary = "활동 기록 삭제",
+            description = "특정 활동 기록을 영구적으로 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "활동 기록이 성공적으로 삭제되었습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ActivitySimpleResponse.class),
+                            examples = @ExampleObject(name = "200 OK", value = "{\"message\": \"활동 기록이 성공적으로 삭제되었습니다.\"}"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "해당 활동 기록을 삭제할 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"해당 활동 기록을 삭제할 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 활동 기록을 찾을 수 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"해당 활동 기록을 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @DeleteMapping("/{historyId}")
+    public ResponseEntity<ActivitySimpleResponse> deleteActivity(
+            @PathVariable Long historyId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        log.info("활동 삭제 요청 - User: {}, HistoryId: {}", userId, historyId);
+
+        // Service 메서드가 ActivitySimpleResponse를 반환하도록 변경 예정
+        ActivitySimpleResponse response = activityHistoryService.deleteActivity(userId, historyId);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
+++ b/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
@@ -58,7 +58,7 @@ public class ActivityHistoryResponse {
     @Schema(description = "활동 관련 작업 성공 응답")
     public static class ActivitySimpleResponse {
 
-        @Schema(description = "응답 메시지", example = "활동 기록이 시작(재개)되었습니다")
+        @Schema(description = "응답 메시지", example = "활동 기록이 (시작, 재개, 삭제)되었습니다")
         private String message;
 
         /**

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
@@ -62,4 +62,11 @@ public interface ActivityHistoryService {
      */
     ActivitySimpleResponse cancelActivity(UUID userId, Long historyId);
 
+    /**
+     * 활동 기록을 삭제합니다.
+     *
+     * @param userId    요청한 사용자의 UUID
+     * @param historyId 삭제할 활동 기록 ID
+     */
+    ActivitySimpleResponse deleteActivity(UUID userId, Long historyId);
 }

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
@@ -243,4 +243,37 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                 "활동 기록이 성공적으로 종료되었습니다."
         );
     }
+
+    /**
+     * 활동 기록을 삭제합니다.
+     * <p>
+     * 활동 기록 존재 여부와 요청자(User)의 소유권을 검증한 후,
+     * <b>JPA Repository</b>를 사용하여 데이터를 삭제합니다.
+     * </p>
+     *
+     * @param userId    요청한 사용자의 UUID
+     * @param historyId 삭제할 활동 기록 ID
+     * @throws ActivityHistoryException
+     * <ul>
+     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 없는 경우</li>
+     * <li>{@code DELETE_PERMISSION_DENIED}: 활동 기록의 소유자가 아닌 경우</li>
+     * </ul>
+     */
+    @Transactional
+    @Override
+    public ActivitySimpleResponse deleteActivity(UUID userId, Long historyId) {
+
+        ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
+
+        if (!activityHistory.getUser().getUsersId().equals(userId)) {
+            throw new ActivityHistoryException(DELETE_PERMISSION_DENIED);
+        }
+
+        activityHistoryRepository.delete(activityHistory);
+
+        log.info("활동 기록 삭제 완료 (JPA) - HistoryId: {}, User: {}", historyId, userId);
+
+        return ActivitySimpleResponse.toDto("활동 기록이 성공적으로 삭제되었습니다.");
+    }
 }

--- a/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
+++ b/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
@@ -77,7 +77,7 @@ class ActivityHistoryServiceTest {
 
         ActivityCreateRequest request = ActivityCreateRequest.builder()
                 .petId(petId)
-                .activityType(ActivityType.WALKING)
+                .activityType("WALKING")
                 .build();
 
         ActivityHistory savedHistory = request.toEntity(user, pet);
@@ -124,7 +124,7 @@ class ActivityHistoryServiceTest {
 
         ActivityCreateRequest request = ActivityCreateRequest.builder()
                 .petId(petId)
-                .activityType(ActivityType.WALKING)
+                .activityType("WALKING")
                 .build();
 
         log.info("유저와 펫은 존재하지만, 소유자가 아니라고 설정합니다.");
@@ -161,7 +161,7 @@ class ActivityHistoryServiceTest {
 
         ActivityCreateRequest request = ActivityCreateRequest.builder()
                 .petId(petId)
-                .activityType(ActivityType.WALKING)
+                .activityType("WALKING")
                 .build();
 
         log.info("소유자 권한은 있으나, 이미 진행 중인 활동이 존재한다고 설정합니다.");
@@ -199,7 +199,7 @@ class ActivityHistoryServiceTest {
 
         ActivityCreateRequest request = ActivityCreateRequest.builder()
                 .petId(petId)
-                .activityType(ActivityType.WALKING)
+                .activityType("WALKING")
                 .build();
 
         log.info("진행 중인 활동은 없으나, 이미 시작 대기 중(BEFORE)인 활동이 존재한다고 설정합니다.");
@@ -562,7 +562,7 @@ class ActivityHistoryServiceTest {
                 .build();
 
         ActivityFinishRequest request = ActivityFinishRequest.builder()
-                .activityHistoryStatus(ActivityHistoryStatus.COMPLETED)
+                .activityHistoryStatus("COMPLETED")
                 .activityHistoryEndAt(endTime)
                 .build();
 
@@ -609,7 +609,7 @@ class ActivityHistoryServiceTest {
                 .build();
 
         ActivityFinishRequest request = ActivityFinishRequest.builder()
-                .activityHistoryStatus(ActivityHistoryStatus.COMPLETED)
+                .activityHistoryStatus("COMPLETED")
                 .activityHistoryEndAt(LocalDateTime.now())
                 .build();
 
@@ -644,11 +644,11 @@ class ActivityHistoryServiceTest {
         ActivityHistory activityHistory = ActivityHistory.builder()
                 .historyId(historyId)
                 .user(user)
-                .activityHistoryStatus(ActivityHistoryStatus.COMPLETED) // 이미 완료됨
+                .activityHistoryStatus(ActivityHistoryStatus.COMPLETED)
                 .build();
 
         ActivityFinishRequest request = ActivityFinishRequest.builder()
-                .activityHistoryStatus(ActivityHistoryStatus.COMPLETED)
+                .activityHistoryStatus("COMPLETED")
                 .activityHistoryEndAt(LocalDateTime.now())
                 .build();
 
@@ -694,5 +694,85 @@ class ActivityHistoryServiceTest {
         assertEquals(ActivityHistoryErrorCode.HISTORY_NOT_FOUND, exception.getErrorCode());
         verify(activityHistoryMapper, times(0)).finishActivity(any(), any(), any());
         log.info("미발견 종료 실패 테스트가 통과되었습니다.");
+    }
+
+    /**
+     * 활동 삭제 성공 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("활동 삭제 성공: 본인의 활동 기록을 삭제하면 JPA delete가 호출되고 성공 메시지를 반환한다.")
+    void deleteActivity_Success() {
+        log.info("활동 삭제 성공 테스트를 시작합니다.");
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 100L;
+        User user = User.builder().usersId(userId).build();
+        ActivityHistory activityHistory = ActivityHistory.builder()
+                .historyId(historyId)
+                .user(user)
+                .build();
+
+        given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
+
+        // when
+        ActivityHistoryResponse.ActivitySimpleResponse response = activityHistoryService.deleteActivity(userId, historyId);
+
+        // then
+        assertNotNull(response);
+        assertEquals("활동 기록이 성공적으로 삭제되었습니다.", response.getMessage());
+        verify(activityHistoryRepository, times(1)).delete(activityHistory);
+        log.info("활동 삭제 성공 테스트 통과");
+    }
+
+    /**
+     * 권한 없는 사용자가 삭제 시도 시 예외 발생 테스트
+     */
+    @Test
+    @DisplayName("활동 삭제 실패: 소유자가 아닌 경우 권한 예외가 발생한다.")
+    void deleteActivity_Fail_PermissionDenied() {
+        log.info("활동 삭제 실패(권한 없음) 테스트를 시작합니다.");
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        Long historyId = 100L;
+        User otherUser = User.builder().usersId(otherUserId).build();
+        ActivityHistory activityHistory = ActivityHistory.builder()
+                .historyId(historyId)
+                .user(otherUser)
+                .build();
+
+        given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
+
+        // when & then
+        ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
+                activityHistoryService.deleteActivity(userId, historyId)
+        );
+
+        assertEquals(ActivityHistoryErrorCode.DELETE_PERMISSION_DENIED, exception.getErrorCode());
+        verify(activityHistoryRepository, times(0)).delete(any());
+        log.info("활동 삭제 실패(권한 없음) 테스트 통과");
+    }
+
+    /**
+     * 존재하지 않는 활동 기록 삭제 시도 시 예외 발생 테스트
+     */
+    @Test
+    @DisplayName("활동 삭제 실패: 기록이 존재하지 않는 경우 예외가 발생한다.")
+    void deleteActivity_Fail_NotFound() {
+        log.info("활동 삭제 실패(미발견) 테스트를 시작합니다.");
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 999L;
+
+        given(activityHistoryRepository.findById(historyId)).willReturn(Optional.empty());
+
+        // when & then
+        ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
+                activityHistoryService.deleteActivity(userId, historyId)
+        );
+
+        assertEquals(ActivityHistoryErrorCode.HISTORY_NOT_FOUND, exception.getErrorCode());
+        verify(activityHistoryRepository, times(0)).delete(any());
+        log.info("활동 삭제 실패(미발견) 테스트 통과");
     }
 }

--- a/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
+++ b/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
@@ -73,12 +73,12 @@ class PetServiceTest {
         UUID userId = UUID.randomUUID();
         PetRequest.PetRegisterRequest request = PetRequest.PetRegisterRequest.builder()
                 .petName("바둑이")
-                .species(PetSpecies.CANINE)
+                .species("CANINE")
                 .breed("Poodle")
                 .age(3)
                 .birth(LocalDateTime.now())
                 .registrationNumber("1234567890")
-                .sex(PetSex.MALE)
+                .sex("MALE")
                 .deviceId("DEV_123")
                 .build();
 


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- JPA Repository를 활용한 활동 기록 영구 삭제 기능 구현
- `ActivityHistoryService`에 삭제 및 권한 검증 로직 추가
- `ActivityHistoryController`에 삭제 API 엔드포인트(`DELETE /activities/history/{historyId}`) 구현
- 삭제 성공 시 200 OK와 성공 메시지 반환
- `ActivityHistoryServiceTest`에 삭제 성공 및 권한/미발견 예외 테스트 케이스 추가
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #76

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

활동 기록 삭제 기능 구현했습니다.