### PR TITLE
✨ Feat: 지도 울타리 범위 표시 및 울타리 범위 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/fence/controller/FenceController.java
+++ b/src/main/java/com/dodo/backend/fence/controller/FenceController.java
@@ -6,6 +6,8 @@ import com.dodo.backend.fence.dto.request.FenceRequest.FenceRangeUpdateRequest;
 import com.dodo.backend.fence.dto.request.FenceRequest.FenceToggleRequest;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeUpdateResponse;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceBoundaryListResponse;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceBoundaryResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceStatusResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceToggleResponse;
 import com.dodo.backend.fence.service.FenceService;
@@ -222,5 +224,92 @@ public class FenceController {
         log.info("울타리 범위 수정 요청 - User: {}, FenceId: {}", userId, fenceId);
 
         return ResponseEntity.ok(fenceService.updateFenceRange(userId, fenceId, request));
+    }
+
+    /**
+     * 지도에 표시할 울타리 경계 단건 정보를 조회합니다.
+     *
+     * @param fenceId     조회할 울타리 ID
+     * @param userDetails 인증된 사용자 정보
+     * @return 울타리 경계 단건 응답
+     */
+    @Operation(summary = "울타리 경계 조회", description = "지도에 표시할 울타리 중심 좌표와 반경을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "울타리 정보 조회를 성공했습니다.",
+                    content = @Content(schema = @Schema(implementation = FenceBoundaryResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "해당 울타리에 대한 접근 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"해당 울타리에 대한 접근 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 울타리 정보입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"존재하지 않는 울타리 정보입니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @GetMapping("/{fenceId}/boundary")
+    public ResponseEntity<FenceBoundaryResponse> getFenceBoundary(
+            @PathVariable Long fenceId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        log.info("울타리 경계 조회 요청 - User: {}, FenceId: {}", userId, fenceId);
+
+        return ResponseEntity.ok(fenceService.getFenceBoundary(userId, fenceId));
+    }
+
+    /**
+     * 지도에 표시할 울타리 경계 목록을 조회합니다.
+     *
+     * @param userDetails 인증된 사용자 정보
+     * @return 울타리 경계 목록 응답
+     */
+    @Operation(summary = "울타리 경계 목록 조회", description = "사용자가 접근 가능한 모든 울타리 중심 좌표와 반경을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "울타리 목록 조회를 성공했습니다.",
+                    content = @Content(schema = @Schema(implementation = FenceBoundaryListResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"),
+                                    @ExampleObject(name = "400 Fence Already Exists", value = "{\"status\": 400, \"message\": \"이미 울타리가 존재합니다.\"}")
+                            })),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "해당 울타리에 대한 접근 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"해당 울타리에 대한 접근 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 울타리 정보입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"존재하지 않는 울타리 정보입니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @GetMapping("/boundaries")
+    public ResponseEntity<FenceBoundaryListResponse> getFenceBoundaries(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        log.info("울타리 경계 목록 조회 요청 - User: {}", userId);
+
+        return ResponseEntity.ok(fenceService.getFenceBoundaries(userId));
     }
 }

--- a/src/main/java/com/dodo/backend/fence/dto/request/FenceRequest.java
+++ b/src/main/java/com/dodo/backend/fence/dto/request/FenceRequest.java
@@ -55,7 +55,8 @@ public class FenceRequest {
         @Schema(description = "울타리 중심 경도", example = "127.0000")
         @DecimalMin(value = "-180.0", message = "잘못된 요청입니다.")
         @DecimalMax(value = "180.0", message = "잘못된 요청입니다.")
-        private BigDecimal centerLongtitude;
+        @JsonAlias("centerLongtitude")
+        private BigDecimal centerLongitude;
 
         @Schema(description = "울타리 반경(미터)", example = "1000")
         @Positive(message = "잘못된 요청입니다.")
@@ -86,7 +87,6 @@ public class FenceRequest {
         @NotNull(message = "잘못된 요청입니다.")
         @DecimalMin(value = "-180.0", message = "잘못된 요청입니다.")
         @DecimalMax(value = "180.0", message = "잘못된 요청입니다.")
-        @JsonAlias("centerLongtitude")
         private BigDecimal centerLongitude;
 
         @Schema(description = "울타리 이름", example = "집 주변 울타리")

--- a/src/main/java/com/dodo/backend/fence/dto/response/FenceResponse.java
+++ b/src/main/java/com/dodo/backend/fence/dto/response/FenceResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * 울타리(Fence) 도메인 응답 DTO를 정의하는 그룹 클래스입니다.
@@ -114,6 +115,176 @@ public class FenceResponse {
         public static FenceRangeUpdateResponse toDto(String message) {
             return FenceRangeUpdateResponse.builder()
                     .message(message)
+                    .build();
+        }
+    }
+
+    /**
+     * 지도에 표시할 울타리 경계 단건 정보를 반환하는 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "울타리 경계 단건 조회 응답")
+    public static class FenceBoundaryResponse {
+
+        @Schema(description = "처리 결과 메시지", example = "울타리 정보 조회를 성공했습니다.")
+        private String message;
+
+        @Schema(description = "울타리 중심점 좌표")
+        private Center center;
+
+        @Schema(description = "울타리 반경(미터)", example = "500")
+        private Integer radius;
+
+        @Schema(description = "울타리 ID", example = "1")
+        private Long fenceId;
+
+        /**
+         * 울타리 중심점 좌표 DTO입니다.
+         */
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @Schema(description = "울타리 중심점")
+        public static class Center {
+
+            @Schema(description = "위도", example = "37.5665")
+            private BigDecimal latitude;
+
+            @Schema(description = "경도", example = "126.9780")
+            private BigDecimal longitude;
+        }
+
+        /**
+         * 울타리 경계 단건 응답 DTO를 생성합니다.
+         *
+         * @param message   처리 결과 메시지
+         * @param latitude  중심 위도
+         * @param longitude 중심 경도
+         * @param radius    반경(미터)
+         * @param fenceId   울타리 ID
+         * @return 생성된 응답 DTO
+         */
+        public static FenceBoundaryResponse toDto(
+                String message,
+                BigDecimal latitude,
+                BigDecimal longitude,
+                Integer radius,
+                Long fenceId
+        ) {
+            return FenceBoundaryResponse.builder()
+                    .message(message)
+                    .center(Center.builder()
+                            .latitude(latitude)
+                            .longitude(longitude)
+                            .build())
+                    .radius(radius)
+                    .fenceId(fenceId)
+                    .build();
+        }
+    }
+
+    /**
+     * 울타리 경계 목록 조회 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "울타리 경계 목록 조회 응답")
+    public static class FenceBoundaryListResponse {
+
+        @Schema(description = "처리 결과 메시지", example = "울타리 목록 조회를 성공했습니다.")
+        private String message;
+
+        @Schema(description = "울타리 경계 목록")
+        private List<FenceBoundaryItem> boundaries;
+
+        /**
+         * 울타리 경계 목록 조회 응답 DTO를 생성합니다.
+         *
+         * @param message    처리 결과 메시지
+         * @param boundaries 울타리 경계 목록
+         * @return 생성된 응답 DTO
+         */
+        public static FenceBoundaryListResponse toDto(String message, List<FenceBoundaryItem> boundaries) {
+            return FenceBoundaryListResponse.builder()
+                    .message(message)
+                    .boundaries(boundaries)
+                    .build();
+        }
+    }
+
+    /**
+     * 울타리 경계 목록의 단건 항목 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "울타리 경계 목록 단건 항목")
+    public static class FenceBoundaryItem {
+
+        @Schema(description = "울타리 ID", example = "1")
+        private Long fenceId;
+
+        @Schema(description = "울타리 이름", example = "집 주변 울타리")
+        private String fenceName;
+
+        @Schema(description = "울타리 중심점 좌표")
+        private FenceBoundaryResponse.Center center;
+
+        @Schema(description = "울타리 반경(미터)", example = "500")
+        private Integer radius;
+
+        @Schema(description = "울타리 활성화 여부", example = "true")
+        private Boolean isActive;
+
+        @Schema(description = "반려동물 ID", example = "1")
+        private Long petId;
+
+        @Schema(description = "반려동물 이름", example = "도도")
+        private String petName;
+
+        @Schema(description = "반려동물 프로필 이미지 URL", example = "https://cdn.dodo.com/pets/1/profile.jpg")
+        private String petImageUrl;
+
+        /**
+         * 울타리 경계 목록 단건 항목 DTO를 생성합니다.
+         *
+         * @param fenceId      울타리 ID
+         * @param fenceName    울타리 이름
+         * @param latitude     중심 위도
+         * @param longitude    중심 경도
+         * @param radius       반경(미터)
+         * @param isActive     울타리 활성화 여부
+         * @param petId        반려동물 ID
+         * @param petName      반려동물 이름
+         * @param petImageUrl  반려동물 프로필 이미지 URL
+         * @return 생성된 응답 DTO
+         */
+        public static FenceBoundaryItem toDto(
+                Long fenceId,
+                String fenceName,
+                BigDecimal latitude,
+                BigDecimal longitude,
+                Integer radius,
+                Boolean isActive,
+                Long petId,
+                String petName,
+                String petImageUrl
+        ) {
+            return FenceBoundaryItem.builder()
+                    .fenceId(fenceId)
+                    .fenceName(fenceName)
+                    .center(FenceBoundaryResponse.Center.builder()
+                            .latitude(latitude)
+                            .longitude(longitude)
+                            .build())
+                    .radius(radius)
+                    .isActive(isActive)
+                    .petId(petId)
+                    .petName(petName)
+                    .petImageUrl(petImageUrl)
                     .build();
         }
     }

--- a/src/main/java/com/dodo/backend/fence/exception/FenceErrorCode.java
+++ b/src/main/java/com/dodo/backend/fence/exception/FenceErrorCode.java
@@ -23,6 +23,13 @@ public enum FenceErrorCode implements BaseErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
 
     /**
+     * 반려동물에 이미 울타리가 설정되어 중복 생성이 불가능한 경우 사용합니다.
+     * <p>
+     * HTTP {@code 400 Bad Request}를 반환합니다.
+     */
+    FENCE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 울타리가 존재합니다."),
+
+    /**
      * 인증되지 않은 사용자가 로그인이 필요한 기능을 호출한 경우 사용합니다.
      * <p>
      * HTTP {@code 401 Unauthorized}를 반환합니다.

--- a/src/main/java/com/dodo/backend/fence/repository/FenceRepository.java
+++ b/src/main/java/com/dodo/backend/fence/repository/FenceRepository.java
@@ -3,6 +3,7 @@ package com.dodo.backend.fence.repository;
 import com.dodo.backend.fence.entity.Fence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -17,5 +18,13 @@ public interface FenceRepository extends JpaRepository<Fence, Long> {
      * @return 울타리 엔티티(Optional)
      */
     Optional<Fence> findByPet_PetId(Long petId);
+
+    /**
+     * 반려동물 ID 목록으로 울타리 정보를 조회합니다.
+     *
+     * @param petIds 반려동물 ID 목록
+     * @return 울타리 엔티티 목록
+     */
+    List<Fence> findAllByPet_PetIdIn(List<Long> petIds);
 
 }

--- a/src/main/java/com/dodo/backend/fence/service/FenceService.java
+++ b/src/main/java/com/dodo/backend/fence/service/FenceService.java
@@ -4,8 +4,10 @@ import com.dodo.backend.fence.dto.request.FenceRequest.FenceRangeRequest;
 import com.dodo.backend.fence.dto.request.FenceRequest.FenceRangeUpdateRequest;
 import com.dodo.backend.fence.dto.request.FenceRequest.FenceToggleRequest;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceLocationCheckResponse;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceBoundaryListResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeUpdateResponse;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceBoundaryResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceStatusResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceToggleResponse;
 
@@ -48,6 +50,23 @@ public interface FenceService {
      * @return 수정 결과 응답 DTO
      */
     FenceRangeUpdateResponse updateFenceRange(UUID userId, Long fenceId, FenceRangeUpdateRequest request);
+
+    /**
+     * 지도에 표시할 울타리 경계 단건 정보를 조회합니다.
+     *
+     * @param userId  요청한 사용자 ID
+     * @param fenceId 조회할 울타리 ID
+     * @return 울타리 경계 단건 응답 DTO
+     */
+    FenceBoundaryResponse getFenceBoundary(UUID userId, Long fenceId);
+
+    /**
+     * 지도에 표시할 울타리 경계 목록을 조회합니다.
+     *
+     * @param userId 요청한 사용자 ID
+     * @return 울타리 경계 목록 응답 DTO
+     */
+    FenceBoundaryListResponse getFenceBoundaries(UUID userId);
 
     /**
      * 반려동물의 울타리 활성화 상태를 조회합니다.

--- a/src/main/java/com/dodo/backend/fence/service/FenceServiceImpl.java
+++ b/src/main/java/com/dodo/backend/fence/service/FenceServiceImpl.java
@@ -3,15 +3,19 @@ package com.dodo.backend.fence.service;
 import com.dodo.backend.fence.dto.request.FenceRequest.FenceRangeRequest;
 import com.dodo.backend.fence.dto.request.FenceRequest.FenceRangeUpdateRequest;
 import com.dodo.backend.fence.dto.request.FenceRequest.FenceToggleRequest;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceBoundaryItem;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceBoundaryListResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceLocationCheckResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeUpdateResponse;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceBoundaryResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceStatusResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceToggleResponse;
 import com.dodo.backend.fence.entity.Fence;
 import com.dodo.backend.fence.exception.FenceException;
 import com.dodo.backend.fence.mapper.FenceMapper;
 import com.dodo.backend.fence.repository.FenceRepository;
+import com.dodo.backend.imagefile.service.ImageFileService;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.pet.service.PetService;
 import com.dodo.backend.userpet.service.UserPetService;
@@ -22,10 +26,14 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.dodo.backend.fence.exception.FenceErrorCode.FENCE_INFO_NOT_FOUND;
 import static com.dodo.backend.fence.exception.FenceErrorCode.FENCE_NOT_FOUND;
+import static com.dodo.backend.fence.exception.FenceErrorCode.FENCE_ALREADY_EXISTS;
+import static com.dodo.backend.fence.exception.FenceErrorCode.FENCE_ACCESS_DENIED;
 import static com.dodo.backend.fence.exception.FenceErrorCode.FENCE_PERMISSION_DENIED;
 import static com.dodo.backend.fence.exception.FenceErrorCode.INVALID_REQUEST;
 import static com.dodo.backend.fence.exception.FenceErrorCode.PET_NOT_FOUND;
@@ -44,13 +52,15 @@ public class FenceServiceImpl implements FenceService {
     private final FenceMapper fenceMapper;
     private final PetService petService;
     private final UserPetService userPetService;
+    private final ImageFileService imageFileService;
 
     /**
      * {@inheritDoc}
      * <p>
      * 1. 반려동물 존재 여부를 검증합니다.
      * 2. 요청 사용자의 반려동물 접근 권한을 검증합니다.
-     * 3. 기존 울타리가 있으면 갱신하고, 없으면 새로 생성합니다.
+     * 3. 동일 반려동물의 기존 울타리 존재 여부를 검증합니다.
+     * 4. 기존 울타리가 없을 때만 새 울타리를 생성합니다.
      */
     @Transactional
     @Override
@@ -64,22 +74,12 @@ public class FenceServiceImpl implements FenceService {
             throw new FenceException(PET_PERMISSION_DENIED);
         }
 
-        Fence savedFence = fenceRepository.findByPet_PetId(request.getPetId())
-                .map(existing -> Fence.builder()
-                        .fenceId(existing.getFenceId())
-                        .pet(existing.getPet())
-                        .name(request.getFenceName())
-                        .centerLatitude(request.getCenterLatitude())
-                        .centerLongitude(request.getCenterLongitude())
-                        .radius(request.getRadius())
-                        .fenceCreatedAt(existing.getFenceCreatedAt())
-                        .fenceIsActive(existing.getFenceIsActive())
-                        .build())
-                .orElseGet(() -> {
-                    Pet pet = petService.getPetById(request.getPetId());
-                    return request.toEntity(pet);
-                });
+        if (fenceRepository.findByPet_PetId(request.getPetId()).isPresent()) {
+            throw new FenceException(FENCE_ALREADY_EXISTS);
+        }
 
+        Pet pet = petService.getPetById(request.getPetId());
+        Fence savedFence = request.toEntity(pet);
         fenceRepository.save(savedFence);
 
         return FenceRangeResponse.toDto("울타리 설정을 완료했습니다.");
@@ -136,7 +136,7 @@ public class FenceServiceImpl implements FenceService {
 
         if (request.getFenceName() == null
                 && request.getCenterLatitude() == null
-                && request.getCenterLongtitude() == null
+                && request.getCenterLongitude() == null
                 && request.getRadius() == null) {
             throw new FenceException(INVALID_REQUEST);
         }
@@ -145,10 +145,87 @@ public class FenceServiceImpl implements FenceService {
                 fenceId,
                 request.getFenceName(),
                 request.getCenterLatitude(),
-                request.getCenterLongtitude(),
+                request.getCenterLongitude(),
                 request.getRadius()
         );
         return FenceRangeUpdateResponse.toDto("울타리 정보를 수정했습니다.");
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * 1. 조회 대상 울타리 존재 여부를 확인합니다.
+     * 2. 요청 사용자의 울타리 접근 권한을 검증합니다.
+     * 3. 울타리 중심 좌표/반경/ID를 응답으로 반환합니다.
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public FenceBoundaryResponse getFenceBoundary(UUID userId, Long fenceId) {
+        Fence fence = fenceRepository.findById(fenceId)
+                .orElseThrow(() -> new FenceException(FENCE_INFO_NOT_FOUND));
+
+        Long petId = fence.getPet().getPetId();
+        if (!userPetService.isApprovedPetOwner(userId, petId)) {
+            throw new FenceException(FENCE_ACCESS_DENIED);
+        }
+
+        return FenceBoundaryResponse.toDto(
+                "울타리 정보 조회를 성공했습니다.",
+                fence.getCenterLatitude(),
+                fence.getCenterLongitude(),
+                fence.getRadius(),
+                fence.getFenceId()
+        );
+    }
+
+    /**
+     * 사용자가 접근 가능한 울타리 경계 목록을 조회합니다.
+     * <p>
+     * <ol>
+     * <li>{@link UserPetService}를 통해 요청 사용자의 승인된(APPROVED) 반려동물 ID 목록을 조회합니다.</li>
+     * <li>승인된 반려동물이 하나도 없으면 {@link FenceException}(FENCE_ACCESS_DENIED)을 발생시킵니다.</li>
+     * <li>조회된 반려동물 ID 목록으로 울타리 목록을 조회합니다.</li>
+     * <li>울타리 데이터가 없으면 {@link FenceException}(FENCE_INFO_NOT_FOUND)을 발생시킵니다.</li>
+     * <li>{@link ImageFileService}에서 반려동물 프로필 이미지 URL 맵을 조회합니다.</li>
+     * <li>울타리 엔티티를 목록 응답 DTO로 매핑하여 반환합니다.</li>
+     * </ol>
+     *
+     * @param userId 요청한 사용자 ID
+     * @return 울타리 경계 목록 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public FenceBoundaryListResponse getFenceBoundaries(UUID userId) {
+        List<Long> approvedPetIds = userPetService.getApprovedPetIds(userId);
+        if (approvedPetIds.isEmpty()) {
+            throw new FenceException(FENCE_ACCESS_DENIED);
+        }
+
+        List<Fence> fences = fenceRepository.findAllByPet_PetIdIn(approvedPetIds);
+        if (fences.isEmpty()) {
+            throw new FenceException(FENCE_INFO_NOT_FOUND);
+        }
+
+        Map<Long, String> petImageUrlMap = imageFileService.getProfileUrlsByPetIds(approvedPetIds);
+
+        List<FenceBoundaryItem> items = fences.stream()
+                .map(fence -> {
+                    Long petId = fence.getPet().getPetId();
+                    return FenceBoundaryItem.toDto(
+                            fence.getFenceId(),
+                            fence.getName(),
+                            fence.getCenterLatitude(),
+                            fence.getCenterLongitude(),
+                            fence.getRadius(),
+                            Boolean.TRUE.equals(fence.getFenceIsActive()),
+                            petId,
+                            fence.getPet().getPetName(),
+                            petImageUrlMap.get(petId)
+                    );
+                })
+                .toList();
+
+        return FenceBoundaryListResponse.toDto("울타리 목록 조회를 성공했습니다.", items);
     }
 
     /**

--- a/src/main/java/com/dodo/backend/userpet/repository/UserPetRepository.java
+++ b/src/main/java/com/dodo/backend/userpet/repository/UserPetRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -89,4 +90,17 @@ public interface UserPetRepository extends JpaRepository<UserPet, UserPetId> {
      * @return 연결된 데이터가 하나라도 있으면 true, 없으면 false
      */
     boolean existsByPet_PetId(Long petId);
+
+    /**
+     * 특정 사용자가 승인(APPROVED)된 반려동물 ID 목록을 조회합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @param status 조회할 등록 상태
+     * @return 반려동물 ID 목록
+     */
+    @Query("SELECT up.pet.petId FROM UserPet up WHERE up.user.usersId = :userId AND up.registrationStatus = :status")
+    List<Long> findPetIdsByUserIdAndRegistrationStatus(
+            @Param("userId") UUID userId,
+            @Param("status") RegistrationStatus status
+    );
 }

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
@@ -6,6 +6,7 @@ import com.dodo.backend.userpet.entity.UserPet;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -133,4 +134,12 @@ public interface UserPetService {
      * @return 유저가 존재하면 true, 아니면 false
      */
     boolean existsUser(UUID userId);
+
+    /**
+     * 특정 사용자의 승인(APPROVED)된 반려동물 ID 목록을 조회합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 승인된 반려동물 ID 목록
+     */
+    List<Long> getApprovedPetIds(UUID userId);
 }

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetServiceImpl.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -373,6 +374,21 @@ public class UserPetServiceImpl implements UserPetService {
     @Override
     public boolean existsUser(UUID userId) {
         return userRepository.existsById(userId);
+    }
+
+    /**
+     * 요청 사용자의 승인된(APPROVED) 반려동물 ID 목록을 조회합니다.
+     * <p>
+     * 사용자-반려동물 연결 테이블에서 승인 상태만 필터링하여
+     * 반려동물 식별자 목록을 반환합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 승인된 반려동물 ID 목록
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public List<Long> getApprovedPetIds(UUID userId) {
+        return userPetRepository.findPetIdsByUserIdAndRegistrationStatus(userId, RegistrationStatus.APPROVED);
     }
 
 }

--- a/src/test/java/com/dodo/backend/fence/service/FenceServiceTest.java
+++ b/src/test/java/com/dodo/backend/fence/service/FenceServiceTest.java
@@ -5,6 +5,8 @@ import com.dodo.backend.fence.dto.request.FenceRequest.FenceRangeUpdateRequest;
 import com.dodo.backend.fence.dto.request.FenceRequest.FenceToggleRequest;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceRangeUpdateResponse;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceBoundaryListResponse;
+import com.dodo.backend.fence.dto.response.FenceResponse.FenceBoundaryResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceStatusResponse;
 import com.dodo.backend.fence.dto.response.FenceResponse.FenceToggleResponse;
 import com.dodo.backend.fence.entity.Fence;
@@ -12,6 +14,7 @@ import com.dodo.backend.fence.exception.FenceErrorCode;
 import com.dodo.backend.fence.exception.FenceException;
 import com.dodo.backend.fence.mapper.FenceMapper;
 import com.dodo.backend.fence.repository.FenceRepository;
+import com.dodo.backend.imagefile.service.ImageFileService;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.pet.service.PetService;
 import com.dodo.backend.userpet.service.UserPetService;
@@ -24,6 +27,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -54,6 +59,9 @@ class FenceServiceTest {
 
     @Mock
     private UserPetService userPetService;
+
+    @Mock
+    private ImageFileService imageFileService;
 
     /**
      * 기존 울타리가 없을 때 새 울타리를 생성하고 성공 메시지를 반환하는지 검증합니다.
@@ -89,11 +97,11 @@ class FenceServiceTest {
     }
 
     /**
-     * 기존 울타리가 있을 때 동일 울타리를 갱신 저장하는지 검증합니다.
+     * 기존 울타리가 있을 때 중복 생성이 차단되는지 검증합니다.
      */
     @Test
-    @DisplayName("울타리 설정 성공: 기존 울타리가 있으면 해당 울타리를 갱신 저장한다.")
-    void setFenceRange_UpdateSuccess() {
+    @DisplayName("울타리 설정 실패: 기존 울타리가 있으면 FENCE_ALREADY_EXISTS 예외가 발생한다.")
+    void setFenceRange_AlreadyExists() {
         // given
         UUID userId = UUID.randomUUID();
         Long petId = 1L;
@@ -120,15 +128,12 @@ class FenceServiceTest {
         given(petService.existsPetById(petId)).willReturn(true);
         given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
         given(fenceRepository.findByPet_PetId(petId)).willReturn(Optional.of(existing));
-        given(fenceRepository.save(any(Fence.class))).willAnswer(invocation -> invocation.getArgument(0));
-
         // when
-        FenceRangeResponse response = fenceService.setFenceRange(userId, request);
+        FenceException exception = assertThrows(FenceException.class, () -> fenceService.setFenceRange(userId, request));
 
         // then
-        assertEquals("울타리 설정을 완료했습니다.", response.getMessage());
-        verify(fenceRepository).save(any(Fence.class));
-        verify(petService, never()).getPetById(any());
+        assertEquals(FenceErrorCode.FENCE_ALREADY_EXISTS, exception.getErrorCode());
+        verify(fenceRepository, never()).save(any(Fence.class));
     }
 
     /**
@@ -495,5 +500,165 @@ class FenceServiceTest {
         // then
         assertEquals(FenceErrorCode.FENCE_PERMISSION_DENIED, exception.getErrorCode());
         verify(fenceMapper, never()).updateFenceRange(any(), any(), any(), any(), any());
+    }
+
+    /**
+     * 울타리 경계 단건 조회가 정상 처리되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("울타리 경계 조회 성공: 중심 좌표와 반경을 반환한다.")
+    void getFenceBoundary_Success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long fenceId = 10L;
+        Long petId = 1L;
+
+        Fence fence = Fence.builder()
+                .fenceId(fenceId)
+                .pet(Pet.builder().petId(petId).build())
+                .name("집 주변 울타리")
+                .centerLatitude(new BigDecimal("37.5665"))
+                .centerLongitude(new BigDecimal("126.9780"))
+                .radius(500)
+                .fenceIsActive(true)
+                .build();
+
+        given(fenceRepository.findById(fenceId)).willReturn(Optional.of(fence));
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(true);
+
+        // when
+        FenceBoundaryResponse response = fenceService.getFenceBoundary(userId, fenceId);
+
+        // then
+        assertEquals("울타리 정보 조회를 성공했습니다.", response.getMessage());
+        assertEquals(fenceId, response.getFenceId());
+        assertEquals(500, response.getRadius());
+        assertEquals(new BigDecimal("37.5665"), response.getCenter().getLatitude());
+        assertEquals(new BigDecimal("126.9780"), response.getCenter().getLongitude());
+    }
+
+    /**
+     * 조회 대상 울타리가 없으면 FENCE_INFO_NOT_FOUND 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("울타리 경계 조회 실패: 울타리 정보가 없으면 FENCE_INFO_NOT_FOUND 예외가 발생한다.")
+    void getFenceBoundary_NotFound() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long fenceId = 999L;
+        given(fenceRepository.findById(fenceId)).willReturn(Optional.empty());
+
+        // when
+        FenceException exception = assertThrows(FenceException.class,
+                () -> fenceService.getFenceBoundary(userId, fenceId));
+
+        // then
+        assertEquals(FenceErrorCode.FENCE_INFO_NOT_FOUND, exception.getErrorCode());
+    }
+
+    /**
+     * 접근 권한이 없으면 FENCE_ACCESS_DENIED 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("울타리 경계 조회 실패: 접근 권한이 없으면 FENCE_ACCESS_DENIED 예외가 발생한다.")
+    void getFenceBoundary_AccessDenied() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long fenceId = 10L;
+        Long petId = 1L;
+
+        Fence fence = Fence.builder()
+                .fenceId(fenceId)
+                .pet(Pet.builder().petId(petId).build())
+                .name("집 주변 울타리")
+                .centerLatitude(new BigDecimal("37.5665"))
+                .centerLongitude(new BigDecimal("126.9780"))
+                .radius(500)
+                .fenceIsActive(true)
+                .build();
+
+        given(fenceRepository.findById(fenceId)).willReturn(Optional.of(fence));
+        given(userPetService.isApprovedPetOwner(userId, petId)).willReturn(false);
+
+        // when
+        FenceException exception = assertThrows(FenceException.class,
+                () -> fenceService.getFenceBoundary(userId, fenceId));
+
+        // then
+        assertEquals(FenceErrorCode.FENCE_ACCESS_DENIED, exception.getErrorCode());
+    }
+
+    /**
+     * 울타리 경계 목록 조회가 정상 처리되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("울타리 경계 목록 조회 성공: 사용자의 모든 울타리 목록을 반환한다.")
+    void getFenceBoundaries_Success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long petId = 1L;
+
+        Fence fence = Fence.builder()
+                .fenceId(10L)
+                .pet(Pet.builder().petId(petId).petName("도도").build())
+                .name("집 주변 울타리")
+                .centerLatitude(new BigDecimal("37.5665"))
+                .centerLongitude(new BigDecimal("126.9780"))
+                .radius(500)
+                .fenceIsActive(true)
+                .build();
+
+        given(userPetService.getApprovedPetIds(userId)).willReturn(List.of(petId));
+        given(fenceRepository.findAllByPet_PetIdIn(List.of(petId))).willReturn(List.of(fence));
+        given(imageFileService.getProfileUrlsByPetIds(List.of(petId)))
+                .willReturn(Map.of(petId, "https://cdn.dodo.com/pets/1/profile.jpg"));
+
+        // when
+        FenceBoundaryListResponse response = fenceService.getFenceBoundaries(userId);
+
+        // then
+        assertEquals("울타리 목록 조회를 성공했습니다.", response.getMessage());
+        assertEquals(1, response.getBoundaries().size());
+        assertEquals("집 주변 울타리", response.getBoundaries().get(0).getFenceName());
+        assertEquals("도도", response.getBoundaries().get(0).getPetName());
+        assertEquals("https://cdn.dodo.com/pets/1/profile.jpg", response.getBoundaries().get(0).getPetImageUrl());
+    }
+
+    /**
+     * 사용자의 승인된 반려동물이 없으면 FENCE_ACCESS_DENIED 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("울타리 경계 목록 조회 실패: 승인된 반려동물이 없으면 FENCE_ACCESS_DENIED 예외가 발생한다.")
+    void getFenceBoundaries_AccessDenied() {
+        // given
+        UUID userId = UUID.randomUUID();
+        given(userPetService.getApprovedPetIds(userId)).willReturn(List.of());
+
+        // when
+        FenceException exception = assertThrows(FenceException.class,
+                () -> fenceService.getFenceBoundaries(userId));
+
+        // then
+        assertEquals(FenceErrorCode.FENCE_ACCESS_DENIED, exception.getErrorCode());
+        verify(fenceRepository, never()).findAllByPet_PetIdIn(any());
+    }
+
+    /**
+     * 승인된 반려동물은 있으나 울타리가 없으면 FENCE_INFO_NOT_FOUND 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("울타리 경계 목록 조회 실패: 울타리가 없으면 FENCE_INFO_NOT_FOUND 예외가 발생한다.")
+    void getFenceBoundaries_NotFound() {
+        // given
+        UUID userId = UUID.randomUUID();
+        given(userPetService.getApprovedPetIds(userId)).willReturn(List.of(1L));
+        given(fenceRepository.findAllByPet_PetIdIn(List.of(1L))).willReturn(List.of());
+
+        // when
+        FenceException exception = assertThrows(FenceException.class,
+                () -> fenceService.getFenceBoundaries(userId));
+
+        // then
+        assertEquals(FenceErrorCode.FENCE_INFO_NOT_FOUND, exception.getErrorCode());
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 울타리 단건 범위 표시 기능 구현 (중심 좌표, 반경, 메시지 반환)
- 울타리 범위 목록 조회 기능 구현 (울타리명, 활성화 여부, 반려동물 정보 포함)
- 사용자 승인 반려동물 기준 접근 제어 및 예외 처리 반영
- Fence 응답 DTO 확장 및 Scalar Api Reference 응답 명세 보강
- Fence 서비스 테스트 보강 및 검증
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #118
<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 지도에 울타리 범위 표시하는 기능 구현했습니다.
- 울타리 범위 목록 조회 기능 구현했습니다.
  - 애완동물 하나당 하나의 울타리 밖에 가지지 못합니다. 