### PR TITLE
✨ Feat: 특정 활동 상세 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
+++ b/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
@@ -4,10 +4,7 @@ import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityStartRequest;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityCreateResponse;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityFinishResponse;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityHistoryPageResponse;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivitySimpleResponse;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.*;
 import com.dodo.backend.activityhistory.service.ActivityHistoryService;
 import com.dodo.backend.common.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -372,5 +369,50 @@ public class ActivityHistoryController {
         ActivityHistoryPageResponse response = activityHistoryService.getMyActivityHistory(userId, pageable);
 
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 특정 활동의 상세 정보를 조회합니다.
+     *
+     * @param historyId   조회할 활동 기록 ID
+     * @param userDetails 인증된 사용자 정보
+     * @return 활동 상세 정보 (HTTP 200)
+     */
+    @Operation(summary = "활동 상세 정보 조회", description = "특정 활동 기록의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "해당 활동 정보를 성공적으로 조회했습니다.",
+                    content = @Content(schema = @Schema(implementation = ActivityHistoryDetailResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "해당 활동 기록을 조회할 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"해당 활동 기록을 조회할 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 활동 기록을 찾을 수 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"해당 ID의 활동 기록을 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "이미 종료된 활동 기록입니다, 아직 기록을 시작하지 않은 활동입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "409 Conflict", value = "{\"status\": 409, \"message\": \"이미 종료된 활동 기록입니다, 아직 기록을 시작하지 않은 활동입니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @GetMapping("/{historyId}")
+    public ResponseEntity<ActivityHistoryDetailResponse> getActivityHistoryDetail(
+            @PathVariable Long historyId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        return ResponseEntity.ok(activityHistoryService.getActivityHistoryDetail(userId, historyId));
     }
 }

--- a/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
+++ b/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
@@ -291,4 +291,89 @@ public class ActivityHistoryResponse {
                     .build();
         }
     }
+
+    /**
+     * 활동 기록의 상세 정보를 클라이언트에게 전달하기 위한 응답 DTO 클래스입니다.
+     * <p>
+     * 활동의 기본 정보(ID, 거리, 시간 등)와 위치 정보,
+     * 그리고 사용자 반응(좋아요 수, 본인 좋아요 여부) 정보를 포함합니다.
+     * </p>
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "활동 기록 상세 조회 응답 DTO")
+    public static class ActivityHistoryDetailResponse {
+
+        @Schema(description = "응답 메시지", example = "해당 활동 정보를 성공적으로 조회했습니다.")
+        private final String message;
+
+        @Schema(description = "활동 기록 ID", example = "101")
+        private final Long historyId;
+
+        @Schema(description = "반려동물 ID", example = "12")
+        private final Long petId;
+
+        @Schema(description = "이동 거리 (km)", example = "5.25")
+        private final BigDecimal distance;
+
+        @Schema(description = "활동 시작 시간", example = "2025-09-30T14:00:00")
+        private final LocalDateTime activityHistoryStartAt;
+
+        @Schema(description = "활동 종료 시간", example = "2025-09-30T14:35:00")
+        private final LocalDateTime activityHistoryEndAt;
+
+        @Schema(description = "시작 위도", example = "37.4979")
+        private final BigDecimal startLatitude;
+
+        @Schema(description = "시작 경도", example = "127.0276")
+        private final BigDecimal startLongitude;
+
+        @Schema(description = "반응(좋아요) 수", example = "28")
+        private final Integer reactionCount;
+
+        @Schema(description = "내가 좋아요를 눌렀는지 여부", example = "true")
+        private final Boolean isLikedByMe;
+
+        /**
+         * 개별 데이터를 받아 상세 조회 응답 DTO 객체를 생성합니다.
+         *
+         * @param message                응답 메시지
+         * @param historyId              활동 기록 ID
+         * @param petId                  반려동물 ID
+         * @param distance               이동 거리
+         * @param activityHistoryStartAt 활동 시작 시간
+         * @param activityHistoryEndAt   활동 종료 시간
+         * @param startLatitude          시작 위도
+         * @param startLongitude         시작 경도
+         * @param reactionCount          좋아요 수
+         * @param isLikedByMe            본인 좋아요 여부
+         * @return 생성된 {@link ActivityHistoryDetailResponse} 객체
+         */
+        public static ActivityHistoryDetailResponse toDto(
+                String message,
+                Long historyId,
+                Long petId,
+                BigDecimal distance,
+                LocalDateTime activityHistoryStartAt,
+                LocalDateTime activityHistoryEndAt,
+                BigDecimal startLatitude,
+                BigDecimal startLongitude,
+                Integer reactionCount,
+                Boolean isLikedByMe
+        ) {
+            return ActivityHistoryDetailResponse.builder()
+                    .message(message)
+                    .historyId(historyId)
+                    .petId(petId)
+                    .distance(distance)
+                    .activityHistoryStartAt(activityHistoryStartAt)
+                    .activityHistoryEndAt(activityHistoryEndAt)
+                    .startLatitude(startLatitude)
+                    .startLongitude(startLongitude)
+                    .reactionCount(reactionCount)
+                    .isLikedByMe(isLikedByMe)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
@@ -4,10 +4,7 @@ import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.Activ
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityStartRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityFinishRequest;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityCreateResponse;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityHistoryPageResponse;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivitySimpleResponse;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityFinishResponse;
+import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.*;
 import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
@@ -81,4 +78,13 @@ public interface ActivityHistoryService {
      * @return 페이징된 활동 기록 응답 DTO
      */
     ActivityHistoryPageResponse getMyActivityHistory(UUID userId, Pageable pageable);
+
+    /**
+     * 특정 활동 기록의 상세 정보를 조회합니다.
+     *
+     * @param userId    요청한 사용자의 UUID
+     * @param historyId 조회할 활동 기록의 ID
+     * @return 활동 기록의 상세 정보 DTO
+     */
+    ActivityHistoryDetailResponse getActivityHistoryDetail(UUID userId, Long historyId);
 }

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
@@ -324,4 +324,52 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                 summaries
         );
     }
+
+    /**
+     * 특정 활동 기록의 상세 정보를 조회합니다.
+     *
+     * @param userId    요청한 사용자의 UUID
+     * @param historyId 조회할 활동 기록의 ID
+     * @return 활동 기록의 상세 정보 DTO {@link ActivityHistoryDetailResponse}
+     * @throws ActivityHistoryException
+     * <ul>
+     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 존재하지 않는 경우</li>
+     * <li>{@code VIEW_PERMISSION_DENIED}: 요청자가 해당 반려동물의 가족 구성원이 아닌 경우</li>
+     * <li>{@code ACTIVITY_NOT_STARTED}: 활동이 아직 시작되지 않은 경우</li>
+     * <li>{@code INVALID_REQUEST}: 활동이 진행 중이거나 취소된 상태인 경우</li>
+     * </ul>
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public ActivityHistoryDetailResponse getActivityHistoryDetail(UUID userId, Long historyId) {
+        ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
+
+        if (!userPetService.isApprovedPetOwner(userId, activityHistory.getPet().getPetId())) {
+            throw new ActivityHistoryException(VIEW_PERMISSION_DENIED);
+        }
+
+        String status = activityHistory.getActivityHistoryStatus().name();
+
+        if ("BEFORE".equals(status)) {
+            throw new ActivityHistoryException(ACTIVITY_NOT_STARTED);
+        }
+
+        if ("IN_PROGRESS".equals(status) || "CANCELED".equals(status)) {
+            throw new ActivityHistoryException(INVALID_REQUEST);
+        }
+
+        return ActivityHistoryDetailResponse.toDto(
+                "해당 활동 정보를 성공적으로 조회했습니다.",
+                activityHistory.getHistoryId(),
+                activityHistory.getPet().getPetId(),
+                activityHistory.getDistance(),
+                activityHistory.getActivityHistoryStartAt(),
+                activityHistory.getActivityHistoryEndAt(),
+                activityHistory.getStartLatitude(),
+                activityHistory.getStartLongitude(),
+                0,
+                false
+        );
+    }
 }

--- a/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
+++ b/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
@@ -842,4 +842,122 @@ class ActivityHistoryServiceTest {
         verify(imageFileService, times(1)).getProfileUrlsByPetIds(any());
         log.info("getMyActivityHistory Success");
     }
+
+    /**
+     * 특정 활동 기록의 상세 정보를 성공적으로 조회하는 시나리오를 테스트합니다.
+     * <p>
+     * 활동 기록이 존재하고, 요청자가 해당 반려동물의 승인된 가족이며,
+     * 활동 상태가 COMPLETED인 경우 정상적으로 상세 정보를 반환해야 합니다.
+     * </p>
+     */
+    @Test
+    @DisplayName("활동 상세 조회 성공: 완료된 활동이며 권한이 있는 경우 상세 정보를 반환한다.")
+    void getActivityHistoryDetail_Success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 101L;
+        Long petId = 12L;
+
+        Pet pet = Pet.builder().petId(petId).build();
+        ActivityHistory history = ActivityHistory.builder()
+                .historyId(historyId)
+                .pet(pet)
+                .activityType(ActivityType.WALKING)
+                .activityHistoryStatus(ActivityHistoryStatus.COMPLETED)
+                .distance(BigDecimal.valueOf(5.25))
+                .activityHistoryStartAt(LocalDateTime.of(2025, 9, 30, 14, 0))
+                .activityHistoryEndAt(LocalDateTime.of(2025, 9, 30, 14, 35))
+                .startLatitude(BigDecimal.valueOf(37.4979))
+                .startLongitude(BigDecimal.valueOf(127.0276))
+                .build();
+
+        log.info("활동 상세 조회 테스트 시작 - 사용자: {}, 기록ID: {}, 반려동물ID: {}", userId, historyId, petId);
+
+        given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(history));
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
+
+        // when
+        ActivityHistoryResponse.ActivityHistoryDetailResponse response = activityHistoryService.getActivityHistoryDetail(userId, historyId);
+        log.info("조회 결과 메시지: {}", response.getMessage());
+
+        // then
+        assertNotNull(response);
+        assertEquals("해당 활동 정보를 성공적으로 조회했습니다.", response.getMessage());
+        assertEquals(historyId, response.getHistoryId());
+        assertEquals(petId, response.getPetId());
+        assertEquals(BigDecimal.valueOf(5.25), response.getDistance());
+        assertEquals(0, response.getReactionCount());
+        assertFalse(response.getIsLikedByMe());
+
+        verify(activityHistoryRepository, times(1)).findById(historyId);
+        verify(userPetService, times(1)).isApprovedPetOwner(userId, petId);
+        log.info("상세 정보 검증 완료 - 거리: {}, 시작시간: {}", response.getDistance(), response.getActivityHistoryStartAt());
+    }
+
+    /**
+     * 완료되지 않은 활동 기록 조회 시 실패하는 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("활동 상세 조회 실패: 활동이 진행 중(IN_PROGRESS)인 경우 잘못된 요청 예외가 발생한다.")
+    void getActivityHistoryDetail_Fail_NotCompleted() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 101L;
+        Long petId = 12L;
+
+        Pet pet = Pet.builder().petId(petId).build();
+        ActivityHistory history = ActivityHistory.builder()
+                .historyId(historyId)
+                .pet(pet)
+                .activityHistoryStatus(ActivityHistoryStatus.IN_PROGRESS)
+                .build();
+
+        log.info("활동 상세 조회 실패 테스트(상태 미완료) - 상태: IN_PROGRESS");
+
+        given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(history));
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
+
+        // when
+        ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
+                activityHistoryService.getActivityHistoryDetail(userId, historyId)
+        );
+        log.info("발생한 예외 코드: {}", exception.getErrorCode());
+
+        // then
+        assertEquals(ActivityHistoryErrorCode.INVALID_REQUEST, exception.getErrorCode());
+        log.info("미완료 활동 조회 차단 검증 완료");
+    }
+
+    /**
+     * 권한이 없는 사용자가 활동 상세 정보를 조회하려 할 때 실패하는 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("활동 상세 조회 실패: 반려동물의 가족 구성원이 아닌 경우 권한 예외가 발생한다.")
+    void getActivityHistoryDetail_Fail_PermissionDenied() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 101L;
+        Long petId = 12L;
+
+        Pet pet = Pet.builder().petId(petId).build();
+        ActivityHistory history = ActivityHistory.builder()
+                .historyId(historyId)
+                .pet(pet)
+                .build();
+
+        log.info("활동 상세 조회 실패 테스트(권한 없음) - 사용자: {}, 반려동물ID: {}", userId, petId);
+
+        given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(history));
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(false);
+
+        // when
+        ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
+                activityHistoryService.getActivityHistoryDetail(userId, historyId)
+        );
+        log.info("발생한 예외 코드: {}", exception.getErrorCode());
+
+        // then
+        assertEquals(ActivityHistoryErrorCode.VIEW_PERMISSION_DENIED, exception.getErrorCode());
+        log.info("비가족 구성원 조회 차단 검증 완료");
+    }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 특정 활동 기록 ID(historyId)를 통한 상세 데이터 조회 엔드포인트 추가
- 반려동물 가족 권한 검증 및 COMPLETED 상태 기록만 조회 가능하도록 로직 구현
- 상세 조회 응답을 위한 ActivityHistoryDetailResponse DTO 추가
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #80

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.
- 특정 활동의 정보에 대해서 볼 수 있는 기능을 구현했는데 활동 기록이 시작전이거나 활동 기록전이거나 취소이면 특정 활동 기록에 대해서 조회하지 못하게 했습니다. 
- 이 기능은 다른사람의 특정활동을 보기 위해서 만든 기능입니다.