### PR TITLE
🔨 Refactor: 활동 종료 로직 서버 주도 처리로 변경 및 이동 거리 계산 추가

### DIFF
--- a/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
+++ b/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
@@ -251,13 +251,12 @@ public class ActivityHistoryController {
     @PatchMapping("/{historyId}/finish")
     public ResponseEntity<ActivityFinishResponse> finishActivity(
             @PathVariable Long historyId,
-            @AuthenticationPrincipal UserDetails userDetails,
-            @RequestBody @Valid ActivityFinishRequest request
+            @AuthenticationPrincipal UserDetails userDetails
     ) {
         UUID userId = UUID.fromString(userDetails.getUsername());
         log.info("활동 종료 요청 - User: {}, HistoryId: {}", userId, historyId);
 
-        ActivityFinishResponse response = activityHistoryService.finishActivity(userId, historyId, request);
+        ActivityFinishResponse response = activityHistoryService.finishActivity(userId, historyId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/dodo/backend/activityhistory/dto/request/ActivityHistoryRequest.java
+++ b/src/main/java/com/dodo/backend/activityhistory/dto/request/ActivityHistoryRequest.java
@@ -81,22 +81,4 @@ public class ActivityHistoryRequest {
         private BigDecimal startLongitude;
     }
 
-    /**
-     * 진행 중인 활동을 종료(COMPLETED)하기 위해 클라이언트로부터 전달받는 요청 DTO입니다.
-     */
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Schema(description = "활동 종료 요청 데이터")
-    public static class ActivityFinishRequest {
-
-        @Schema(description = "변경할 활동 상태 (COMPLETED)", example = "COMPLETED")
-        @NotNull(message = "활동 상태는 필수입니다.")
-        private String activityHistoryStatus;
-
-        @Schema(description = "활동 종료 시간", example = "2025-10-01T21:30:00")
-        @NotNull(message = "종료 시간은 필수입니다.")
-        private LocalDateTime activityHistoryEndAt;
-    }
 }

--- a/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
+++ b/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
@@ -105,9 +105,6 @@ public class ActivityHistoryResponse {
         @Schema(description = "활동 종료 시간", example = "2025-10-01T21:30:00")
         private LocalDateTime activityHistoryEndAt;
 
-        @Schema(description = "활동 상태", example = "COMPLETED")
-        private String activityHistoryStatus;
-
         /**
          * 활동 종료 정보를 기반으로 클라이언트에게 전달할 응답 DTO를 생성합니다.
          * <p>
@@ -119,7 +116,6 @@ public class ActivityHistoryResponse {
          * @param distance               총 이동 거리 (km)
          * @param activityHistoryStartAt 활동 시작 시간
          * @param activityHistoryEndAt   활동 종료 시간
-         * @param activityHistoryStatus  최종 변경된 활동 상태 (문자열)
          * @param message                성공 메시지
          * @return 생성된 {@link ActivityFinishResponse} 객체
          */
@@ -128,7 +124,6 @@ public class ActivityHistoryResponse {
                                                    BigDecimal distance,
                                                    LocalDateTime activityHistoryStartAt,
                                                    LocalDateTime activityHistoryEndAt,
-                                                   String activityHistoryStatus,
                                                    String message) {
             return ActivityFinishResponse.builder()
                     .message(message)
@@ -137,7 +132,6 @@ public class ActivityHistoryResponse {
                     .distance(distance)
                     .activityHistoryStartAt(activityHistoryStartAt)
                     .activityHistoryEndAt(activityHistoryEndAt)
-                    .activityHistoryStatus(activityHistoryStatus)
                     .build();
         }
     }

--- a/src/main/java/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.java
+++ b/src/main/java/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.java
@@ -39,13 +39,15 @@ public interface ActivityHistoryMapper {
                         @Param("status") String status);
 
     /**
-     * 활동을 완료(COMPLETED) 상태로 변경하고, 클라이언트로부터 전달받은 종료 시간을 기록합니다.
+     * 활동을 완료(COMPLETED) 상태로 변경하고, 종료 시간 및 총 이동 거리를 기록합니다.
      *
      * @param historyId 활동 기록 ID
      * @param status    변경할 상태 (COMPLETED)
      * @param endAt     활동 종료 시간
+     * @param distance  총 이동 거리 (km 또는 m, BigDecimal 타입)
      */
     void finishActivity(@Param("historyId") Long historyId,
                         @Param("status") String status,
-                        @Param("endAt") LocalDateTime endAt);
+                        @Param("endAt") LocalDateTime endAt,
+                        @Param("distance") BigDecimal distance);
 }

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
@@ -2,8 +2,6 @@ package com.dodo.backend.activityhistory.service;
 
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityStartRequest;
-import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityFinishRequest;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.*;
 import org.springframework.data.domain.Pageable;
 
@@ -41,17 +39,13 @@ public interface ActivityHistoryService {
     ActivitySimpleResponse startActivity(UUID userId, Long historyId, ActivityStartRequest request);
 
     /**
-     * 진행 중인 활동 기록을 완료(종료)합니다.
-     * <p>
-     * 활동 상태를 '완료(COMPLETED)'로 변경하고 종료 시간 및 최종 상태를 기록합니다.
-     * </p>
+     * 진행 중인 활동을 완료(COMPLETED) 상태로 변경하고 종료 처리를 수행합니다.
      *
      * @param userId    요청한 사용자의 UUID
      * @param historyId 활동 기록 ID
-     * @param request   종료 시간 및 상태 정보가 담긴 요청 DTO
-     * @return 종료된 활동 기록의 상세 정보(거리, 시간 등)를 포함한 응답 DTO
+     * @return 종료된 활동 기록의 상세 정보 DTO
      */
-    ActivityFinishResponse finishActivity(UUID userId, Long historyId, ActivityFinishRequest request);
+    ActivityFinishResponse finishActivity(UUID userId, Long historyId);
 
     /**
      * 진행 중인 활동 기록을 취소(중단)합니다.

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
@@ -13,6 +13,7 @@ import com.dodo.backend.activityhistory.repository.ActivityHistoryRepository;
 import com.dodo.backend.imagefile.service.ImageFileService;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.pet.service.PetService;
+import com.dodo.backend.routepoint.service.RoutePointService;
 import com.dodo.backend.user.entity.User;
 import com.dodo.backend.user.service.UserService;
 import com.dodo.backend.userpet.service.UserPetService;
@@ -23,10 +24,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.*;
 import static com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCode.*;
@@ -34,7 +36,7 @@ import static com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCod
 /**
  * {@link ActivityHistoryService} 인터페이스의 구현체 클래스입니다.
  * <p>
- * 반려동물의 활동 기록(ActivityHistory)의 생성(Create), 시작(Start/Resume), 중단(Cancel) 등
+ * 반려동물의 활동 기록(ActivityHistory)의 생성(Create), 시작(Start/Resume), 중단(Cancel), 종료(Finish) 등
  * 활동 생명주기를 관리하는 핵심 비즈니스 로직을 수행합니다.
  * </p>
  */
@@ -49,6 +51,7 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     private final UserService userService;
     private final ImageFileService imageFileService;
     private final ActivityHistoryMapper activityHistoryMapper;
+    private final RoutePointService routePointService;
 
     /**
      * 새로운 활동 기록을 생성합니다.
@@ -199,27 +202,19 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
      * <p>
      * <ol>
      * <li>활동 기록 존재 여부 및 요청자(User)의 권한(소유권)을 검증합니다.</li>
-     * <li>활동 상태가 '시작 전(BEFORE)'인 경우 예외를 발생시킵니다.</li>
-     * <li>활동 상태가 '진행 중(IN_PROGRESS)'인지 확인합니다. (이미 종료된 경우 예외 발생)</li>
-     * <li>활동 상태를 '완료(COMPLETED)'로 변경하고 종료 시간을 기록합니다.</li>
+     * <li>활동 상태가 '시작 전(BEFORE)'이거나 이미 '종료(COMPLETED)'된 경우 예외를 발생시킵니다.</li>
+     * <li>{@link RoutePointService}를 호출하여 총 이동 거리(Distance)를 계산합니다.</li>
+     * <li>활동 상태를 '완료(COMPLETED)'로 변경하고 서버 시간(NOW)으로 종료 시간을 기록합니다.</li>
      * <li>종료된 활동 정보를 담은 응답 DTO를 반환합니다.</li>
      * </ol>
      *
      * @param userId    요청한 사용자의 UUID
      * @param historyId 활동 기록 ID
-     * @param request   종료 시간 및 상태 정보
-     * @return 종료된 활동 기록의 상세 정보 DTO
-     * @throws ActivityHistoryException
-     * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 없는 경우</li>
-     * <li>{@code STOP_PERMISSION_DENIED}: 활동 기록의 소유자가 아닌 경우</li>
-     * <li>{@code ACTIVITY_NOT_STARTED}: 아직 시작하지 않은(BEFORE) 활동을 종료하려 할 경우</li>
-     * <li>{@code ALREADY_COMPLETED}: 진행 중인 활동이 아닌 경우 (이미 종료됨)</li>
-     * </ul>
+     * @return 종료된 활동 기록의 상세 정보 DTO (이동 거리 포함)
      */
     @Transactional
     @Override
-    public ActivityFinishResponse finishActivity(UUID userId, Long historyId, ActivityFinishRequest request) {
+    public ActivityFinishResponse finishActivity(UUID userId, Long historyId) {
 
         ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
                 .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
@@ -236,21 +231,25 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
             throw new ActivityHistoryException(ALREADY_COMPLETED);
         }
 
+        BigDecimal totalDistance = routePointService.calculateTotalDistance(historyId);
+
+        LocalDateTime endTime = LocalDateTime.now();
+
         activityHistoryMapper.finishActivity(
                 historyId,
-                request.getActivityHistoryStatus(),
-                request.getActivityHistoryEndAt()
+                "COMPLETED",
+                endTime,
+                totalDistance
         );
 
-        log.info("활동 종료 완료 - HistoryId: {}, User: {}", historyId, userId);
+        log.info("활동 종료 완료 - HistoryId: {}, User: {}, Distance: {}m", historyId, userId, totalDistance);
 
         return ActivityFinishResponse.toDto(
                 activityHistory.getHistoryId(),
                 activityHistory.getActivityType(),
-                activityHistory.getDistance(),
+                totalDistance,
                 activityHistory.getActivityHistoryStartAt(),
-                request.getActivityHistoryEndAt(),
-                request.getActivityHistoryStatus(),
+                endTime,
                 "활동 기록이 성공적으로 종료되었습니다."
         );
     }

--- a/src/main/java/com/dodo/backend/routepoint/repository/RoutePointRepository.java
+++ b/src/main/java/com/dodo/backend/routepoint/repository/RoutePointRepository.java
@@ -2,8 +2,23 @@ package com.dodo.backend.routepoint.repository;
 
 import com.dodo.backend.routepoint.entity.RoutePoint;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import java.util.List;
+
+/**
+ * {@link RoutePoint} 엔티티를 관리하는 JPA 리포지토리입니다.
+ * <p>
+ * 이동 경로 좌표의 저장 및 조회를 담당합니다.
+ */
 public interface RoutePointRepository extends JpaRepository<RoutePoint, Long> {
+
+    /**
+     * 특정 활동 기록(History)에 속한 모든 경로 지점을 측정 시간(measuredAt) 오름차순으로 조회합니다.
+     * <p>
+     * 이동 거리 계산 시 순차적인 좌표 데이터가 필요하므로 시간순 정렬이 필수적입니다.
+     *
+     * @param historyId 조회할 활동 기록의 ID
+     * @return 시간순으로 정렬된 RoutePoint 리스트
+     */
+    List<RoutePoint> findAllByActivityHistory_HistoryIdOrderByRoutePointsMeasuredAtAsc(Long historyId);
 }

--- a/src/main/java/com/dodo/backend/routepoint/service/RoutePointService.java
+++ b/src/main/java/com/dodo/backend/routepoint/service/RoutePointService.java
@@ -2,6 +2,7 @@ package com.dodo.backend.routepoint.service;
 
 import com.dodo.backend.routepoint.socket.request.WebSocketRequest;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 public interface RoutePointService {
@@ -14,4 +15,12 @@ public interface RoutePointService {
      * @return 상태(status)와 생성된 경로 ID(routePointId)를 담은 Map
      */
     Map<String, Object> saveRouteAndGetStatus(Long historyId, WebSocketRequest.RouteDataRequest request);
+
+    /**
+     * 특정 활동 기록의 총 이동 거리를 계산합니다.
+     *
+     * @param historyId 계산할 활동 기록의 ID
+     * @return 총 이동 거리 (단위: 미터, Double)
+     */
+    BigDecimal calculateTotalDistance(Long historyId);
 }

--- a/src/main/java/com/dodo/backend/routepoint/service/RoutePointServiceImpl.java
+++ b/src/main/java/com/dodo/backend/routepoint/service/RoutePointServiceImpl.java
@@ -11,14 +11,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
- * {@link RoutePointService}의 구현체입니다.
+ * {@link RoutePointService}의 구현체 클래스입니다.
  * <p>
- * 실시간 활동 경로(RoutePoint)를 저장하고, 동시에 {@link HeartRateService}를 호출하여
- * 심박수 데이터 저장 및 부정맥 분석을 위임합니다.
+ * 실시간 활동 경로(RoutePoint)를 DB에 저장하고, 활동 종료 시 총 이동 거리를 계산하는 역할을 수행합니다.
+ * 또한 {@link HeartRateService}를 호출하여 심박수 데이터 저장 및 부정맥 분석을 위임합니다.
+ * </p>
  */
 @Slf4j
 @Service
@@ -31,10 +35,16 @@ public class RoutePointServiceImpl implements RoutePointService {
 
     /**
      * 활동 상태를 확인하고, 활동이 진행 중인 경우 경로와 심박수 데이터를 저장한 후 상태와 생성된 경로 ID를 반환합니다.
+     * <p>
+     * 1. 활동 기록(ActivityHistory) 존재 여부를 확인합니다.<br>
+     * 2. 활동 상태가 '진행 중(IN_PROGRESS)'인지 검증합니다. (종료된 경우 저장하지 않음)<br>
+     * 3. 위도/경도 데이터가 존재하면 {@link RoutePoint} 엔티티로 변환하여 저장합니다.<br>
+     * 4. 심박수 데이터가 존재하면 {@link HeartRateService}로 처리를 위임합니다.
+     * </p>
      *
      * @param historyId 활동 기록 ID
      * @param request   수신된 위치 및 심박수 데이터 (DTO)
-     * @return 상태(status)와 경로 지점 ID(routePointId)를 포함하는 Map 객체
+     * @return 상태(status)와 생성된 경로 지점 ID(routePointId)를 포함하는 Map 객체
      * @throws IllegalArgumentException historyId에 해당하는 활동 기록이 존재하지 않을 경우 발생
      */
     @Transactional
@@ -74,5 +84,67 @@ public class RoutePointServiceImpl implements RoutePointService {
         result.put("routePointId", routePointId);
 
         return result;
+    }
+
+    /**
+     * 특정 활동 기록의 총 이동 거리를 계산합니다. (Haversine 공식 적용)
+     * <p>
+     * 1. 저장된 모든 경로 지점을 시간순(measuredAt ASC)으로 조회합니다.<br>
+     * 2. 인접한 두 좌표(Point A -> Point B) 간의 거리를 하버사인 공식을 통해 계산하여 누적합니다.<br>
+     * 3. 데이터가 없거나 1개뿐인 경우 이동 거리는 0으로 간주합니다.
+     * </p>
+     *
+     * @param historyId 계산할 활동 기록의 ID
+     * @return 총 이동 거리 (단위: 미터, BigDecimal 타입)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public BigDecimal calculateTotalDistance(Long historyId) {
+        List<RoutePoint> points = routePointRepository.findAllByActivityHistory_HistoryIdOrderByRoutePointsMeasuredAtAsc(historyId);
+
+        if (points.size() < 2) {
+            return BigDecimal.ZERO;
+        }
+
+        double totalDistance = 0.0;
+
+        for (int i = 0; i < points.size() - 1; i++) {
+            RoutePoint p1 = points.get(i);
+            RoutePoint p2 = points.get(i + 1);
+
+            totalDistance += haversine(
+                    p1.getLatitude().doubleValue(), p1.getLongitude().doubleValue(),
+                    p2.getLatitude().doubleValue(), p2.getLongitude().doubleValue()
+            );
+        }
+
+        return BigDecimal.valueOf(totalDistance)
+                .setScale(3, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * 두 위도/경도 좌표 간의 거리를 계산하는 하버사인(Haversine) 공식입니다.
+     * <p>
+     * 지구의 곡률을 고려하여 두 지점 사이의 대원 거리(Great-circle distance)를 구합니다.
+     *
+     * @param lat1 지점 1의 위도
+     * @param lon1 지점 1의 경도
+     * @param lat2 지점 2의 위도
+     * @param lon2 지점 2의 경도
+     * @return 두 지점 사이의 거리 (단위: 미터)
+     */
+    private double haversine(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371; // 지구 반지름 (km)
+
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
+                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c * 1000;
     }
 }

--- a/src/main/resources/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.xml
+++ b/src/main/resources/com/dodo/backend/activityhistory/mapper/ActivityHistoryMapper.xml
@@ -39,14 +39,16 @@
         WHERE history_id = #{historyId}
     </update>
 
-    <!-- 진행 중인 활동 기록을 '완료(FINISHED)' 상태로 변경하고 활동 종료 시간을 기록합니다.
-        1. activity_history_status : 활동 상태를 FINISHED로 변경
-        2. activity_history_end_at : 활동이 정상 종료된 시간을 endAt 파라미터로 기록
-        3. WHERE history_id : historyId를 기준으로 특정 활동 기록을 식별 -->
+    <!-- 진행 중인 활동 기록을 '완료(FINISHED)' 상태로 변경합니다.
+         1. activity_history_status : 활동 상태를 FINISHED로 변경
+         2. activity_history_end_at : 활동이 정상 종료된 시간을 endAt 파라미터로 기록
+         3. distance : 활동 종료 시점까지의 총 이동 거리
+         4. WHERE history_id : historyId를 기준으로 특정 활동 기록을 식별 -->
     <update id="finishActivity">
         UPDATE activity_history
         SET activity_history_status = #{status},
-            activity_history_end_at = #{endAt}
+            activity_history_end_at = #{endAt},
+            distance = #{distance}
         WHERE history_id = #{historyId}
     </update>
 </mapper>

--- a/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
+++ b/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
@@ -1,8 +1,7 @@
 package com.dodo.backend.activityhistory.service;
 
-import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
-import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityFinishRequest;
+import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityStartRequest;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.ActivityHistorySummary;
 import com.dodo.backend.activityhistory.entity.ActivityHistory;
@@ -15,6 +14,7 @@ import com.dodo.backend.activityhistory.repository.ActivityHistoryRepository;
 import com.dodo.backend.imagefile.service.ImageFileService;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.pet.service.PetService;
+import com.dodo.backend.routepoint.service.RoutePointService;
 import com.dodo.backend.user.entity.User;
 import com.dodo.backend.user.service.UserService;
 import com.dodo.backend.userpet.service.UserPetService;
@@ -38,6 +38,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,6 +71,9 @@ class ActivityHistoryServiceTest {
     @Mock
     private UserService userService;
 
+    @Mock
+    private RoutePointService routePointService;
+
     /**
      * 활동 기록 생성 성공 시나리오를 테스트합니다.
      */
@@ -91,8 +95,6 @@ class ActivityHistoryServiceTest {
         ActivityHistory savedHistory = request.toEntity(user, pet);
         ReflectionTestUtils.setField(savedHistory, "historyId", 100L);
 
-        log.info("User: {}, Pet: {}, Request: {}", userId, petId, request);
-
         given(userService.getUserById(userId)).willReturn(user);
         given(petService.getPetById(petId)).willReturn(pet);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
@@ -102,7 +104,6 @@ class ActivityHistoryServiceTest {
 
         // when
         ActivityHistoryResponse.ActivityCreateResponse response = activityHistoryService.createActivity(userId, request);
-        log.info("createActivity Result: {}", response);
 
         // then
         assertNotNull(response);
@@ -113,7 +114,6 @@ class ActivityHistoryServiceTest {
         verify(petService, times(1)).getPetById(petId);
         verify(userPetService, times(1)).isApprovedPetOwner(userId, petId);
         verify(activityHistoryRepository, times(1)).save(any(ActivityHistory.class));
-        log.info("Saved HistoryId: {}, Type: {}", response.getHistoryId(), response.getActivityType());
     }
 
     /**
@@ -134,8 +134,6 @@ class ActivityHistoryServiceTest {
                 .activityType("WALKING")
                 .build();
 
-        log.info("User: {}, Pet: {} (Not Owner)", userId, petId);
-
         given(userService.getUserById(userId)).willReturn(user);
         given(petService.getPetById(petId)).willReturn(pet);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(false);
@@ -144,7 +142,6 @@ class ActivityHistoryServiceTest {
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.createActivity(userId, request)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.CREATE_PERMISSION_DENIED, exception.getErrorCode());
@@ -169,8 +166,6 @@ class ActivityHistoryServiceTest {
                 .activityType("WALKING")
                 .build();
 
-        log.info("User: {}, Pet: {} (Already In Progress)", userId, petId);
-
         given(userService.getUserById(userId)).willReturn(user);
         given(petService.getPetById(petId)).willReturn(pet);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
@@ -180,7 +175,6 @@ class ActivityHistoryServiceTest {
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.createActivity(userId, request)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.ALREADY_IN_PROGRESS, exception.getErrorCode());
@@ -205,8 +199,6 @@ class ActivityHistoryServiceTest {
                 .activityType("WALKING")
                 .build();
 
-        log.info("User: {}, Pet: {} (Already Exists Before)", userId, petId);
-
         given(userService.getUserById(userId)).willReturn(user);
         given(petService.getPetById(petId)).willReturn(pet);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
@@ -217,7 +209,6 @@ class ActivityHistoryServiceTest {
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.createActivity(userId, request)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.ALREADY_EXISTS_BEFORE, exception.getErrorCode());
@@ -241,13 +232,10 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.BEFORE)
                 .build();
 
-        // Mocking: 요청 객체 (위치 정보 포함)
-        ActivityHistoryRequest.ActivityStartRequest request = ActivityHistoryRequest.ActivityStartRequest.builder()
+        ActivityStartRequest request = ActivityStartRequest.builder()
                 .startLatitude(BigDecimal.valueOf(37.1234))
                 .startLongitude(BigDecimal.valueOf(127.1234))
                 .build();
-
-        log.info("User: {}, HistoryId: {}, Status: BEFORE, Request: {}", userId, historyId, request);
 
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
@@ -261,7 +249,6 @@ class ActivityHistoryServiceTest {
                 request.getStartLatitude(),
                 request.getStartLongitude()
         );
-        log.info("Mapper startActivity called with status: IN_PROGRESS");
     }
 
     /**
@@ -282,9 +269,7 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.BEFORE)
                 .build();
 
-        ActivityHistoryRequest.ActivityStartRequest request = ActivityHistoryRequest.ActivityStartRequest.builder().build();
-
-        log.info("User: {}, Owner: {}, HistoryId: {}", userId, otherUserId, historyId);
+        ActivityStartRequest request = ActivityStartRequest.builder().build();
 
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
@@ -292,7 +277,6 @@ class ActivityHistoryServiceTest {
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.startActivity(userId, historyId, request)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.START_PERMISSION_DENIED, exception.getErrorCode());
@@ -316,9 +300,7 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.IN_PROGRESS)
                 .build();
 
-        ActivityHistoryRequest.ActivityStartRequest request = ActivityHistoryRequest.ActivityStartRequest.builder().build();
-
-        log.info("User: {}, HistoryId: {}, Status: IN_PROGRESS (Invalid)", userId, historyId);
+        ActivityStartRequest request = ActivityStartRequest.builder().build();
 
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
@@ -326,7 +308,6 @@ class ActivityHistoryServiceTest {
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.startActivity(userId, historyId, request)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.ALREADY_IN_PROGRESS, exception.getErrorCode());
@@ -342,9 +323,7 @@ class ActivityHistoryServiceTest {
         // given
         UUID userId = UUID.randomUUID();
         Long historyId = 999L;
-        ActivityHistoryRequest.ActivityStartRequest request = ActivityHistoryRequest.ActivityStartRequest.builder().build();
-
-        log.info("User: {}, HistoryId: {} (Not Found)", userId, historyId);
+        ActivityStartRequest request = ActivityStartRequest.builder().build();
 
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.empty());
 
@@ -352,7 +331,6 @@ class ActivityHistoryServiceTest {
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.startActivity(userId, historyId, request)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.HISTORY_NOT_FOUND, exception.getErrorCode());
@@ -376,18 +354,15 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.CANCELED)
                 .build();
 
-        ActivityHistoryRequest.ActivityStartRequest request = ActivityHistoryRequest.ActivityStartRequest.builder()
+        ActivityStartRequest request = ActivityStartRequest.builder()
                 .startLatitude(BigDecimal.valueOf(37.5))
                 .startLongitude(BigDecimal.valueOf(127.5))
                 .build();
 
-        log.info("User: {}, HistoryId: {}, Status: CANCELED", userId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
         // when
-        ActivityHistoryResponse.ActivitySimpleResponse response = activityHistoryService.startActivity(userId, historyId, request);
-        log.info("resumeActivity Result: {}", response);
+        activityHistoryService.startActivity(userId, historyId, request);
 
         // then
         verify(activityHistoryMapper, times(1)).resumeActivity(
@@ -395,7 +370,6 @@ class ActivityHistoryServiceTest {
                 ActivityHistoryStatus.IN_PROGRESS.name()
         );
         verify(activityHistoryMapper, times(0)).startActivity(any(), any(), any(), any());
-        log.info("Mapper resumeActivity called with status: IN_PROGRESS");
     }
 
     /**
@@ -415,13 +389,10 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.IN_PROGRESS)
                 .build();
 
-        log.info("User: {}, HistoryId: {}, Status: IN_PROGRESS", userId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
         // when
         ActivityHistoryResponse.ActivitySimpleResponse response = activityHistoryService.cancelActivity(userId, historyId);
-        log.info("cancelActivity Result: {}", response.getMessage());
 
         // then
         assertEquals("활동 기록이 성공적으로 중단되었습니다.", response.getMessage());
@@ -429,7 +400,6 @@ class ActivityHistoryServiceTest {
                 historyId,
                 ActivityHistoryStatus.CANCELED.name()
         );
-        log.info("Mapper cancelActivity called with status: CANCELED");
     }
 
     /**
@@ -450,15 +420,12 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.IN_PROGRESS)
                 .build();
 
-        log.info("User: {}, Owner: {}, HistoryId: {}", userId, otherUserId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
         // when
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.cancelActivity(userId, historyId)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.STOP_PERMISSION_DENIED, exception.getErrorCode());
@@ -482,15 +449,12 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.BEFORE)
                 .build();
 
-        log.info("User: {}, HistoryId: {}, Status: BEFORE (Invalid)", userId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
         // when
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.cancelActivity(userId, historyId)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.ALREADY_COMPLETED, exception.getErrorCode());
@@ -507,15 +471,12 @@ class ActivityHistoryServiceTest {
         UUID userId = UUID.randomUUID();
         Long historyId = 999L;
 
-        log.info("User: {}, HistoryId: {} (Not Found)", userId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.empty());
 
         // when
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.cancelActivity(userId, historyId)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.HISTORY_NOT_FOUND, exception.getErrorCode());
@@ -526,49 +487,42 @@ class ActivityHistoryServiceTest {
      * 활동 종료 성공 시나리오를 테스트합니다.
      */
     @Test
-    @DisplayName("활동 종료 성공: 진행 중인 활동을 완료하면 상태 변경 Mapper가 호출되고 결과를 반환한다.")
+    @DisplayName("활동 종료 성공: 진행 중인 활동을 완료하면 거리 계산 후 상태 변경 Mapper가 호출되고 결과를 반환한다.")
     void finishActivity_Success() {
         // given
         UUID userId = UUID.randomUUID();
         Long historyId = 100L;
-        LocalDateTime endTime = LocalDateTime.of(2025, 10, 1, 21, 30);
+        LocalDateTime startTime = LocalDateTime.now().minusHours(1);
+        BigDecimal calculatedDistance = BigDecimal.valueOf(5.235);
 
         User user = User.builder().usersId(userId).build();
         ActivityHistory activityHistory = ActivityHistory.builder()
                 .historyId(historyId)
                 .user(user)
                 .activityType(ActivityType.WALKING)
-                .distance(BigDecimal.valueOf(5.235))
+                .distance(BigDecimal.ZERO)
                 .activityHistoryStatus(ActivityHistoryStatus.IN_PROGRESS)
-                .activityHistoryStartAt(endTime.minusHours(1))
+                .activityHistoryStartAt(startTime)
                 .build();
-
-        ActivityFinishRequest request = ActivityFinishRequest.builder()
-                .activityHistoryStatus("COMPLETED")
-                .activityHistoryEndAt(endTime)
-                .build();
-
-        log.info("User: {}, HistoryId: {}, EndTime: {}", userId, historyId, endTime);
 
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
+        given(routePointService.calculateTotalDistance(historyId)).willReturn(calculatedDistance);
 
         // when
-        ActivityHistoryResponse.ActivityFinishResponse response = activityHistoryService.finishActivity(userId, historyId, request);
-        log.info("finishActivity Result: Status={}, EndTime={}", response.getActivityHistoryStatus(), response.getActivityHistoryEndAt());
+        ActivityHistoryResponse.ActivityFinishResponse response = activityHistoryService.finishActivity(userId, historyId);
 
         // then
         assertNotNull(response);
         assertEquals(historyId, response.getHistoryId());
-        assertEquals(ActivityType.WALKING.name(), response.getActivityType());
-        assertEquals("COMPLETED", response.getActivityHistoryStatus());
-        assertEquals(endTime, response.getActivityHistoryEndAt());
+        assertNotNull(response.getActivityHistoryEndAt());
+        assertEquals(calculatedDistance, response.getDistance());
 
         verify(activityHistoryMapper, times(1)).finishActivity(
-                historyId,
-                ActivityHistoryStatus.COMPLETED.name(),
-                endTime
+                eq(historyId),
+                eq("COMPLETED"),
+                any(LocalDateTime.class),
+                eq(calculatedDistance)
         );
-        log.info("Mapper finishActivity called with status: COMPLETED");
     }
 
     /**
@@ -589,24 +543,16 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.IN_PROGRESS)
                 .build();
 
-        ActivityFinishRequest request = ActivityFinishRequest.builder()
-                .activityHistoryStatus("COMPLETED")
-                .activityHistoryEndAt(LocalDateTime.now())
-                .build();
-
-        log.info("User: {}, Owner: {}, HistoryId: {}", userId, otherUserId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
         // when
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
-                activityHistoryService.finishActivity(userId, historyId, request)
+                activityHistoryService.finishActivity(userId, historyId)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.STOP_PERMISSION_DENIED, exception.getErrorCode());
-        verify(activityHistoryMapper, times(0)).finishActivity(any(), any(), any());
+        verify(activityHistoryMapper, times(0)).finishActivity(any(), any(), any(), any());
     }
 
     /**
@@ -626,24 +572,16 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.COMPLETED)
                 .build();
 
-        ActivityFinishRequest request = ActivityFinishRequest.builder()
-                .activityHistoryStatus("COMPLETED")
-                .activityHistoryEndAt(LocalDateTime.now())
-                .build();
-
-        log.info("User: {}, HistoryId: {}, Status: COMPLETED (Invalid)", userId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
         // when
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
-                activityHistoryService.finishActivity(userId, historyId, request)
+                activityHistoryService.finishActivity(userId, historyId)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.ALREADY_COMPLETED, exception.getErrorCode());
-        verify(activityHistoryMapper, times(0)).finishActivity(any(), any(), any());
+        verify(activityHistoryMapper, times(0)).finishActivity(any(), any(), any(), any());
     }
 
     /**
@@ -655,21 +593,17 @@ class ActivityHistoryServiceTest {
         // given
         UUID userId = UUID.randomUUID();
         Long historyId = 999L;
-        ActivityFinishRequest request = ActivityFinishRequest.builder().build();
-
-        log.info("User: {}, HistoryId: {} (Not Found)", userId, historyId);
 
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.empty());
 
         // when
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
-                activityHistoryService.finishActivity(userId, historyId, request)
+                activityHistoryService.finishActivity(userId, historyId)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.HISTORY_NOT_FOUND, exception.getErrorCode());
-        verify(activityHistoryMapper, times(0)).finishActivity(any(), any(), any());
+        verify(activityHistoryMapper, times(0)).finishActivity(any(), any(), any(), any());
     }
 
     /**
@@ -687,15 +621,12 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.BEFORE)
                 .build();
 
-        log.info("User: {}, HistoryId: {}, Status: BEFORE (Not Started)", userId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
         // when
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
-                activityHistoryService.finishActivity(userId, historyId, ActivityFinishRequest.builder().build())
+                activityHistoryService.finishActivity(userId, historyId)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.ACTIVITY_NOT_STARTED, exception.getErrorCode());
@@ -716,13 +647,10 @@ class ActivityHistoryServiceTest {
                 .user(user)
                 .build();
 
-        log.info("User: {}, HistoryId: {}", userId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
         // when
         ActivityHistoryResponse.ActivitySimpleResponse response = activityHistoryService.deleteActivity(userId, historyId);
-        log.info("deleteActivity Result: {}", response.getMessage());
 
         // then
         assertNotNull(response);
@@ -746,15 +674,12 @@ class ActivityHistoryServiceTest {
                 .user(otherUser)
                 .build();
 
-        log.info("User: {}, Owner: {}, HistoryId: {}", userId, otherUserId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(activityHistory));
 
         // when
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.deleteActivity(userId, historyId)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.DELETE_PERMISSION_DENIED, exception.getErrorCode());
@@ -771,15 +696,12 @@ class ActivityHistoryServiceTest {
         UUID userId = UUID.randomUUID();
         Long historyId = 999L;
 
-        log.info("User: {}, HistoryId: {} (Not Found)", userId, historyId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.empty());
 
         // when
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.deleteActivity(userId, historyId)
         );
-        log.info("Exception Code: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.HISTORY_NOT_FOUND, exception.getErrorCode());
@@ -813,8 +735,6 @@ class ActivityHistoryServiceTest {
         Page<ActivityHistory> page = new org.springframework.data.domain.PageImpl<>(List.of(history), pageable, 1);
         Map<Long, String> imageMap = Map.of(petId, "http://example.com/bori.jpg");
 
-        log.info("User: {}, Page: 0, Size: 10", userId);
-
         given(userService.getUserById(userId)).willReturn(user);
         given(activityHistoryRepository.findAllByUser(user, pageable)).willReturn(page);
         given(imageFileService.getProfileUrlsByPetIds(List.of(petId))).willReturn(imageMap);
@@ -822,9 +742,6 @@ class ActivityHistoryServiceTest {
         // when
         ActivityHistoryResponse.ActivityHistoryPageResponse response = activityHistoryService.getMyActivityHistory(userId, pageable);
         ActivityHistorySummary summary = response.getHistories().get(0);
-
-        log.info("Result Count: {}, First Item Pet: {}, Image: {}",
-                response.getTotalElements(), summary.getPet().getName(), summary.getPet().getProfileImageUrl());
 
         // then
         assertNotNull(response);
@@ -840,15 +757,10 @@ class ActivityHistoryServiceTest {
 
         verify(activityHistoryRepository, times(1)).findAllByUser(user, pageable);
         verify(imageFileService, times(1)).getProfileUrlsByPetIds(any());
-        log.info("getMyActivityHistory Success");
     }
 
     /**
      * 특정 활동 기록의 상세 정보를 성공적으로 조회하는 시나리오를 테스트합니다.
-     * <p>
-     * 활동 기록이 존재하고, 요청자가 해당 반려동물의 승인된 가족이며,
-     * 활동 상태가 COMPLETED인 경우 정상적으로 상세 정보를 반환해야 합니다.
-     * </p>
      */
     @Test
     @DisplayName("활동 상세 조회 성공: 완료된 활동이며 권한이 있는 경우 상세 정보를 반환한다.")
@@ -871,14 +783,11 @@ class ActivityHistoryServiceTest {
                 .startLongitude(BigDecimal.valueOf(127.0276))
                 .build();
 
-        log.info("활동 상세 조회 테스트 시작 - 사용자: {}, 기록ID: {}, 반려동물ID: {}", userId, historyId, petId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(history));
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
 
         // when
         ActivityHistoryResponse.ActivityHistoryDetailResponse response = activityHistoryService.getActivityHistoryDetail(userId, historyId);
-        log.info("조회 결과 메시지: {}", response.getMessage());
 
         // then
         assertNotNull(response);
@@ -891,7 +800,6 @@ class ActivityHistoryServiceTest {
 
         verify(activityHistoryRepository, times(1)).findById(historyId);
         verify(userPetService, times(1)).isApprovedPetOwner(userId, petId);
-        log.info("상세 정보 검증 완료 - 거리: {}, 시작시간: {}", response.getDistance(), response.getActivityHistoryStartAt());
     }
 
     /**
@@ -912,8 +820,6 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.IN_PROGRESS)
                 .build();
 
-        log.info("활동 상세 조회 실패 테스트(상태 미완료) - 상태: IN_PROGRESS");
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(history));
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
 
@@ -921,11 +827,9 @@ class ActivityHistoryServiceTest {
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.getActivityHistoryDetail(userId, historyId)
         );
-        log.info("발생한 예외 코드: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.INVALID_REQUEST, exception.getErrorCode());
-        log.info("미완료 활동 조회 차단 검증 완료");
     }
 
     /**
@@ -945,8 +849,6 @@ class ActivityHistoryServiceTest {
                 .pet(pet)
                 .build();
 
-        log.info("활동 상세 조회 실패 테스트(권한 없음) - 사용자: {}, 반려동물ID: {}", userId, petId);
-
         given(activityHistoryRepository.findById(historyId)).willReturn(Optional.of(history));
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(false);
 
@@ -954,19 +856,13 @@ class ActivityHistoryServiceTest {
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.getActivityHistoryDetail(userId, historyId)
         );
-        log.info("발생한 예외 코드: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.VIEW_PERMISSION_DENIED, exception.getErrorCode());
-        log.info("비가족 구성원 조회 차단 검증 완료");
     }
 
     /**
      * 반려동물의 활동 상태 조회 성공 시나리오를 테스트합니다. (진행 중인 활동이 있는 경우)
-     * <p>
-     * 최신 활동 기록의 상태가 IN_PROGRESS인 경우,
-     * 적절한 메시지와 함께 해당 활동의 historyId를 반환해야 합니다.
-     * </p>
      */
     @Test
     @DisplayName("반려동물 활동 상태 조회 성공: 활동이 진행 중인 경우 기록 ID를 반환한다.")
@@ -982,15 +878,12 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.IN_PROGRESS)
                 .build();
 
-        log.info("반려동물 상태 조회 테스트(진행 중) 시작 - 사용자: {}, 반려동물ID: {}", userId, petId);
-
         given(petService.getPetById(petId)).willReturn(pet);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
         given(activityHistoryRepository.findFirstByPetOrderByHistoryIdDesc(pet)).willReturn(Optional.of(history));
 
         // when
         ActivityHistoryResponse.ActivityStatusResponse response = activityHistoryService.getPetActivityStatus(userId, petId);
-        log.info("조회 결과 메시지: {}, 기록ID: {}", response.getMessage(), response.getHistoryId());
 
         // then
         assertNotNull(response);
@@ -1000,14 +893,10 @@ class ActivityHistoryServiceTest {
         verify(petService, times(1)).getPetById(petId);
         verify(userPetService, times(1)).isApprovedPetOwner(userId, petId);
         verify(activityHistoryRepository, times(1)).findFirstByPetOrderByHistoryIdDesc(pet);
-        log.info("진행 중 상태 조회 검증 완료");
     }
 
     /**
      * 반려동물의 활동 상태 조회 성공 시나리오를 테스트합니다. (시작 전 또는 중단된 활동이 있는 경우)
-     * <p>
-     * 최신 기록이 BEFORE나 CANCELED인 경우에도 후속 조치를 위해 historyId를 반환해야 합니다.
-     * </p>
      */
     @Test
     @DisplayName("반려동물 활동 상태 조회 성공: 활동이 시작 전인 경우 기록 ID를 반환한다.")
@@ -1023,28 +912,21 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.BEFORE)
                 .build();
 
-        log.info("반려동물 상태 조회 테스트(시작 전) 시작 - 반려동물ID: {}", petId);
-
         given(petService.getPetById(petId)).willReturn(pet);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
         given(activityHistoryRepository.findFirstByPetOrderByHistoryIdDesc(pet)).willReturn(Optional.of(history));
 
         // when
         ActivityHistoryResponse.ActivityStatusResponse response = activityHistoryService.getPetActivityStatus(userId, petId);
-        log.info("조회 결과 메시지: {}, 기록ID: {}", response.getMessage(), response.getHistoryId());
 
         // then
         assertNotNull(response);
         assertEquals("활동 시작 전 상태입니다.", response.getMessage());
         assertEquals(historyId, response.getHistoryId());
-        log.info("시작 전 상태 조회 검증 완료");
     }
 
     /**
      * 반려동물의 활동 상태 조회 성공 시나리오를 테스트합니다. (진행 중인 활동이 없는 경우)
-     * <p>
-     * 최신 기록이 COMPLETED인 경우, 진행 중인 활동이 없으므로 ID를 null로 반환해야 합니다.
-     * </p>
      */
     @Test
     @DisplayName("반려동물 활동 상태 조회 성공: 진행 중인 활동이 없는 경우 ID를 null로 반환한다.")
@@ -1059,21 +941,17 @@ class ActivityHistoryServiceTest {
                 .activityHistoryStatus(ActivityHistoryStatus.COMPLETED)
                 .build();
 
-        log.info("반려동물 상태 조회 테스트(활동 완료) 시작 - 반려동물ID: {}", petId);
-
         given(petService.getPetById(petId)).willReturn(pet);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
         given(activityHistoryRepository.findFirstByPetOrderByHistoryIdDesc(pet)).willReturn(Optional.of(history));
 
         // when
         ActivityHistoryResponse.ActivityStatusResponse response = activityHistoryService.getPetActivityStatus(userId, petId);
-        log.info("조회 결과 메시지: {}, 기록ID: {}", response.getMessage(), response.getHistoryId());
 
         // then
         assertNotNull(response);
         assertEquals("현재 진행 중인 활동이 없습니다.", response.getMessage());
         assertNull(response.getHistoryId());
-        log.info("완료 상태 조회 검증 완료");
     }
 
     /**
@@ -1087,15 +965,12 @@ class ActivityHistoryServiceTest {
         Long petId = 1L;
         Pet pet = Pet.builder().petId(petId).build();
 
-        log.info("반려동물 상태 조회 테스트(기록 없음) 시작 - 반려동물ID: {}", petId);
-
         given(petService.getPetById(petId)).willReturn(pet);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
         given(activityHistoryRepository.findFirstByPetOrderByHistoryIdDesc(pet)).willReturn(Optional.empty());
 
         // when
         ActivityHistoryResponse.ActivityStatusResponse response = activityHistoryService.getPetActivityStatus(userId, petId);
-        log.info("조회 결과 메시지: {}", response.getMessage());
 
         // then
         assertNotNull(response);
@@ -1114,8 +989,6 @@ class ActivityHistoryServiceTest {
         Long petId = 1L;
         Pet pet = Pet.builder().petId(petId).build();
 
-        log.info("반려동물 상태 조회 실패 테스트(권한 없음) - 사용자: {}, 반려동물ID: {}", userId, petId);
-
         given(petService.getPetById(petId)).willReturn(pet);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(false);
 
@@ -1123,11 +996,9 @@ class ActivityHistoryServiceTest {
         ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
                 activityHistoryService.getPetActivityStatus(userId, petId)
         );
-        log.info("발생한 예외 코드: {}", exception.getErrorCode());
 
         // then
         assertEquals(ActivityHistoryErrorCode.VIEW_PERMISSION_DENIED, exception.getErrorCode());
         verify(activityHistoryRepository, times(0)).findFirstByPetOrderByHistoryIdDesc(any());
-        log.info("권한 없음 검증 완료");
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 데이터 무결성을 위해 클라이언트 입력값(종료 시간, 상태) 대신 서버 시간(`LocalDateTime.now`)과 고정 상수(`COMPLETED`)를 사용하도록 변경
- 활동 종료 시 `RoutePointService`를 통해 총 이동 거리(Haversine 공식)를 계산하고 DB에 저장하는 로직 구현
- 불필요해진 `ActivityFinishRequest` DTO 삭제 및 Controller, Mapper, 테스트 코드 동기화
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #86
<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

기능 수정해서 request 아무것도 안받게 했고 종료할 대 최종 거리 산출되게 했습니다.