### PR TITLE
✨ Feat: 울타리 실시간 위치 웹소켓 기능 및 테스트 구현

### DIFF
--- a/src/main/java/com/dodo/backend/common/handler/StompHandler.java
+++ b/src/main/java/com/dodo/backend/common/handler/StompHandler.java
@@ -13,6 +13,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
 /**
@@ -45,28 +46,80 @@ public class StompHandler implements ChannelInterceptor {
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
-        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+        if (accessor == null || accessor.getCommand() == null) {
+            return message;
+        }
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
             String authorizationHeader = accessor.getFirstNativeHeader("Authorization");
+            authenticate(accessor, authorizationHeader);
+            return message;
+        }
 
-            if (authorizationHeader == null) {
-                throw new MessageDeliveryException("Authorization 헤더가 누락되었습니다.");
+        if (StompCommand.SEND.equals(accessor.getCommand())) {
+            Authentication auth = requireAuthentication(accessor);
+            String destination = accessor.getDestination();
+
+            if (destination != null && destination.startsWith("/pub/")) {
+                if (!hasAuthority(auth, "ROLE_DEVICE")) {
+                    throw new MessageDeliveryException("디바이스 인증이 필요한 기능입니다.");
+                }
             }
+            return message;
+        }
 
-            if (!authorizationHeader.startsWith("Bearer ")) {
-                throw new MessageDeliveryException("유효하지 않은 인증 형식입니다.");
+        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            Authentication auth = requireAuthentication(accessor);
+            String destination = accessor.getDestination();
+
+            if (destination != null && destination.startsWith("/sub/")) {
+                if (hasAuthority(auth, "ROLE_DEVICE")) {
+                    throw new MessageDeliveryException("디바이스 계정은 방송 채널을 구독할 수 없습니다.");
+                }
             }
-
-            String token = authorizationHeader.substring(7);
-
-            if (!jwtTokenProvider.validateToken(token)) {
-                throw new MessageDeliveryException("토큰이 유효하지 않거나 만료되었습니다.");
-            }
-
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            accessor.setUser(authentication);
-
-            log.info("WebSocket 인증 성공: {}", authentication.getName());
         }
         return message;
+    }
+
+    /**
+     * CONNECT 프레임의 Authorization 헤더를 검증하고 인증 정보를 세션에 저장합니다.
+     */
+    private void authenticate(StompHeaderAccessor accessor, String authorizationHeader) {
+        if (authorizationHeader == null) {
+            throw new MessageDeliveryException("Authorization 헤더가 누락되었습니다.");
+        }
+
+        if (!authorizationHeader.startsWith("Bearer ")) {
+            throw new MessageDeliveryException("유효하지 않은 인증 형식입니다.");
+        }
+
+        String token = authorizationHeader.substring(7);
+
+        if (!jwtTokenProvider.validateToken(token)) {
+            throw new MessageDeliveryException("토큰이 유효하지 않거나 만료되었습니다.");
+        }
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        accessor.setUser(authentication);
+        log.info("WebSocket 인증 성공: {}", authentication.getName());
+    }
+
+    /**
+     * 현재 STOMP 세션의 인증 정보를 확인하고 반환합니다.
+     */
+    private Authentication requireAuthentication(StompHeaderAccessor accessor) {
+        if (accessor.getUser() instanceof Authentication auth) {
+            return auth;
+        }
+        throw new MessageDeliveryException("로그인이 필요한 기능입니다.");
+    }
+
+    /**
+     * 인증 객체에 특정 권한이 포함되어 있는지 확인합니다.
+     */
+    private boolean hasAuthority(Authentication authentication, String authority) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(authority::equals);
     }
 }

--- a/src/main/java/com/dodo/backend/common/subscribe/RedisSubscriber.java
+++ b/src/main/java/com/dodo/backend/common/subscribe/RedisSubscriber.java
@@ -24,8 +24,8 @@ public class RedisSubscriber {
     /**
      * Redis 채널에서 메시지가 발행(Publish)되면 호출되는 콜백 메서드입니다.
      * <p>
-     * 수신된 JSON 래퍼(Wrapper) 객체에서 historyId(주소)와 실제 메시지(내용물)를 분리합니다.
-     * historyId를 사용하여 적절한 웹소켓 채널을 찾은 뒤, 껍데기를 벗긴 실제 메시지만 전송합니다.
+     * 수신된 JSON 래퍼(Wrapper) 객체에서 라우팅 키(historyId 또는 petId)와 실제 메시지(내용물)를 분리합니다.
+     * 라우팅 키를 사용하여 적절한 웹소켓 채널을 찾은 뒤, 껍데기를 벗긴 실제 메시지만 전송합니다.
      *
      * @param wrapperMessage Redis 채널을 통해 수신된 래퍼 JSON 문자열
      */
@@ -34,19 +34,35 @@ public class RedisSubscriber {
             JsonNode rootNode = objectMapper.readTree(wrapperMessage);
 
             long historyId = rootNode.path("historyId").asLong();
+            long petId = rootNode.path("petId").asLong();
             JsonNode realPayload = rootNode.path("message");
 
-            if (historyId == 0 || realPayload.isMissingNode()) {
+            if (realPayload.isMissingNode()) {
                 log.warn("유효하지 않은 Redis 메시지 형식입니다: {}", wrapperMessage);
                 return;
             }
 
-            log.info("Redis 채널 수신 (ID: {}) -> 웹소켓 전파 완료", historyId);
+            if (historyId != 0) {
+                log.info("Redis 채널 수신 (historyId: {}) -> 웹소켓 전파 완료", historyId);
 
-            messagingTemplate.convertAndSend(
-                    "/sub/activities/history/routes/" + historyId,
-                    realPayload.toString()
-            );
+                messagingTemplate.convertAndSend(
+                        "/sub/activities/history/routes/" + historyId,
+                        realPayload.toString()
+                );
+                return;
+            }
+
+            if (petId != 0) {
+                log.info("Redis 채널 수신 (petId: {}) -> 웹소켓 전파 완료", petId);
+
+                messagingTemplate.convertAndSend(
+                        "/sub/fence/location/" + petId,
+                        realPayload.toString()
+                );
+                return;
+            }
+
+            log.warn("라우팅 키가 없는 Redis 메시지입니다: {}", wrapperMessage);
 
         } catch (Exception e) {
             log.error("Redis 메시지 처리 중 오류 발생: {}", e.getMessage());

--- a/src/main/java/com/dodo/backend/fence/controller/FenceWebSocketController.java
+++ b/src/main/java/com/dodo/backend/fence/controller/FenceWebSocketController.java
@@ -1,0 +1,163 @@
+package com.dodo.backend.fence.controller;
+
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceLocationCheckResponse;
+import com.dodo.backend.fence.exception.FenceException;
+import com.dodo.backend.fence.service.FenceService;
+import com.dodo.backend.fence.socket.FenceSocketType;
+import com.dodo.backend.fence.socket.FenceWebSocketMessage;
+import com.dodo.backend.fence.socket.request.FenceWebSocketRequest.FenceLocationRequest;
+import com.dodo.backend.fence.socket.response.FenceWebSocketResponse.FenceLocationBroadcastResponse;
+import com.dodo.backend.fence.socket.response.FenceWebSocketResponse.FenceLocationErrorResponse;
+import com.dodo.backend.fence.socket.response.FenceWebSocketResponse.FenceLocationSuccessResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+/**
+ * 울타리 실시간 위치 웹소켓 메시지를 처리하는 컨트롤러입니다.
+ */
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class FenceWebSocketController {
+
+    private final FenceService fenceService;
+    private final StringRedisTemplate redisTemplate;
+    private final ChannelTopic topic;
+    private final ObjectMapper objectMapper;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * Redis Pub/Sub 전송을 위해 라우팅 정보(petId)와 실제 메시지를 포장하는 내부 래퍼 클래스입니다.
+     */
+    @Getter
+    @AllArgsConstructor
+    private static class RedisPublishWrapper {
+        private Long petId;
+        private Object message;
+    }
+
+    /**
+     * 임베디드에서 전송한 실시간 위치를 수신하고 울타리 내부 여부를 판정합니다.
+     * <p>
+     * 처리 결과는 브로드캐스트 채널(`/sub/fence/location/{petId}`)과
+     * 개인 응답 채널(`/user/queue/reply`)로 각각 전송됩니다.
+     *
+     * @param petId     경로 변수 반려동물 ID
+     * @param message   수신 메시지
+     * @param principal 인증된 사용자 정보
+     */
+    @MessageMapping("/fence/location/{petId}")
+    public void receiveFenceLocation(
+            @DestinationVariable Long petId,
+            FenceWebSocketMessage<FenceLocationRequest> message,
+            Principal principal
+    ) {
+        FenceLocationRequest request = validateAndExtract(message);
+
+        try {
+            FenceLocationCheckResponse result = fenceService.checkFenceLocationByPet(
+                    petId,
+                    request.getLatitude(),
+                    request.getLongitude(),
+                    request.getMeasuredAt()
+            );
+
+            FenceLocationBroadcastResponse broadcast = FenceLocationBroadcastResponse.builder()
+                    .petId(petId)
+                    .latitude(request.getLatitude())
+                    .longitude(request.getLongitude())
+                    .measuredAt(request.getMeasuredAt())
+                    .insideFence(result.getInsideFence())
+                    .distanceMeter(result.getDistanceMeter())
+                    .radius(result.getRadius())
+                    .message(result.getInsideFence()
+                            ? "설정 반경 " + result.getRadius() + "m 이내입니다."
+                            : "설정 반경 " + result.getRadius() + "m 이탈입니다.")
+                    .build();
+
+            try {
+                RedisPublishWrapper wrapper = new RedisPublishWrapper(
+                        petId,
+                        FenceWebSocketMessage.success(broadcast)
+                );
+                String jsonWrapper = objectMapper.writeValueAsString(wrapper);
+                redisTemplate.convertAndSend(topic.getTopic(), jsonWrapper);
+            } catch (JsonProcessingException e) {
+                log.error("Fence Redis 메시지 발행 중 직렬화 오류: {}", e.getMessage());
+                throw new RuntimeException("서버 내부 오류가 발생했습니다.");
+            }
+
+            FenceLocationSuccessResponse ack = FenceLocationSuccessResponse.builder()
+                    .code(200)
+                    .message("위치 데이터 수신 및 처리 완료")
+                    .build();
+
+            messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/queue/reply",
+                    FenceWebSocketMessage.success(ack)
+            );
+        } catch (FenceException e) {
+            sendError(principal, e.getErrorCode().getHttpStatus().value(), e.getErrorCode().getMessage(), request);
+        } catch (IllegalArgumentException e) {
+            sendError(principal, 400, "잘못된 요청입니다.", request);
+        } catch (Exception e) {
+            log.error("울타리 위치 처리 중 서버 오류 발생: {}", e.getMessage(), e);
+            sendError(principal, 500, "서버 내부 오류가 발생했습니다.", request);
+        }
+    }
+
+    /**
+     * 개인 응답 채널(`/user/queue/reply`)로 표준 에러 메시지를 전송합니다.
+     *
+     * @param principal       사용자 인증 정보
+     * @param code            에러 코드
+     * @param message         에러 메시지
+     * @param originalMessage 원본 요청 메시지
+     */
+    private void sendError(Principal principal, int code, String message, Object originalMessage) {
+        FenceLocationErrorResponse errorResponse = FenceLocationErrorResponse.builder()
+                .code(code)
+                .message(message)
+                .originalMessage(originalMessage)
+                .build();
+
+        messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/queue/reply",
+                FenceWebSocketMessage.error(errorResponse)
+        );
+    }
+
+    /**
+     * 수신 메시지의 타입과 필수 필드를 검증합니다.
+     *
+     * @param message 수신 메시지
+     * @return 유효성 검증을 통과한 요청 DTO
+     */
+    private FenceLocationRequest validateAndExtract(FenceWebSocketMessage<FenceLocationRequest> message) {
+        if (message == null || message.getType() != FenceSocketType.SEND || message.getPayload() == null) {
+            throw new IllegalArgumentException("잘못된 요청입니다.");
+        }
+
+        FenceLocationRequest payload = message.getPayload();
+
+        if (payload.getLatitude() == null || payload.getLongitude() == null || payload.getMeasuredAt() == null) {
+            throw new IllegalArgumentException("잘못된 요청입니다.");
+        }
+
+        return payload;
+    }
+}

--- a/src/main/java/com/dodo/backend/fence/dto/response/FenceResponse.java
+++ b/src/main/java/com/dodo/backend/fence/dto/response/FenceResponse.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.math.BigDecimal;
+
 /**
  * 울타리(Fence) 도메인 응답 DTO를 정의하는 그룹 클래스입니다.
  */
@@ -32,6 +34,41 @@ public class FenceResponse {
         public static FenceRangeResponse toDto(String message) {
             return FenceRangeResponse.builder()
                     .message(message)
+                    .build();
+        }
+    }
+
+    /**
+     * 실시간 위치가 울타리 내부인지 판정한 결과 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "실시간 울타리 판정 결과")
+    public static class FenceLocationCheckResponse {
+
+        @Schema(description = "울타리 내부 여부", example = "true")
+        private Boolean insideFence;
+
+        @Schema(description = "중심점으로부터의 거리(미터)", example = "125.42")
+        private BigDecimal distanceMeter;
+
+        @Schema(description = "설정된 울타리 반경(미터)", example = "500")
+        private Integer radius;
+
+        /**
+         * 실시간 울타리 판정 결과 DTO를 생성합니다.
+         *
+         * @param insideFence  울타리 내부 여부
+         * @param distanceMeter 중심점으로부터의 거리(미터)
+         * @param radius        설정된 울타리 반경(미터)
+         * @return 생성된 응답 DTO
+         */
+        public static FenceLocationCheckResponse toDto(Boolean insideFence, BigDecimal distanceMeter, Integer radius) {
+            return FenceLocationCheckResponse.builder()
+                    .insideFence(insideFence)
+                    .distanceMeter(distanceMeter)
+                    .radius(radius)
                     .build();
         }
     }

--- a/src/main/java/com/dodo/backend/fence/entity/Fence.java
+++ b/src/main/java/com/dodo/backend/fence/entity/Fence.java
@@ -29,8 +29,8 @@ public class Fence {
     @Column(name = "fence_id")
     private Long fenceId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "pet_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false, unique = true)
     private Pet pet;
 
     @Column(name = "name", length = 255)

--- a/src/main/java/com/dodo/backend/fence/service/FenceService.java
+++ b/src/main/java/com/dodo/backend/fence/service/FenceService.java
@@ -1,8 +1,11 @@
 package com.dodo.backend.fence.service;
 
 import com.dodo.backend.fence.dto.request.FenceRequest.FenceRangeRequest;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceLocationCheckResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeResponse;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
@@ -20,5 +23,28 @@ public interface FenceService {
      * @return 설정 완료 응답 DTO
      */
     FenceRangeResponse setFenceRange(UUID userId, FenceRangeRequest request);
+
+    /**
+     * 반려동물 ID 기준으로 실시간 위치의 울타리 내부 여부를 판정합니다.
+     *
+     * @param petId      반려동물 ID
+     * @param latitude   실시간 위도
+     * @param longitude  실시간 경도
+     * @param measuredAt 측정 시각
+     * @return 울타리 판정 결과 DTO
+     */
+    FenceLocationCheckResponse checkFenceLocationByPet(Long petId, BigDecimal latitude, BigDecimal longitude, LocalDateTime measuredAt);
+
+    /**
+     * 실시간 위치 데이터를 기반으로 울타리 내부 여부를 판정합니다.
+     *
+     * @param userId     요청한 사용자 ID
+     * @param petId      반려동물 ID
+     * @param latitude   실시간 위도
+     * @param longitude  실시간 경도
+     * @param measuredAt 측정 시각
+     * @return 울타리 판정 결과 DTO
+     */
+    FenceLocationCheckResponse checkFenceLocation(UUID userId, Long petId, BigDecimal latitude, BigDecimal longitude, LocalDateTime measuredAt);
 
 }

--- a/src/main/java/com/dodo/backend/fence/service/FenceServiceImpl.java
+++ b/src/main/java/com/dodo/backend/fence/service/FenceServiceImpl.java
@@ -1,6 +1,7 @@
 package com.dodo.backend.fence.service;
 
 import com.dodo.backend.fence.dto.request.FenceRequest.FenceRangeRequest;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceLocationCheckResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeResponse;
 import com.dodo.backend.fence.entity.Fence;
 import com.dodo.backend.fence.exception.FenceException;
@@ -12,8 +13,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+import static com.dodo.backend.fence.exception.FenceErrorCode.FENCE_INFO_NOT_FOUND;
 import static com.dodo.backend.fence.exception.FenceErrorCode.PET_NOT_FOUND;
 import static com.dodo.backend.fence.exception.FenceErrorCode.PET_PERMISSION_DENIED;
 
@@ -70,4 +75,100 @@ public class FenceServiceImpl implements FenceService {
         return FenceRangeResponse.toDto("울타리 설정을 완료했습니다.");
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * 1. 반려동물 존재 여부를 검증합니다.
+     * 2. 요청 사용자의 반려동물 접근 권한을 검증합니다.
+     * 3. 반려동물의 울타리 설정 정보를 조회합니다.
+     * 4. 실시간 좌표와 울타리 중심 좌표의 거리를 계산하여 내부 여부를 판정합니다.
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public FenceLocationCheckResponse checkFenceLocation(
+            UUID userId,
+            Long petId,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            LocalDateTime measuredAt
+    ) {
+        if (!petService.existsPetById(petId)) {
+            throw new FenceException(PET_NOT_FOUND);
+        }
+
+        if (!userPetService.isApprovedPetOwner(userId, petId)) {
+            throw new FenceException(PET_PERMISSION_DENIED);
+        }
+
+        Fence fence = fenceRepository.findByPet_PetId(petId)
+                .orElseThrow(() -> new FenceException(FENCE_INFO_NOT_FOUND));
+
+        double distance = haversine(
+                latitude.doubleValue(),
+                longitude.doubleValue(),
+                fence.getCenterLatitude().doubleValue(),
+                fence.getCenterLongitude().doubleValue()
+        );
+
+        BigDecimal distanceMeter = BigDecimal.valueOf(distance).setScale(2, RoundingMode.HALF_UP);
+        boolean insideFence = distanceMeter.compareTo(BigDecimal.valueOf(fence.getRadius())) <= 0;
+
+        return FenceLocationCheckResponse.toDto(insideFence, distanceMeter, fence.getRadius());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * 디바이스에서 전달된 반려동물 ID 기준으로 울타리 내부 여부를 판정합니다.
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public FenceLocationCheckResponse checkFenceLocationByPet(
+            Long petId,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            LocalDateTime measuredAt
+    ) {
+        if (!petService.existsPetById(petId)) {
+            throw new FenceException(PET_NOT_FOUND);
+        }
+
+        Fence fence = fenceRepository.findByPet_PetId(petId)
+                .orElseThrow(() -> new FenceException(FENCE_INFO_NOT_FOUND));
+
+        double distance = haversine(
+                latitude.doubleValue(),
+                longitude.doubleValue(),
+                fence.getCenterLatitude().doubleValue(),
+                fence.getCenterLongitude().doubleValue()
+        );
+
+        BigDecimal distanceMeter = BigDecimal.valueOf(distance).setScale(2, RoundingMode.HALF_UP);
+        boolean insideFence = distanceMeter.compareTo(BigDecimal.valueOf(fence.getRadius())) <= 0;
+
+        return FenceLocationCheckResponse.toDto(insideFence, distanceMeter, fence.getRadius());
+    }
+
+    /**
+     * 하버사인 공식을 사용해 두 좌표 간의 거리(미터)를 계산합니다.
+     *
+     * @param lat1 시작 지점 위도
+     * @param lon1 시작 지점 경도
+     * @param lat2 도착 지점 위도
+     * @param lon2 도착 지점 경도
+     * @return 두 좌표 간의 거리(미터)
+     */
+    private double haversine(double lat1, double lon1, double lat2, double lon2) {
+        final int earthRadiusKm = 6371;
+
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return earthRadiusKm * c * 1000;
+    }
 }

--- a/src/main/java/com/dodo/backend/fence/socket/FenceSocketType.java
+++ b/src/main/java/com/dodo/backend/fence/socket/FenceSocketType.java
@@ -1,0 +1,10 @@
+package com.dodo.backend.fence.socket;
+
+/**
+ * 울타리 웹소켓 메시지 타입을 정의하는 Enum입니다.
+ */
+public enum FenceSocketType {
+    SEND,
+    SUCCESS,
+    ERROR
+}

--- a/src/main/java/com/dodo/backend/fence/socket/FenceWebSocketMessage.java
+++ b/src/main/java/com/dodo/backend/fence/socket/FenceWebSocketMessage.java
@@ -1,0 +1,47 @@
+package com.dodo.backend.fence.socket;
+
+import lombok.*;
+
+/**
+ * 울타리 웹소켓 통신 공통 메시지 래퍼 클래스입니다.
+ *
+ * @param <T> 페이로드 타입
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FenceWebSocketMessage<T> {
+
+    private FenceSocketType type;
+    private T payload;
+
+    /**
+     * 성공 메시지를 생성합니다.
+     *
+     * @param payload 응답 페이로드
+     * @param <T>     페이로드 타입
+     * @return 성공 래퍼 메시지
+     */
+    public static <T> FenceWebSocketMessage<T> success(T payload) {
+        return FenceWebSocketMessage.<T>builder()
+                .type(FenceSocketType.SUCCESS)
+                .payload(payload)
+                .build();
+    }
+
+    /**
+     * 실패 메시지를 생성합니다.
+     *
+     * @param payload 응답 페이로드
+     * @param <T>     페이로드 타입
+     * @return 실패 래퍼 메시지
+     */
+    public static <T> FenceWebSocketMessage<T> error(T payload) {
+        return FenceWebSocketMessage.<T>builder()
+                .type(FenceSocketType.ERROR)
+                .payload(payload)
+                .build();
+    }
+}

--- a/src/main/java/com/dodo/backend/fence/socket/request/FenceWebSocketRequest.java
+++ b/src/main/java/com/dodo/backend/fence/socket/request/FenceWebSocketRequest.java
@@ -1,0 +1,45 @@
+package com.dodo.backend.fence.socket.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 울타리 웹소켓 요청 DTO 그룹입니다.
+ */
+@Schema(description = "울타리 웹소켓 요청 DTO 그룹")
+public class FenceWebSocketRequest {
+
+    /**
+     * 실시간 위치 전송 요청 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "실시간 위치 전송 요청")
+    public static class FenceLocationRequest {
+
+        @Schema(description = "위도", example = "37.5665")
+        private BigDecimal latitude;
+
+        @Schema(description = "경도", example = "126.9780")
+        private BigDecimal longitude;
+
+        @Schema(description = "측정 시각", example = "2025-10-02T10:55:00")
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime measuredAt;
+    }
+}

--- a/src/main/java/com/dodo/backend/fence/socket/response/FenceWebSocketResponse.java
+++ b/src/main/java/com/dodo/backend/fence/socket/response/FenceWebSocketResponse.java
@@ -1,0 +1,89 @@
+package com.dodo.backend.fence.socket.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 울타리 웹소켓 응답 DTO 그룹입니다.
+ */
+@Schema(description = "울타리 웹소켓 응답 DTO 그룹")
+public class FenceWebSocketResponse {
+
+    /**
+     * 브로드캐스트용 실시간 위치 데이터 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "브로드캐스트 실시간 위치 데이터")
+    public static class FenceLocationBroadcastResponse {
+
+        @Schema(description = "반려동물 ID", example = "1")
+        private Long petId;
+
+        @Schema(description = "위도", example = "37.5665")
+        private BigDecimal latitude;
+
+        @Schema(description = "경도", example = "126.9780")
+        private BigDecimal longitude;
+
+        @Schema(description = "측정 시각", example = "2025-10-02T10:55:00")
+        private LocalDateTime measuredAt;
+
+        @Schema(description = "울타리 내부 여부", example = "true")
+        private Boolean insideFence;
+
+        @Schema(description = "중심점으로부터의 거리(미터)", example = "125.42")
+        private BigDecimal distanceMeter;
+
+        @Schema(description = "설정된 울타리 반경(미터)", example = "500")
+        private Integer radius;
+
+        @Schema(description = "울타리 판정 메시지", example = "설정 반경 500m 이내입니다.")
+        private String message;
+    }
+
+    /**
+     * 개인 응답 성공 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "실시간 위치 수신 성공 응답")
+    public static class FenceLocationSuccessResponse {
+
+        @Schema(description = "응답 코드", example = "200")
+        private int code;
+
+        @Schema(description = "응답 메시지", example = "위치 데이터 수신 및 처리 완료")
+        private String message;
+    }
+
+    /**
+     * 개인 응답 에러 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "실시간 위치 수신 실패 응답")
+    public static class FenceLocationErrorResponse {
+
+        @Schema(description = "에러 코드", example = "404")
+        private int code;
+
+        @Schema(description = "에러 메시지", example = "애완동물을 찾을 수 없습니다.")
+        private String message;
+
+        @Schema(description = "원본 메시지")
+        private Object originalMessage;
+    }
+}

--- a/src/main/java/com/dodo/backend/routepoint/controller/RoutePointController.java
+++ b/src/main/java/com/dodo/backend/routepoint/controller/RoutePointController.java
@@ -75,6 +75,22 @@ public class RoutePointController {
         String currentStatus = (String) result.get("status");
         Long routePointId = (Long) result.get("routePointId");
 
+        if (!"IN_PROGRESS".equals(currentStatus)) {
+            RouteDataErrorResponse errorPayload = RouteDataErrorResponse.toDto(
+                    409,
+                    getInactiveStatusMessage(currentStatus),
+                    currentStatus,
+                    requestData
+            );
+
+            messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/queue/reply",
+                    WebSocketMessage.error(errorPayload)
+            );
+            return;
+        }
+
         RouteDataDetailResponse broadcastPayload = RouteDataDetailResponse.toDto(
                 routePointId,
                 requestData.getLatitude(),
@@ -109,6 +125,22 @@ public class RoutePointController {
     }
 
     /**
+     * 진행 중이 아닌 활동 상태에 대한 사용자 안내 메시지를 반환합니다.
+     *
+     * @param status 현재 활동 상태 문자열
+     * @return 상태별 안내 메시지
+     */
+    private String getInactiveStatusMessage(String status) {
+        if ("COMPLETED".equals(status)) {
+            return "이미 끝난 활동기록입니다.";
+        }
+        if ("CANCELED".equals(status)) {
+            return "취소된 활동기록입니다.";
+        }
+        return "활동이 종료된 상태이므로 데이터를 받을 수 없습니다.";
+    }
+
+    /**
      * 메시지 처리 중 발생하는 예외를 핸들링하여 표준 에러 규격으로 응답합니다.
      *
      * @param e         발생한 예외
@@ -118,9 +150,27 @@ public class RoutePointController {
     public void handleException(Exception e, Principal principal) {
         log.error("웹소켓 처리 중 예외 발생: {}", e.getMessage());
 
+        int code = 500;
+        String message = "서버 내부 오류가 발생했습니다.";
+
+        if (e instanceof IllegalArgumentException) {
+            String rawMessage = e.getMessage() == null ? "" : e.getMessage();
+            if (rawMessage.contains("활동 기록 식별자가 일치하지 않습니다")) {
+                code = 400;
+                message = "잘못된 요청입니다.";
+            } else if (rawMessage.contains("해당 활동 기록을 찾을 수 없습니다")) {
+                code = 404;
+                message = "관련 활동 기록을 찾을 수 없습니다.";
+            } else {
+                code = 400;
+                message = "잘못된 요청입니다.";
+            }
+        }
+
         RouteDataErrorResponse errorPayload = RouteDataErrorResponse.toDto(
-                500,
-                e.getMessage(),
+                code,
+                message,
+                null,
                 null
         );
 

--- a/src/main/java/com/dodo/backend/routepoint/socket/response/WebSocketResponse.java
+++ b/src/main/java/com/dodo/backend/routepoint/socket/response/WebSocketResponse.java
@@ -118,15 +118,19 @@ public class WebSocketResponse {
         private int code;
 
         @Schema(description = "에러 메시지", example = "활동 기록을 찾을 수 없습니다.")
-        private String errorMessage;
+        private String message;
+
+        @Schema(description = "활동 상태", example = "COMPLETED")
+        private String status;
 
         @Schema(description = "원본 데이터")
         private Object originalMessage;
 
-        public static RouteDataErrorResponse toDto(int code, String errorMessage, Object originalMessage) {
+        public static RouteDataErrorResponse toDto(int code, String message, String status, Object originalMessage) {
             return RouteDataErrorResponse.builder()
                     .code(code)
-                    .errorMessage(errorMessage)
+                    .message(message)
+                    .status(status)
                     .originalMessage(originalMessage)
                     .build();
         }

--- a/src/main/resources/templates/websocket/socket-test.html
+++ b/src/main/resources/templates/websocket/socket-test.html
@@ -53,8 +53,12 @@
     <div class="card">
         <div class="card-title"><i class="fas fa-key"></i> 인증 및 연결 설정</div>
         <div class="input-group">
-            <label style="font-size: 12px; color: #666; font-weight: 600;">액세스 토큰 (Access Token)</label>
-            <input type="text" id="token" class="form-control" onchange="saveToken()" style="margin-top:5px;" placeholder="Bearer 제외한 토큰 값을 입력하세요">
+            <label style="font-size: 12px; color: #666; font-weight: 600;">유저 액세스 토큰 (구독용)</label>
+            <input type="text" id="userToken" class="form-control" onchange="saveToken()" style="margin-top:5px;" placeholder="Bearer 제외한 유저 토큰 값을 입력하세요">
+        </div>
+        <div class="input-group" style="margin-top:10px;">
+            <label style="font-size: 12px; color: #666; font-weight: 600;">디바이스 액세스 토큰 (전송용)</label>
+            <input type="text" id="deviceToken" class="form-control" onchange="saveToken()" style="margin-top:5px;" placeholder="Bearer 제외한 디바이스 토큰 값을 입력하세요">
         </div>
         <div class="grid-2" style="margin-top:15px;">
             <button onclick="connect()" id="btnConnect" class="btn btn-primary"><i class="fas fa-link"></i> 연결하기</button>
@@ -87,6 +91,27 @@
         </button>
     </div>
 
+    <div class="card">
+        <div class="card-title"><i class="fas fa-map-marked-alt"></i> 울타리 위치 데이터 시뮬레이션</div>
+        <div class="grid-2" style="margin-bottom:15px;">
+            <div>
+                <label style="font-size: 11px; color: #888;">반려동물 ID</label>
+                <input type="number" id="petId" class="form-control" value="1">
+            </div>
+            <div>
+                <label style="font-size: 11px; color: #888;">전송 주기 (ms)</label>
+                <input type="number" id="fenceInterval" class="form-control" value="1000">
+            </div>
+        </div>
+        <div class="grid-2">
+            <button onclick="startFenceAutoSend()" id="btnFenceStart" class="btn btn-success btn-disabled"><i class="fas fa-play"></i> 울타리 자동 전송 시작</button>
+            <button onclick="stopFenceAutoSend()" id="btnFenceStop" class="btn btn-danger btn-disabled"><i class="fas fa-stop"></i> 울타리 전송 중단</button>
+        </div>
+        <button onclick="sendFenceOnce()" id="btnFenceSendOnce" class="btn btn-secondary btn-disabled" style="margin-top: 10px; background: #228be6;">
+            <i class="fas fa-paper-plane"></i> 울타리 수동 전송 (1회)
+        </button>
+    </div>
+
     <div class="card" style="background: rgba(33, 37, 41, 0.05); border: none;">
         <div class="card-title"><i class="fas fa-terminal"></i> 실시간 로그 터미널</div>
         <div id="logs" class="log-container"></div>
@@ -94,27 +119,45 @@
 </div>
 
 <script>
-    var stompClient = null;
+    var userClient = null;
+    var deviceClient = null;
+    var isUserConnected = false;
+    var isDeviceConnected = false;
     var timerId = null;
+    var fenceTimerId = null;
+    var fenceSub = null;
+    var currentFenceSubPetId = null;
     var currentLat = 37.5665;
     var currentLng = 126.9780;
+    var fenceLat = 37.5665;
+    var fenceLng = 126.9780;
 
     window.onload = function() {
-        var savedToken = localStorage.getItem("dodo_token");
-        if(savedToken) document.getElementById("token").value = savedToken;
+        var savedUserToken = localStorage.getItem("dodo_user_token");
+        var savedDeviceToken = localStorage.getItem("dodo_device_token");
+        if (savedUserToken) document.getElementById("userToken").value = savedUserToken;
+        if (savedDeviceToken) document.getElementById("deviceToken").value = savedDeviceToken;
     }
 
-    function saveToken() { localStorage.setItem("dodo_token", document.getElementById("token").value); }
+    function saveToken() {
+        localStorage.setItem("dodo_user_token", document.getElementById("userToken").value);
+        localStorage.setItem("dodo_device_token", document.getElementById("deviceToken").value);
+    }
 
-    function setStatus(isConnected) {
+    function setStatus() {
+        var isConnected = isUserConnected && isDeviceConnected;
         var badge = document.getElementById("connectionStatus");
-        badge.innerHTML = isConnected ? '<i class="fas fa-check-circle"></i> 연결됨' : '<i class="fas fa-plug"></i> 연결 해제됨';
+        badge.innerHTML = isConnected
+            ? '<i class="fas fa-check-circle"></i> 연결됨 (USER+DEVICE)'
+            : '<i class="fas fa-plug"></i> 연결 해제됨';
         badge.className = isConnected ? "status-badge connected" : "status-badge";
 
         document.getElementById("btnConnect").classList.toggle("btn-disabled", isConnected);
         document.getElementById("btnDisconnect").classList.toggle("btn-disabled", !isConnected);
         document.getElementById("btnStart").classList.toggle("btn-disabled", !isConnected);
         document.getElementById("btnSendOnce").classList.toggle("btn-disabled", !isConnected);
+        document.getElementById("btnFenceStart").classList.toggle("btn-disabled", !isConnected);
+        document.getElementById("btnFenceSendOnce").classList.toggle("btn-disabled", !isConnected);
     }
 
     function log(type, message) {
@@ -138,45 +181,72 @@
     }
 
     function connect() {
-        var token = document.getElementById("token").value;
-        if (!token) { alert("토큰을 입력하세요!"); return; }
+        var userToken = document.getElementById("userToken").value;
+        var deviceToken = document.getElementById("deviceToken").value;
+
+        if (!userToken || !deviceToken) {
+            alert("유저 토큰과 디바이스 토큰을 모두 입력하세요!");
+            return;
+        }
 
         var historyId = document.getElementById("historyId").value;
-        var socket = new WebSocket('ws://localhost:8080/ws-dodo');
-        stompClient = Stomp.over(socket);
-        stompClient.debug = null;
+        var petId = document.getElementById("petId").value;
 
-        stompClient.debug = function(str) {
+        var userSocket = new WebSocket('ws://localhost:8080/ws-dodo');
+        userClient = Stomp.over(userSocket);
+        userClient.debug = null;
+
+        userClient.debug = function(str) {
             if(str.includes("RECEIPT")) log('RCPT', '서버 영수증(Receipt) 수신 완료');
         };
 
-        stompClient.connect({'Authorization': 'Bearer ' + token}, function (frame) {
-            setStatus(true);
-            log('INFO', '서버에 성공적으로 연결되었습니다.');
+        userClient.connect({'Authorization': 'Bearer ' + userToken}, function () {
+            isUserConnected = true;
+            setStatus();
+            log('INFO', 'USER 소켓 연결 성공');
 
-            stompClient.subscribe('/user/queue/reply', function (response) {
-                log('ACK', response.body);
-            });
-
-            stompClient.subscribe('/sub/activities/history/routes/' + historyId, function (response) {
+            userClient.subscribe('/sub/activities/history/routes/' + historyId, function (response) {
                 log('RECV', response.body);
             });
 
-            log('INFO', `구독 완료: 개인 응답 채널 및 활동(${historyId}) 채널`);
+            subscribeFenceChannel();
+            log('INFO', `USER 구독 완료: 활동(${historyId}), 울타리(${petId})`);
+
+            var deviceSocket = new WebSocket('ws://localhost:8080/ws-dodo');
+            deviceClient = Stomp.over(deviceSocket);
+            deviceClient.debug = null;
+
+            deviceClient.connect({'Authorization': 'Bearer ' + deviceToken}, function () {
+                isDeviceConnected = true;
+                setStatus();
+                log('INFO', 'DEVICE 소켓 연결 성공');
+
+                deviceClient.subscribe('/user/queue/reply', function (response) {
+                    log('ACK', response.body);
+                });
+
+            }, function (error) {
+                isDeviceConnected = false;
+                setStatus();
+                var errMsg = error.headers ? error.headers.message : error;
+                log('ERR', 'DEVICE 연결 실패: ' + errMsg);
+            });
+
         }, function (error) {
-            setStatus(false);
+            isUserConnected = false;
+            setStatus();
             var errMsg = error.headers ? error.headers.message : error;
-            log('ERR', '연결 실패: ' + errMsg);
+            log('ERR', 'USER 연결 실패: ' + errMsg);
         });
     }
 
     function sendOnce() {
-        if (!stompClient) return;
+        if (!deviceClient || !deviceClient.connected) return;
         var historyId = document.getElementById("historyId").value;
         var payload = createPayload();
         var headers = { receipt: 'rcpt-' + Date.now() };
 
-        stompClient.send("/pub/activities/history/routes/" + historyId, headers, payload);
+        deviceClient.send("/pub/activities/history/routes/" + historyId, headers, payload);
         log('SEND', payload);
     }
 
@@ -212,10 +282,78 @@
         document.getElementById("btnStop").classList.add("btn-disabled");
     }
 
+    function sendFenceOnce() {
+        if (!deviceClient || !deviceClient.connected) return;
+        subscribeFenceChannel();
+        var petId = document.getElementById("petId").value;
+        var payload = createFencePayload();
+        var headers = { receipt: 'fence-rcpt-' + Date.now() };
+
+        deviceClient.send("/pub/fence/location/" + petId, headers, payload);
+        log('SEND', payload);
+    }
+
+    function createFencePayload() {
+        fenceLat += (Math.random() - 0.5) * 0.0002;
+        fenceLng += (Math.random() - 0.5) * 0.0002;
+
+        return JSON.stringify({
+            "type": "SEND",
+            "payload": {
+                "latitude": parseFloat(fenceLat.toFixed(7)),
+                "longitude": parseFloat(fenceLng.toFixed(7)),
+                "measuredAt": new Date(new Date().getTime() - (new Date().getTimezoneOffset() * 60000)).toISOString().slice(0, 19)
+            }
+        });
+    }
+
+    function startFenceAutoSend() {
+        subscribeFenceChannel();
+        fenceTimerId = setInterval(sendFenceOnce, document.getElementById("fenceInterval").value);
+        log('INFO', '울타리 위치 데이터 자동 전송을 시작합니다.');
+        document.getElementById("btnFenceStart").classList.add("btn-disabled");
+        document.getElementById("btnFenceStop").classList.remove("btn-disabled");
+    }
+
+    function stopFenceAutoSend() {
+        clearInterval(fenceTimerId);
+        log('INFO', '울타리 자동 전송이 중단되었습니다.');
+        document.getElementById("btnFenceStart").classList.remove("btn-disabled");
+        document.getElementById("btnFenceStop").classList.add("btn-disabled");
+    }
+
+    function subscribeFenceChannel() {
+        if (!userClient || !userClient.connected) return;
+        var petId = document.getElementById("petId").value;
+        if (!petId) return;
+
+        if (currentFenceSubPetId === petId && fenceSub) return;
+
+        if (fenceSub) {
+            fenceSub.unsubscribe();
+            fenceSub = null;
+        }
+
+        fenceSub = userClient.subscribe('/sub/fence/location/' + petId, function (response) {
+            log('RECV', response.body);
+        });
+
+        currentFenceSubPetId = petId;
+        log('INFO', '울타리 구독 완료: /sub/fence/location/' + petId);
+    }
+
     function disconnect() {
-        if (stompClient) stompClient.disconnect();
+        if (userClient) userClient.disconnect();
+        if (deviceClient) deviceClient.disconnect();
+        userClient = null;
+        deviceClient = null;
+        isUserConnected = false;
+        isDeviceConnected = false;
+        fenceSub = null;
+        currentFenceSubPetId = null;
         stopAutoSend();
-        setStatus(false);
+        stopFenceAutoSend();
+        setStatus();
         log('INFO', '서버와의 연결이 종료되었습니다.');
     }
 </script>

--- a/src/test/java/com/dodo/backend/common/subscribe/RedisSubscriberTest.java
+++ b/src/test/java/com/dodo/backend/common/subscribe/RedisSubscriberTest.java
@@ -89,4 +89,36 @@ class RedisSubscriberTest {
 
         log.info("테스트 종료: 성공 (무시됨 확인)");
     }
+
+    /**
+     * petId 기반 Wrapper 메시지를 수신했을 때, fence 구독 채널로 전송되는지 테스트합니다.
+     */
+    @Test
+    @DisplayName("petId Wrapper 메시지를 수신하면 fence 채널로 내부 메시지만 전송")
+    void onMessage_Fence_Success() {
+        log.info("테스트 시작: onMessage_Fence_Success");
+
+        // given
+        String wrapperJson = "{" +
+                "\"petId\": 7," +
+                "\"message\": {" +
+                "\"type\": \"SUCCESS\"," +
+                "\"payload\": {" +
+                "\"insideFence\": true," +
+                "\"distanceMeter\": 12.34" +
+                "}" +
+                "}" +
+                "}";
+
+        // when
+        redisSubscriber.onMessage(wrapperJson);
+
+        // then
+        verify(messagingTemplate).convertAndSend(
+                eq("/sub/fence/location/7"),
+                argThat((String json) -> json.contains("\"insideFence\":true"))
+        );
+
+        log.info("테스트 종료: 성공");
+    }
 }

--- a/src/test/java/com/dodo/backend/fence/controller/FenceWebSocketControllerTest.java
+++ b/src/test/java/com/dodo/backend/fence/controller/FenceWebSocketControllerTest.java
@@ -1,0 +1,168 @@
+package com.dodo.backend.fence.controller;
+
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceLocationCheckResponse;
+import com.dodo.backend.fence.exception.FenceErrorCode;
+import com.dodo.backend.fence.exception.FenceException;
+import com.dodo.backend.fence.service.FenceService;
+import com.dodo.backend.fence.socket.FenceSocketType;
+import com.dodo.backend.fence.socket.FenceWebSocketMessage;
+import com.dodo.backend.fence.socket.request.FenceWebSocketRequest.FenceLocationRequest;
+import com.dodo.backend.fence.socket.response.FenceWebSocketResponse.FenceLocationErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.math.BigDecimal;
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@link FenceWebSocketController}의 웹소켓 메시지 수신/응답 흐름을 검증하는 테스트 클래스입니다.
+ */
+@ExtendWith(MockitoExtension.class)
+class FenceWebSocketControllerTest {
+
+    @InjectMocks
+    private FenceWebSocketController fenceWebSocketController;
+
+    @Mock
+    private FenceService fenceService;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ChannelTopic topic;
+
+    @Spy
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private Principal principal;
+
+    /**
+     * 정상적인 위치 메시지 수신 시 Redis 발행과 개인 ACK 응답이 수행되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("울타리 위치 수신 성공: Redis 발행 및 SUCCESS ACK 전송")
+    void receiveFenceLocation_Success() throws Exception {
+        // given
+        Long petId = 2L;
+        FenceLocationRequest request = FenceLocationRequest.builder()
+                .latitude(new BigDecimal("37.5665"))
+                .longitude(new BigDecimal("126.9780"))
+                .measuredAt(LocalDateTime.now())
+                .build();
+
+        FenceWebSocketMessage<FenceLocationRequest> message = FenceWebSocketMessage.<FenceLocationRequest>builder()
+                .type(FenceSocketType.SEND)
+                .payload(request)
+                .build();
+
+        given(principal.getName()).willReturn("device-user");
+        given(topic.getTopic()).willReturn("route-points");
+        given(objectMapper.writeValueAsString(any()))
+                .willReturn("{\"petId\":2,\"insideFence\":true}");
+        given(fenceService.checkFenceLocationByPet(eq(petId), any(), any(), any()))
+                .willReturn(FenceLocationCheckResponse.toDto(true, new BigDecimal("14.80"), 500));
+
+        // when
+        fenceWebSocketController.receiveFenceLocation(petId, message, principal);
+
+        // then
+        verify(fenceService).checkFenceLocationByPet(eq(petId), any(), any(), any());
+        verify(redisTemplate).convertAndSend(eq("route-points"), argThat((String json) ->
+                json.contains("\"petId\":2") && json.contains("\"insideFence\":true")
+        ));
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("device-user"),
+                eq("/queue/reply"),
+                any(FenceWebSocketMessage.class)
+        );
+    }
+
+    /**
+     * 서비스 레이어에서 FenceException 발생 시 ERROR ACK가 전송되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("울타리 위치 수신 실패: FenceException 발생 시 ERROR ACK 전송")
+    void receiveFenceLocation_FenceException() {
+        // given
+        Long petId = 999L;
+        FenceLocationRequest request = FenceLocationRequest.builder()
+                .latitude(new BigDecimal("37.5665"))
+                .longitude(new BigDecimal("126.9780"))
+                .measuredAt(LocalDateTime.now())
+                .build();
+
+        FenceWebSocketMessage<FenceLocationRequest> message = FenceWebSocketMessage.<FenceLocationRequest>builder()
+                .type(FenceSocketType.SEND)
+                .payload(request)
+                .build();
+
+        given(principal.getName()).willReturn("device-user");
+        given(fenceService.checkFenceLocationByPet(eq(petId), any(), any(), any()))
+                .willThrow(new FenceException(FenceErrorCode.PET_NOT_FOUND));
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+
+        // when
+        fenceWebSocketController.receiveFenceLocation(petId, message, principal);
+
+        // then
+        verify(redisTemplate, never()).convertAndSend(anyString(), anyString());
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("device-user"),
+                eq("/queue/reply"),
+                payloadCaptor.capture()
+        );
+
+        Object captured = payloadCaptor.getValue();
+        assertInstanceOf(FenceWebSocketMessage.class, captured);
+        FenceWebSocketMessage<?> ack = (FenceWebSocketMessage<?>) captured;
+        assertEquals(FenceSocketType.ERROR, ack.getType());
+        assertInstanceOf(FenceLocationErrorResponse.class, ack.getPayload());
+    }
+
+    /**
+     * 유효하지 않은 메시지 타입(SEND 아님) 수신 시 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("울타리 위치 수신 실패: 잘못된 메시지 타입이면 IllegalArgumentException 발생")
+    void receiveFenceLocation_InvalidMessageType() {
+        // given
+        Long petId = 1L;
+        FenceLocationRequest request = FenceLocationRequest.builder()
+                .latitude(new BigDecimal("37.5665"))
+                .longitude(new BigDecimal("126.9780"))
+                .measuredAt(LocalDateTime.now())
+                .build();
+
+        FenceWebSocketMessage<FenceLocationRequest> message = FenceWebSocketMessage.<FenceLocationRequest>builder()
+                .type(FenceSocketType.SUCCESS)
+                .payload(request)
+                .build();
+
+        // when & then
+        assertThrows(IllegalArgumentException.class,
+                () -> fenceWebSocketController.receiveFenceLocation(petId, message, principal));
+    }
+}

--- a/src/test/java/com/dodo/backend/routepoint/controller/RoutePointControllerTest.java
+++ b/src/test/java/com/dodo/backend/routepoint/controller/RoutePointControllerTest.java
@@ -19,11 +19,13 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -138,5 +140,47 @@ class RoutePointControllerTest {
                 .isInstanceOf(IllegalArgumentException.class);
 
         log.info("테스트 종료: 성공 (예외 발생 확인됨)");
+    }
+
+    /**
+     * 활동이 종료 상태(COMPLETED/CANCELED)일 때는 성공 응답이 아닌 에러 ACK가 전송되는지 테스트합니다.
+     */
+    @Test
+    @DisplayName("활동 종료 상태이면 Redis 발행 없이 ERROR ACK를 전송한다")
+    void receiveRouteData_InactiveStatus_ErrorAck() {
+        log.info("테스트 시작: receiveRouteData_InactiveStatus_ErrorAck");
+
+        // given
+        Long historyId = 4L;
+        RouteDataRequest requestData = RouteDataRequest.builder()
+                .historyId(historyId)
+                .latitude(BigDecimal.valueOf(37.5665))
+                .longitude(BigDecimal.valueOf(126.9780))
+                .measuredAt(LocalDateTime.now())
+                .build();
+
+        WebSocketMessage<RouteDataRequest> message = WebSocketMessage.<RouteDataRequest>builder()
+                .payload(requestData)
+                .build();
+
+        given(principal.getName()).willReturn("user1");
+        Map<String, Object> serviceResult = new HashMap<>();
+        serviceResult.put("status", "COMPLETED");
+        serviceResult.put("routePointId", null);
+        given(routePointService.saveRouteAndGetStatus(eq(historyId), any()))
+                .willReturn(serviceResult);
+
+        // when
+        routePointController.receiveRouteData(historyId, message, principal);
+
+        // then
+        verify(redisTemplate, never()).convertAndSend(anyString(), anyString());
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("user1"),
+                eq("/queue/reply"),
+                any(WebSocketMessage.class)
+        );
+
+        log.info("테스트 종료: 성공");
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- pub/fence/location/{petId} 위치 송신 처리 및 울타리 내부/외부 판정 로직 추가
- sub/fence/location/{petId} 브로드캐스트 전파와 /user/queue/reply ACK 응답 규격 적용
- STOMP 인증 정책 분리(pub: 디바이스 토큰, sub: 유저 토큰)
- FenceWebSocketControllerTest 추가(성공/예외/유효성 케이스)
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #110
<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 울타리 기능 구현을 위해서 실시간 위치 데이터 전송하는거랑 수신하는거 구현했습니다.
- 디바이스에서 송신할때는 디바이스 토큰 프론트에서는 수신할때 그냥 Access Token으로 검증하게 했습니다. 