### PR TITLE
✨ Feat: 건강 분석 결과 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/auth/client/GptClient.java
+++ b/src/main/java/com/dodo/backend/auth/client/GptClient.java
@@ -96,6 +96,7 @@ public class GptClient {
         String title = cleanSingleLine(requiredString(parsed, "title"));
         String summary = cleanSingleLine(requiredString(parsed, "summary"));
         String content = cleanBody(requiredString(parsed, "content"));
+        List<String> recommendations = requiredStringList(parsed, "recommendations");
 
         Object chartData = parsed.get("chartData");
         if (!(chartData instanceof Map<?, ?> chartMap)) {
@@ -103,6 +104,7 @@ public class GptClient {
         }
 
         Map<String, Object> fullContentMap = new LinkedHashMap<>();
+        fullContentMap.put("recommendations", recommendations);
         fullContentMap.put("chartData", chartMap);
         fullContentMap.put("analysisType", normalizedType);
         fullContentMap.put("generatedAt", LocalDateTime.now().toString());
@@ -174,6 +176,7 @@ public class GptClient {
                   "title": "반드시 '{petName}의 yyyy년 M월 d일 건강 분석 리포트' 형식",
                   "summary": "핵심 요약 1~2문장(템플릿 문구 금지)",
                   "content": "분석 본문만 4~6문장. '제목:', '요약:', '기본 본문:' 접두어 금지",
+                  "recommendations": ["실행 가능한 권장 행동 2~4개"],
                   "chartData": {
                     "weightSeries": {"labels": [], "data": []},
                     "activitySeries": {"labels": [], "distance": []},
@@ -188,6 +191,7 @@ public class GptClient {
                 - title은 healthData.petName을 반드시 포함
                 - title 날짜는 healthData.reportDate를 기준으로 작성
                 - title/summary/content에 템플릿 문구('일별 건강 분석 리포트', '일별 데이터 기반 건강 분석 요약입니다.') 사용 금지
+                - recommendations는 반드시 2~4개 문자열 배열로 작성 (예: "간식 10%% 줄이기", "산책 시간 15분 늘리기")
                 - chartData.weightSeries.labels / activitySeries.labels / heartRateSeries.labels 는 모두 필수
                 - 각 시리즈에서 데이터가 1개 이상이면 labels도 반드시 1개 이상이어야 함
                 - 각 시리즈의 labels 길이는 해당 data(또는 distance) 길이와 반드시 동일해야 함
@@ -223,6 +227,29 @@ public class GptClient {
             throw new IllegalStateException("GPT 응답 필수 필드 누락: " + key);
         }
         return str;
+    }
+
+    /**
+     * 필수 문자열 배열 필드를 추출합니다.
+     *
+     * @param map 맵 데이터
+     * @param key 필드 키
+     * @return 문자열 리스트 값
+     */
+    private List<String> requiredStringList(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (!(value instanceof List<?> list) || list.isEmpty()) {
+            throw new IllegalStateException("GPT 응답 필수 배열 필드 누락: " + key);
+        }
+
+        for (Object element : list) {
+            if (!(element instanceof String str) || str.isBlank()) {
+                throw new IllegalStateException("GPT 응답 배열 필드 값이 올바르지 않습니다: " + key);
+            }
+        }
+
+        List<String> casted = (List<String>) list;
+        return casted;
     }
 
     /**

--- a/src/main/java/com/dodo/backend/healthanalysis/controller/HealthAnalysisController.java
+++ b/src/main/java/com/dodo/backend/healthanalysis/controller/HealthAnalysisController.java
@@ -5,10 +5,12 @@ import com.dodo.backend.healthanalysis.dto.request.HealthAnalysisRequest.AiRepor
 import com.dodo.backend.healthanalysis.dto.request.HealthAnalysisRequest.AnalysisUpdateRequest;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisDeleteResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisDetailResponse;
+import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisListResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AiReportCreateResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisUpdateResponse;
 import com.dodo.backend.healthanalysis.service.HealthAnalysisService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,6 +19,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,6 +32,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
@@ -89,6 +95,60 @@ public class HealthAnalysisController {
     }
 
     /**
+     * 반려동물 기준 건강 분석 결과 목록을 조회합니다.
+     *
+     * @param petId 조회 대상 반려동물 ID
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지 크기
+     * @param period 분석 기간 타입(DAILY/WEEKLY/MONTHLY)
+     * @param userDetails 인증된 사용자 정보
+     * @return 건강 분석 목록 응답
+     */
+    @Operation(summary = "건강 분석 결과 목록 조회", description = "petId 기준으로 건강 분석 결과 목록을 페이징 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "건강 분석 결과 조회를 성공했습니다.",
+                    content = @Content(schema = @Schema(implementation = AnalysisListResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "건강 분석 리포트 이력 조회를 할 수 없는 반려동물입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"건강 분석 리포트 이력 조회를 할 수 없는 반려동물입니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 반려동물을 찾을 수 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"해당 반려동물을 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @GetMapping("/{petId}")
+    public ResponseEntity<AnalysisListResponse> getAnalysisList(
+            @PathVariable Long petId,
+            @Parameter(hidden = true) @ParameterObject @PageableDefault(size = 10) Pageable pageable,
+            @RequestParam(required = false) String period,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        log.info("건강 분석 목록 조회 요청 - User: {}, PetId: {}, page: {}, size: {}, period: {}",
+                userId, petId, pageable.getPageNumber(), pageable.getPageSize(), period);
+        return ResponseEntity.ok(healthAnalysisService.getAnalysisList(
+                userId,
+                petId,
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                period
+        ));
+    }
+
+    /**
      * 건강 분석 상세 조회를 요청합니다.
      *
      * @param analysisId  조회할 분석 보고서 ID
@@ -120,7 +180,7 @@ public class HealthAnalysisController {
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
     })
-    @GetMapping("/{analysisId}")
+    @GetMapping("/detail/{analysisId}")
     public ResponseEntity<AnalysisDetailResponse> getAnalysisDetail(
             @PathVariable Long analysisId,
             @AuthenticationPrincipal UserDetails userDetails

--- a/src/main/java/com/dodo/backend/healthanalysis/dto/response/HealthAnalysisResponse.java
+++ b/src/main/java/com/dodo/backend/healthanalysis/dto/response/HealthAnalysisResponse.java
@@ -1,11 +1,14 @@
 package com.dodo.backend.healthanalysis.dto.response;
 
+import com.dodo.backend.healthanalysis.entity.HealthAnalysis;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 건강 분석 도메인의 응답 DTO 그룹입니다.
@@ -164,6 +167,141 @@ public class HealthAnalysisResponse {
         public static AnalysisDeleteResponse toDto(String message) {
             return AnalysisDeleteResponse.builder()
                     .message(message)
+                    .build();
+        }
+    }
+
+    /**
+     * 건강 분석 결과 목록 조회 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "건강 분석 결과 목록 조회 응답")
+    public static class AnalysisListResponse {
+
+        @Schema(description = "응답 메시지", example = "건강 분석 결과 조회를 성공했습니다.")
+        private String message;
+
+        @Schema(description = "페이지 정보")
+        private PageInfo pageInfo;
+
+        @Schema(description = "건강 분석 결과 목록")
+        private List<AnalysisListItem> data;
+
+        /**
+         * 목록 조회 응답 DTO를 생성합니다.
+         *
+         * @param message 응답 메시지
+         * @param page 페이지 정보가 담긴 Page 객체
+         * @param data 목록 데이터
+         * @return 초기화된 목록 조회 응답 DTO
+         */
+        public static AnalysisListResponse toDto(String message, Page<HealthAnalysis> page, List<AnalysisListItem> data) {
+            return AnalysisListResponse.builder()
+                    .message(message)
+                    .pageInfo(PageInfo.toDto(page))
+                    .data(data)
+                    .build();
+        }
+    }
+
+    /**
+     * 건강 분석 목록 조회의 페이지 메타 정보를 담는 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "건강 분석 목록 페이지 정보")
+    public static class PageInfo {
+
+        @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+        private int page;
+
+        @Schema(description = "페이지 크기", example = "10")
+        private int size;
+
+        @Schema(description = "전체 요소 수", example = "4")
+        private long totalElements;
+
+        @Schema(description = "전체 페이지 수", example = "1")
+        private int totalPages;
+
+        /**
+         * Page 객체를 페이지 정보 DTO로 변환합니다.
+         *
+         * @param page Page 객체
+         * @return 페이지 정보 DTO
+         */
+        public static PageInfo toDto(Page<HealthAnalysis> page) {
+            return PageInfo.builder()
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalElements(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .build();
+        }
+    }
+
+    /**
+     * 건강 분석 목록의 개별 항목 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "건강 분석 목록 항목")
+    public static class AnalysisListItem {
+
+        @Schema(description = "분석 ID", example = "1")
+        private Long analysisId;
+
+        @Schema(description = "분석 제목", example = "2025년 10월 정기 건강 분석 리포트")
+        private String healthAnalysisTitle;
+
+        @Schema(description = "분석 요약", example = "활동량은 양호하나, 체중이 약간 증가하는 경향을 보입니다.")
+        private String healthAnalysisSummary;
+
+        @Schema(description = "상세 분석 JSON")
+        private Object healthAnalysisFullContent;
+
+        @Schema(description = "분석 일시", example = "2025-10-14T10:00:00")
+        private LocalDateTime analysisDate;
+
+        @Schema(description = "분석 타입", example = "MONTHLY")
+        private String analysisType;
+
+        @Schema(description = "분석 상태", example = "COMPLETED")
+        private String analysisStatus;
+
+        /**
+         * 목록 항목 DTO를 생성합니다.
+         *
+         * @param analysisId 분석 ID
+         * @param healthAnalysisTitle 분석 제목
+         * @param healthAnalysisSummary 분석 요약
+         * @param healthAnalysisFullContent 상세 분석 JSON
+         * @param analysisDate 분석 일시
+         * @param analysisType 분석 타입 문자열
+         * @param analysisStatus 분석 상태 문자열
+         * @return 목록 항목 DTO
+         */
+        public static AnalysisListItem toDto(
+                Long analysisId,
+                String healthAnalysisTitle,
+                String healthAnalysisSummary,
+                Object healthAnalysisFullContent,
+                LocalDateTime analysisDate,
+                String analysisType,
+                String analysisStatus
+        ) {
+            return AnalysisListItem.builder()
+                    .analysisId(analysisId)
+                    .healthAnalysisTitle(healthAnalysisTitle)
+                    .healthAnalysisSummary(healthAnalysisSummary)
+                    .healthAnalysisFullContent(healthAnalysisFullContent)
+                    .analysisDate(analysisDate)
+                    .analysisType(analysisType)
+                    .analysisStatus(analysisStatus)
                     .build();
         }
     }

--- a/src/main/java/com/dodo/backend/healthanalysis/repository/HealthAnalysisRepository.java
+++ b/src/main/java/com/dodo/backend/healthanalysis/repository/HealthAnalysisRepository.java
@@ -1,9 +1,35 @@
 package com.dodo.backend.healthanalysis.repository;
 
+import com.dodo.backend.healthanalysis.entity.AnalysisType;
 import com.dodo.backend.healthanalysis.entity.HealthAnalysis;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HealthAnalysisRepository extends JpaRepository<HealthAnalysis, Long> {
+
+    /**
+     * 특정 반려동물의 건강 분석 결과를 분석 일시 내림차순으로 조회합니다.
+     *
+     * @param petId 반려동물 ID
+     * @param pageable 페이징 정보
+     * @return 건강 분석 결과 페이지
+     */
+    Page<HealthAnalysis> findAllByPet_PetIdOrderByAnalysisDateDesc(Long petId, Pageable pageable);
+
+    /**
+     * 특정 반려동물의 건강 분석 결과를 분석 타입으로 필터링하여 분석 일시 내림차순으로 조회합니다.
+     *
+     * @param petId 반려동물 ID
+     * @param analysisType 분석 타입
+     * @param pageable 페이징 정보
+     * @return 건강 분석 결과 페이지
+     */
+    Page<HealthAnalysis> findAllByPet_PetIdAndAnalysisTypeOrderByAnalysisDateDesc(
+            Long petId,
+            AnalysisType analysisType,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/dodo/backend/healthanalysis/service/HealthAnalysisService.java
+++ b/src/main/java/com/dodo/backend/healthanalysis/service/HealthAnalysisService.java
@@ -4,6 +4,7 @@ import com.dodo.backend.healthanalysis.dto.request.HealthAnalysisRequest.AiRepor
 import com.dodo.backend.healthanalysis.dto.request.HealthAnalysisRequest.AnalysisUpdateRequest;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisDetailResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisDeleteResponse;
+import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisListResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AiReportCreateResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisUpdateResponse;
 
@@ -51,4 +52,16 @@ public interface HealthAnalysisService {
      * @return 삭제 결과 응답 DTO
      */
     AnalysisDeleteResponse deleteAnalysis(UUID userId, Long analysisId);
+
+    /**
+     * 반려동물 기준 건강 분석 결과 목록을 조회합니다.
+     *
+     * @param userId 요청한 사용자 ID
+     * @param petId 반려동물 ID
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지 크기
+     * @param period 분석 기간 타입 (DAILY/WEEKLY/MONTHLY)
+     * @return 목록 조회 응답 DTO
+     */
+    AnalysisListResponse getAnalysisList(UUID userId, Long petId, int page, int size, String period);
 }

--- a/src/main/java/com/dodo/backend/healthanalysis/service/HealthAnalysisServiceImpl.java
+++ b/src/main/java/com/dodo/backend/healthanalysis/service/HealthAnalysisServiceImpl.java
@@ -6,6 +6,8 @@ import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.Analy
 import com.dodo.backend.healthanalysis.dto.request.HealthAnalysisRequest.AiReportCreateRequest;
 import com.dodo.backend.healthanalysis.dto.request.HealthAnalysisRequest.AnalysisUpdateRequest;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisDeleteResponse;
+import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisListItem;
+import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisListResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AiReportCreateResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisUpdateResponse;
 import com.dodo.backend.healthanalysis.entity.AnalysisStatus;
@@ -23,6 +25,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +44,7 @@ import static com.dodo.backend.healthanalysis.exception.HealthAnalysisErrorCode.
 import static com.dodo.backend.healthanalysis.exception.HealthAnalysisErrorCode.DELETE_PERMISSION_DENIED;
 import static com.dodo.backend.healthanalysis.exception.HealthAnalysisErrorCode.INVALID_REQUEST;
 import static com.dodo.backend.healthanalysis.exception.HealthAnalysisErrorCode.PET_NOT_FOUND;
+import static com.dodo.backend.healthanalysis.exception.HealthAnalysisErrorCode.REPORT_HISTORY_PERMISSION_DENIED;
 import static com.dodo.backend.healthanalysis.exception.HealthAnalysisErrorCode.UPDATE_PERMISSION_DENIED;
 import static com.dodo.backend.healthanalysis.exception.HealthAnalysisErrorCode.VIEW_PERMISSION_DENIED;
 
@@ -202,6 +208,50 @@ public class HealthAnalysisServiceImpl implements HealthAnalysisService {
     }
 
     /**
+     * 반려동물 기준 건강 분석 결과 목록을 조회합니다.
+     *
+     * @param userId 요청 사용자 ID
+     * @param petId 반려동물 ID
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param period 분석 기간 타입
+     * @return 건강 분석 목록 조회 응답 DTO
+     * @throws HealthAnalysisException 요청값이 잘못되었거나 권한/반려동물 검증에 실패한 경우
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public AnalysisListResponse getAnalysisList(UUID userId, Long petId, int page, int size, String period) {
+        if (page < 0 || size <= 0) {
+            throw new HealthAnalysisException(INVALID_REQUEST);
+        }
+
+        if (!petService.existsPetById(petId)) {
+            throw new HealthAnalysisException(PET_NOT_FOUND);
+        }
+
+        if (!userPetService.isApprovedPetOwner(userId, petId)) {
+            throw new HealthAnalysisException(REPORT_HISTORY_PERMISSION_DENIED);
+        }
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<HealthAnalysis> analysisPage = getAnalysisPageByPeriod(petId, period, pageable);
+
+        List<AnalysisListItem> items = analysisPage.getContent().stream()
+                .map(analysis -> AnalysisListItem.toDto(
+                        analysis.getAnalysisId(),
+                        analysis.getHealthAnalysisTitle(),
+                        analysis.getHealthAnalysisSummary(),
+                        parseJsonSafely(analysis.getHealthAnalysisFullContent()),
+                        analysis.getAnalysisDate(),
+                        analysis.getAnalysisType() == null ? null : analysis.getAnalysisType().name(),
+                        analysis.getAnalysisStatus() == null ? null : analysis.getAnalysisStatus().name()
+                ))
+                .toList();
+
+        return AnalysisListResponse.toDto("건강 분석 결과 조회를 성공했습니다.", analysisPage, items);
+    }
+
+    /**
      * 분석 단위(DAILY/WEEKLY/MONTHLY)에 따라 데이터를 조회하고 GPT 전달용 payload를 구성합니다.
      *
      * @param analysisType 분석 단위
@@ -281,6 +331,34 @@ public class HealthAnalysisServiceImpl implements HealthAnalysisService {
             log.warn("healthAnalysisFullContent JSON 파싱 실패 - raw 문자열을 반환합니다. analysisFullContent={}", json, e);
             return json;
         }
+    }
+
+    /**
+     * period 조건에 따라 건강 분석 목록 페이지를 조회합니다.
+     *
+     * @param petId 반려동물 ID
+     * @param period 분석 기간 타입
+     * @param pageable 페이징 정보
+     * @return 건강 분석 목록 페이지
+     */
+    private Page<HealthAnalysis> getAnalysisPageByPeriod(Long petId, String period, Pageable pageable) {
+        if (period == null || period.isBlank()) {
+            return healthAnalysisRepository.findAllByPet_PetIdOrderByAnalysisDateDesc(petId, pageable);
+        }
+
+        String normalizedPeriod = period.trim().toUpperCase(Locale.ROOT);
+        AnalysisType analysisType;
+        try {
+            analysisType = AnalysisType.valueOf(normalizedPeriod);
+        } catch (IllegalArgumentException e) {
+            throw new HealthAnalysisException(INVALID_REQUEST);
+        }
+
+        return healthAnalysisRepository.findAllByPet_PetIdAndAnalysisTypeOrderByAnalysisDateDesc(
+                petId,
+                analysisType,
+                pageable
+        );
     }
 
 }

--- a/src/test/java/com/dodo/backend/healthanalysis/service/HealthAnalysisServiceTest.java
+++ b/src/test/java/com/dodo/backend/healthanalysis/service/HealthAnalysisServiceTest.java
@@ -6,8 +6,10 @@ import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.Analy
 import com.dodo.backend.healthanalysis.dto.request.HealthAnalysisRequest.AiReportCreateRequest;
 import com.dodo.backend.healthanalysis.dto.request.HealthAnalysisRequest.AnalysisUpdateRequest;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisDeleteResponse;
+import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisListResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AiReportCreateResponse;
 import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisUpdateResponse;
+import com.dodo.backend.healthanalysis.entity.AnalysisType;
 import com.dodo.backend.healthanalysis.entity.HealthAnalysis;
 import com.dodo.backend.healthanalysis.exception.HealthAnalysisErrorCode;
 import com.dodo.backend.healthanalysis.exception.HealthAnalysisException;
@@ -26,10 +28,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Map;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -472,5 +477,89 @@ class HealthAnalysisServiceTest {
         // then
         assertEquals(HealthAnalysisErrorCode.DELETE_PERMISSION_DENIED, exception.getErrorCode());
         verify(healthAnalysisRepository, never()).delete(any(HealthAnalysis.class));
+    }
+
+    /**
+     * 건강 분석 목록 조회 성공 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("건강 분석 목록 조회 성공: 권한이 있으면 페이지 정보와 목록을 반환한다.")
+    void getAnalysisList_Success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long petId = 2L;
+
+        HealthAnalysis analysis = HealthAnalysis.builder()
+                .healthAnalysisTitle("10월 리포트")
+                .healthAnalysisSummary("요약")
+                .healthAnalysisFullContent("{\"chartData\":{}}")
+                .analysisDate(LocalDateTime.now())
+                .analysisType(AnalysisType.MONTHLY)
+                .analysisStatus(com.dodo.backend.healthanalysis.entity.AnalysisStatus.COMPLETED)
+                .build();
+        ReflectionTestUtils.setField(analysis, "analysisId", 1L);
+        ReflectionTestUtils.setField(analysis, "pet", Pet.builder().petId(petId).build());
+
+        given(petService.existsPetById(petId)).willReturn(true);
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
+        given(healthAnalysisRepository.findAllByPet_PetIdOrderByAnalysisDateDesc(eq(petId), any()))
+                .willReturn(new PageImpl<>(List.of(analysis), PageRequest.of(0, 10), 1));
+        given(objectMapper.readValue("{\"chartData\":{}}", Object.class)).willReturn(Map.of("chartData", Map.of()));
+
+        // when
+        AnalysisListResponse response = healthAnalysisService.getAnalysisList(userId, petId, 0, 10, null);
+
+        // then
+        assertEquals("건강 분석 결과 조회를 성공했습니다.", response.getMessage());
+        assertEquals(0, response.getPageInfo().getPage());
+        assertEquals(10, response.getPageInfo().getSize());
+        assertEquals(1, response.getData().size());
+        assertEquals("MONTHLY", response.getData().get(0).getAnalysisType());
+    }
+
+    /**
+     * 건강 분석 목록 조회 시 권한이 없으면 예외가 발생하는지 테스트합니다.
+     */
+    @Test
+    @DisplayName("건강 분석 목록 조회 실패: 권한이 없으면 REPORT_HISTORY_PERMISSION_DENIED 예외가 발생한다.")
+    void getAnalysisList_Fail_PermissionDenied() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long petId = 2L;
+
+        given(petService.existsPetById(petId)).willReturn(true);
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(false);
+
+        // when
+        HealthAnalysisException exception = assertThrows(HealthAnalysisException.class, () ->
+                healthAnalysisService.getAnalysisList(userId, petId, 0, 10, "DAILY")
+        );
+
+        // then
+        assertEquals(HealthAnalysisErrorCode.REPORT_HISTORY_PERMISSION_DENIED, exception.getErrorCode());
+        verify(healthAnalysisRepository, never()).findAllByPet_PetIdOrderByAnalysisDateDesc(anyLong(), any());
+    }
+
+    /**
+     * 건강 분석 목록 조회 시 분석 타입이 잘못되면 예외가 발생하는지 테스트합니다.
+     */
+    @Test
+    @DisplayName("건강 분석 목록 조회 실패: period 값이 잘못되면 INVALID_REQUEST 예외가 발생한다.")
+    void getAnalysisList_Fail_InvalidPeriod() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long petId = 2L;
+
+        given(petService.existsPetById(petId)).willReturn(true);
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
+
+        // when
+        HealthAnalysisException exception = assertThrows(HealthAnalysisException.class, () ->
+                healthAnalysisService.getAnalysisList(userId, petId, 0, 10, "YEARLY")
+        );
+
+        // then
+        assertEquals(HealthAnalysisErrorCode.INVALID_REQUEST, exception.getErrorCode());
+        verify(healthAnalysisRepository, never()).findAllByPet_PetIdAndAnalysisTypeOrderByAnalysisDateDesc(anyLong(), any(), any());
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- GET /health/analysis/{petId} 목록 조회 API 추가 (page/size/period 지원)
- 상세 조회 경로를 /health/analysis/detail/{analysisId}로 분리해 라우팅 충돌 해소
- period(DAILY/WEEKLY/MONTHLY) 필터 및 유효성 검증 로직 추가
- 목록 응답 DTO(pageInfo, data) 추가, analysisType/analysisStatus 문자열 반환 처리
- JPA Repository 목록 조회 메서드 추가 및 서비스 권한/존재 검증 반영
- 목록 조회 단위 테스트(성공/권한없음/잘못된 period) 추가
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #106
<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

건강 분석 결과 목록 조회 기능 구현했는데 엔드포인트가 겹쳐서 그거 때문에 건강분석 상세 조회 기능 엔드포인트를 /health/analysis/deatil/{analysisId}로 변경했습니다.