### PR TITLE
✨ Feat: 메인 페이지 조회 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/healthanalysis/dto/request/HealthAnalysisRequest.java
+++ b/src/main/java/com/dodo/backend/healthanalysis/dto/request/HealthAnalysisRequest.java
@@ -6,40 +6,45 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 /**
- * 건강 분석 도메인의 요청 DTO 그룹입니다.
+ * 건강 분석 요청 DTO 모음입니다.
  */
-@Schema(description = "건강 분석 관련 요청 DTO 그룹")
+@Schema(description = "건강 분석 요청 DTO 모음")
 public class HealthAnalysisRequest {
 
     /**
-     * AI 건강 분석 보고서 생성 요청 DTO입니다.
+     * AI 건강 분석 리포트 생성 요청입니다.
      */
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "AI 건강 분석 보고서 생성 요청")
+    @Schema(description = "AI 건강 분석 리포트 생성 요청")
     public static class AiReportCreateRequest {
 
-        @Schema(description = "분석 타입 (DAILY, WEEKLY, MONTHLY)", example = "DAILY")
+        @Schema(description = "분석 주기(DAILY, WEEKLY, MONTHLY)", example = "DAILY")
         private String analysisType;
+
+        @Schema(description = "특이사항 리스트", example = "[\"최근 식욕이 줄었습니다.\", \"운동량이 늘었습니다.\"]")
+        private List<String> specialNotes;
     }
 
     /**
-     * 건강 분석 결과 수정 요청 DTO입니다.
+     * 건강 분석 리포트 수정 요청입니다.
      */
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "건강 분석 결과 수정 요청")
+    @Schema(description = "건강 분석 리포트 수정 요청")
     public static class AnalysisUpdateRequest {
 
-        @Schema(description = "수정할 분석 제목", example = "2025년 10월 정기 건강 분석 리포트 (수정본)")
+        @Schema(description = "수정할 분석 제목", example = "2025년 10월 건강 분석 리포트(수정본)")
         private String healthAnalysisTitle;
 
-        @Schema(description = "수정할 분석 요약", example = "활동량은 양호하나 체중이 약간 증가하는 경향을 보입니다. 식단 조절 및 산책 시간 증가를 강력히 권장합니다.")
+        @Schema(description = "수정할 분석 요약", example = "운동량 증가가 필요합니다. 심박수는 안정적입니다.")
         private String healthAnalysisSummary;
     }
 }

--- a/src/main/java/com/dodo/backend/healthanalysis/service/HealthAnalysisServiceImpl.java
+++ b/src/main/java/com/dodo/backend/healthanalysis/service/HealthAnalysisServiceImpl.java
@@ -95,7 +95,7 @@ public class HealthAnalysisServiceImpl implements HealthAnalysisService {
             throw new HealthAnalysisException(ACCESS_DENIED);
         }
 
-        Map<String, Object> healthData = buildHealthData(normalizedType, petId);
+        Map<String, Object> healthData = buildHealthData(normalizedType, petId, request.getSpecialNotes());
         Map<String, Object> generated = gptClient.generateHealthAnalysis(normalizedType, petId, healthData);
 
         HealthAnalysis saved = healthAnalysisRepository.save(
@@ -258,7 +258,7 @@ public class HealthAnalysisServiceImpl implements HealthAnalysisService {
      * @param petId        반려동물 ID
      * @return GPT 전달용 데이터 맵
      */
-    private Map<String, Object> buildHealthData(String analysisType, Long petId) {
+    private Map<String, Object> buildHealthData(String analysisType, Long petId, List<String> specialNotes) {
         LocalDate today = LocalDate.now();
         String petName = petService.getPetById(petId).getPetName();
         LocalDateTime startDateTime;
@@ -309,6 +309,7 @@ public class HealthAnalysisServiceImpl implements HealthAnalysisService {
         payload.put("reportDate", today.toString());
         payload.put("periodStart", startDateTime);
         payload.put("periodEnd", endDateTime);
+        payload.put("specialNotes", specialNotes == null ? List.of() : specialNotes);
         payload.put("petWeights", petWeightData);
         payload.put("activityHistories", activityHistoryData);
         payload.put("heartRates", heartRateData);

--- a/src/main/java/com/dodo/backend/main/controller/MainController.java
+++ b/src/main/java/com/dodo/backend/main/controller/MainController.java
@@ -1,0 +1,71 @@
+package com.dodo.backend.main.controller;
+
+import com.dodo.backend.common.exception.ErrorResponse;
+import com.dodo.backend.main.dto.response.MainResponse.MainPageResponse;
+import com.dodo.backend.main.service.MainService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * 메인 페이지 정보를 조회하는 컨트롤러입니다.
+ */
+@RestController
+@RequestMapping("/main")
+@RequiredArgsConstructor
+@Tag(name = "Main API", description = "Main page API")
+public class MainController {
+
+    private final MainService mainService;
+
+    /**
+     * 인증된 사용자의 메인 페이지 정보를 조회합니다.
+     *
+     * @param userDetails 인증된 사용자 정보
+     * @return 메인 페이지 응답 본문
+     */
+    @Operation(summary = "메인 페이지 정보 조회", description = "로그인한 사용자의 메인 페이지 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "메인 페이지 정보를 가져오는데 성공했습니다.",
+                    content = @Content(schema = @Schema(implementation = MainPageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request",
+                                    value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "인증에 실패했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized",
+                                    value = "{\"status\": 401, \"message\": \"인증에 실패했습니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden",
+                                    value = "{\"status\": 403, \"message\": \"접근 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error",
+                                    value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @GetMapping
+    public ResponseEntity<MainPageResponse> getMainPage(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        return ResponseEntity.ok(mainService.getMainPage(userId));
+    }
+}

--- a/src/main/java/com/dodo/backend/main/dto/response/MainResponse.java
+++ b/src/main/java/com/dodo/backend/main/dto/response/MainResponse.java
@@ -1,0 +1,146 @@
+package com.dodo.backend.main.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 메인 페이지 응답 DTO 모음입니다.
+ */
+@Schema(description = "메인 페이지 응답 DTO 모음")
+public class MainResponse {
+
+    /**
+     * 메인 페이지 응답 본문입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "메인 페이지 응답")
+    public static class MainPageResponse {
+
+        @Schema(description = "응답 메시지", example = "메인 페이지 정보를 가져오는데 성공했습니다.")
+        private String message;
+
+        @Schema(description = "반려동물 프로필 목록")
+        private List<PetProfile> petProfiles;
+
+        @Schema(description = "건강 리포트 목록")
+        private List<HealthReport> healthReports;
+
+        @Schema(description = "공지사항 목록")
+        private List<Announcement> announcement;
+
+        /**
+         * 메인 페이지 응답 DTO를 생성합니다.
+         *
+         * @param message       응답 메시지
+         * @param petProfiles   반려동물 프로필 요약
+         * @param healthReports 건강 리포트 요약
+         * @param announcement  공지사항 요약
+         * @return 메인 페이지 응답 DTO
+         */
+        public static MainPageResponse toDto(String message,
+                                             List<PetProfile> petProfiles,
+                                             List<HealthReport> healthReports,
+                                             List<Announcement> announcement) {
+            return MainPageResponse.builder()
+                    .message(message)
+                    .petProfiles(petProfiles)
+                    .healthReports(healthReports)
+                    .announcement(announcement)
+                    .build();
+        }
+    }
+
+    /**
+     * 메인 페이지에 노출되는 반려동물 프로필 요약입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "반려동물 프로필 요약")
+    public static class PetProfile {
+
+        @Schema(description = "반려동물 ID", example = "101")
+        private Long petId;
+
+        @Schema(description = "반려동물 이름", example = "보리")
+        private String name;
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/bori.jpg")
+        private String imageFileUrl;
+
+        @Schema(description = "품종", example = "말티즈")
+        private String breed;
+
+        @Schema(description = "나이", example = "5")
+        private Integer age;
+
+        @Schema(description = "종", example = "CANINE")
+        private String spercies;
+
+        @Schema(description = "성별", example = "MALE")
+        private String sex;
+
+        @Schema(description = "체중", example = "4.2")
+        private Double weight;
+    }
+
+    /**
+     * 메인 페이지에 노출되는 건강 리포트 요약입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "건강 리포트 요약")
+    public static class HealthReport {
+
+        @Schema(description = "반려동물 ID", example = "101")
+        private Long petId;
+
+        @Schema(description = "반려동물 이름", example = "보리")
+        private String petName;
+
+        @Schema(description = "대시보드 ID", example = "201")
+        private Long dashboardId;
+
+        @Schema(description = "리포트 제목", example = "정기 건강검진 요약")
+        private String healthReportTitle;
+
+        @Schema(description = "리포트 요약", example = "전반적으로 양호하나, 체중 관리가 필요합니다.")
+        private String healthReportSummary;
+
+        @Schema(description = "리포트 본문", example = "")
+        private String healthReportContent;
+
+        @Schema(description = "검진 일자", example = "2025-09-15")
+        private LocalDate checkupDate;
+    }
+
+    /**
+     * 메인 페이지에 노출되는 공지사항 요약입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "공지사항 요약")
+    public static class Announcement {
+
+        @Schema(description = "제목", example = "공지 제목")
+        private String boardTitle;
+
+        @Schema(description = "내용", example = "공지 내용입니다.")
+        private String boardContent;
+
+        @Schema(description = "이미지 URL", example = "http://www.asdkfjasdfas")
+        private String imageFileUrl;
+
+        @Schema(description = "조회 수", example = "10")
+        private Integer viewCount;
+    }
+}

--- a/src/main/java/com/dodo/backend/main/service/MainService.java
+++ b/src/main/java/com/dodo/backend/main/service/MainService.java
@@ -1,0 +1,19 @@
+package com.dodo.backend.main.service;
+
+import com.dodo.backend.main.dto.response.MainResponse.MainPageResponse;
+
+import java.util.UUID;
+
+/**
+ * 메인 페이지 데이터를 조회하는 서비스 인터페이스입니다.
+ */
+public interface MainService {
+
+    /**
+     * 로그인 사용자의 메인 페이지 정보를 조회합니다.
+     *
+     * @param userId 인증된 사용자 ID
+     * @return 메인 페이지 응답 본문
+     */
+    MainPageResponse getMainPage(UUID userId);
+}

--- a/src/main/java/com/dodo/backend/main/service/MainServiceImpl.java
+++ b/src/main/java/com/dodo/backend/main/service/MainServiceImpl.java
@@ -1,0 +1,148 @@
+package com.dodo.backend.main.service;
+
+import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisListItem;
+import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisListResponse;
+import com.dodo.backend.healthanalysis.service.HealthAnalysisService;
+import com.dodo.backend.main.dto.response.MainResponse.*;
+import com.dodo.backend.pet.dto.response.PetResponse.PetListResponse;
+import com.dodo.backend.pet.dto.response.PetResponse.PetListResponse.PetSummary;
+import com.dodo.backend.pet.service.PetService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 메인 페이지 서비스 구현체입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class MainServiceImpl implements MainService {
+
+    private final PetService petService;
+    private final HealthAnalysisService healthAnalysisService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 로그인한 사용자의 메인 페이지 정보를 조회합니다.
+     *
+     * @param userId 인증된 사용자 ID
+     * @return 메인 페이지 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public MainPageResponse getMainPage(UUID userId) {
+        List<PetProfile> petProfiles = buildPetProfiles(userId);
+        List<HealthReport> healthReports = buildHealthReports(userId, petProfiles);
+
+        return MainPageResponse.toDto(
+                "메인 페이지 정보를 가져오는데 성공했습니다.",
+                petProfiles,
+                healthReports,
+                null
+        );
+    }
+
+    /**
+     * 펫 도메인 서비스만 사용하여 메인에 필요한 프로필 목록을 생성합니다.
+     *
+     * @param userId 인증된 사용자 ID
+     * @return 반려동물 프로필 목록
+     */
+    private List<PetProfile> buildPetProfiles(UUID userId) {
+        PetListResponse petListResponse = petService.getPetList(userId, Pageable.unpaged());
+        List<PetSummary> pets = petListResponse.getPets();
+
+        if (pets == null || pets.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return pets.stream()
+                .map(pet -> PetProfile.builder()
+                        .petId(pet.getPetId())
+                        .name(pet.getPetName())
+                        .imageFileUrl(pet.getImageFileUrl())
+                        .breed(pet.getBreed())
+                        .age(pet.getAge())
+                        .spercies(pet.getSpecies())
+                        .sex(pet.getSex())
+                        .weight(pet.getWeight())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 각 반려동물의 최신 건강 분석 리포트를 요약 목록으로 만듭니다.
+     *
+     * @param userId      인증된 사용자 ID
+     * @param petProfiles 반려동물 프로필 목록
+     * @return 건강 리포트 목록
+     */
+    private List<HealthReport> buildHealthReports(UUID userId, List<PetProfile> petProfiles) {
+        if (petProfiles == null || petProfiles.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return petProfiles.stream()
+                .map(profile -> buildLatestHealthReport(userId, profile))
+                .filter(report -> report != null)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 반려동물의 최신 건강 분석 리포트를 불러와 요약 DTO로 변환합니다.
+     *
+     * @param userId  인증된 사용자 ID
+     * @param profile 반려동물 프로필
+     * @return 건강 리포트 요약(없으면 null)
+     */
+    private HealthReport buildLatestHealthReport(UUID userId, PetProfile profile) {
+        AnalysisListResponse response = healthAnalysisService.getAnalysisList(
+                userId,
+                profile.getPetId(),
+                0,
+                1,
+                null
+        );
+
+        List<AnalysisListItem> items = response.getData();
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+
+        AnalysisListItem item = items.get(0);
+        String content = serializeAnalysisContent(item.getHealthAnalysisFullContent());
+
+        return HealthReport.builder()
+                .petId(profile.getPetId())
+                .petName(profile.getName())
+                .dashboardId(item.getAnalysisId())
+                .healthReportTitle(item.getHealthAnalysisTitle())
+                .healthReportSummary(item.getHealthAnalysisSummary())
+                .healthReportContent(content)
+                .checkupDate(item.getAnalysisDate() == null ? null : item.getAnalysisDate().toLocalDate())
+                .build();
+    }
+
+    /**
+     * 분석 상세 내용을 문자열(JSON)로 직렬화합니다.
+     *
+     * @param content 분석 상세 객체
+     * @return 직렬화된 문자열
+     */
+    private String serializeAnalysisContent(Object content) {
+        if (content == null) {
+            return "";
+        }
+        if (content instanceof String value) {
+            return value;
+        }
+        return objectMapper.valueToTree(content).toString();
+    }
+}

--- a/src/main/java/com/dodo/backend/petweight/service/PetWeightServiceImpl.java
+++ b/src/main/java/com/dodo/backend/petweight/service/PetWeightServiceImpl.java
@@ -63,7 +63,8 @@ public class PetWeightServiceImpl implements PetWeightService {
         return results.stream()
                 .collect(Collectors.toMap(
                         row -> (Long) row[0],
-                        row -> (Double) row[1]
+                        row -> (Double) row[1],
+                        (existing, replacement) -> replacement
                 ));
     }
 

--- a/src/main/java/com/dodo/backend/routepoint/controller/TestWebSocketController.java
+++ b/src/main/java/com/dodo/backend/routepoint/controller/TestWebSocketController.java
@@ -21,7 +21,7 @@ public class TestWebSocketController {
      */
     @GetMapping("/view/socket")
     public String socketTestPage() {
-        log.info("🌐 WebSocket GPS Simulation Page requested");
+        log.info("웹소켓 시뮬레이션 페이지가 요청되었습니다.");
         return "websocket/socket-test";
     }
 }

--- a/src/test/java/com/dodo/backend/main/service/MainServiceTest.java
+++ b/src/test/java/com/dodo/backend/main/service/MainServiceTest.java
@@ -1,0 +1,227 @@
+package com.dodo.backend.main.service;
+
+import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisListItem;
+import com.dodo.backend.healthanalysis.dto.response.HealthAnalysisResponse.AnalysisListResponse;
+import com.dodo.backend.healthanalysis.service.HealthAnalysisService;
+import com.dodo.backend.main.dto.response.MainResponse.HealthReport;
+import com.dodo.backend.main.dto.response.MainResponse.MainPageResponse;
+import com.dodo.backend.main.dto.response.MainResponse.PetProfile;
+import com.dodo.backend.pet.dto.response.PetResponse.PetListResponse;
+import com.dodo.backend.pet.dto.response.PetResponse.PetListResponse.PetSummary;
+import com.dodo.backend.pet.service.PetService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@link MainService}의 비즈니스 로직을 검증하는 테스트 클래스입니다.
+ */
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class MainServiceTest {
+
+    @InjectMocks
+    private MainServiceImpl mainService;
+
+    @Mock
+    private PetService petService;
+
+    @Mock
+    private HealthAnalysisService healthAnalysisService;
+
+    @Spy
+    private ObjectMapper objectMapper;
+
+    /**
+     * 반려동물과 최신 건강 리포트가 존재할 때 메인 페이지 정보를 반환하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("메인 페이지 조회 성공: 반려동물과 건강 리포트가 포함된다.")
+    void getMainPage_WithPetProfilesAndHealthReports() {
+        log.info("테스트 시작: 반려동물과 건강 리포트가 포함된 메인 페이지 조회");
+
+        // given
+        UUID userId = UUID.randomUUID();
+        PetSummary petSummary = PetSummary.builder()
+                .petId(1L)
+                .petName("보리")
+                .imageFileUrl("https://example.com/pets/1.png")
+                .species("CANINE")
+                .breed("POODLE")
+                .sex("FEMALE")
+                .age(3)
+                .weight(4.5)
+                .build();
+
+        PetListResponse petListResponse = PetListResponse.builder()
+                .message("반려동물 목록 조회 성공")
+                .pets(List.of(petSummary))
+                .totalPages(1)
+                .totalElements(1L)
+                .currentPage(0)
+                .pageSize(10)
+                .build();
+
+        Map<String, Object> fullContent = Map.of("score", 95);
+        LocalDateTime analysisDate = LocalDateTime.of(2025, 1, 15, 10, 30);
+        AnalysisListItem analysisListItem = AnalysisListItem.toDto(
+                101L,
+                "월간 리포트",
+                "건강 요약",
+                fullContent,
+                analysisDate,
+                "MONTHLY",
+                "COMPLETED"
+        );
+
+        AnalysisListResponse analysisListResponse = AnalysisListResponse.builder()
+                .message("건강 분석 결과 조회 성공")
+                .pageInfo(null)
+                .data(List.of(analysisListItem))
+                .build();
+
+        given(petService.getPetList(userId, Pageable.unpaged())).willReturn(petListResponse);
+        given(healthAnalysisService.getAnalysisList(userId, petSummary.getPetId(), 0, 1, null))
+                .willReturn(analysisListResponse);
+
+        // when
+        MainPageResponse response = mainService.getMainPage(userId);
+
+        // then
+        assertNotNull(response);
+        List<PetProfile> petProfiles = response.getPetProfiles();
+        assertEquals(1, petProfiles.size());
+
+        PetProfile profile = petProfiles.get(0);
+        assertEquals(petSummary.getPetId(), profile.getPetId());
+        assertEquals(petSummary.getPetName(), profile.getName());
+        assertEquals(petSummary.getImageFileUrl(), profile.getImageFileUrl());
+        assertEquals(petSummary.getBreed(), profile.getBreed());
+        assertEquals(petSummary.getAge(), profile.getAge());
+        assertEquals(petSummary.getSpecies(), profile.getSpercies());
+        assertEquals(petSummary.getSex(), profile.getSex());
+        assertEquals(petSummary.getWeight(), profile.getWeight());
+
+        List<HealthReport> healthReports = response.getHealthReports();
+        assertEquals(1, healthReports.size());
+
+        HealthReport healthReport = healthReports.get(0);
+        assertEquals(analysisListItem.getAnalysisId(), healthReport.getDashboardId());
+        assertEquals(analysisListItem.getHealthAnalysisTitle(), healthReport.getHealthReportTitle());
+        assertEquals(analysisListItem.getHealthAnalysisSummary(), healthReport.getHealthReportSummary());
+        assertEquals("{\"score\":95}", healthReport.getHealthReportContent());
+        assertEquals(analysisDate.toLocalDate(), healthReport.getCheckupDate());
+        assertEquals(petSummary.getPetName(), healthReport.getPetName());
+
+        verify(petService).getPetList(userId, Pageable.unpaged());
+        verify(healthAnalysisService).getAnalysisList(userId, petSummary.getPetId(), 0, 1, null);
+
+        log.info("테스트 종료: 메인 페이지 응답 검증 완료");
+    }
+
+    /**
+     * 반려동물 정보가 없을 때 빈 목록과 기본 메세지를 반환하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("메인 페이지 조회: 반려동물이 없으면 빈 리스트 반환")
+    void getMainPage_WithoutPets_ReturnsEmptyLists() {
+        log.info("테스트 시작: 반려동물 없음 - 빈 메인 페이지 응답");
+
+        // given
+        UUID userId = UUID.randomUUID();
+        PetListResponse petListResponse = PetListResponse.builder()
+                .message("반려동물 없음")
+                .pets(Collections.emptyList())
+                .totalPages(0)
+                .totalElements(0L)
+                .currentPage(0)
+                .pageSize(0)
+                .build();
+
+        given(petService.getPetList(userId, Pageable.unpaged())).willReturn(petListResponse);
+
+        // when
+        MainPageResponse response = mainService.getMainPage(userId);
+
+        // then
+        assertNotNull(response);
+        assertTrue(response.getPetProfiles().isEmpty());
+        assertTrue(response.getHealthReports().isEmpty());
+
+        verify(petService).getPetList(userId, Pageable.unpaged());
+        verifyNoInteractions(healthAnalysisService);
+
+        log.info("테스트 종료: 반려동물 없음 응답 검증 완료");
+    }
+
+    /**
+     * 반려동물은 존재하지만 건강 분석 이력이 없을 때 건강 리포트가 비어 있는지 검증합니다.
+     */
+    @Test
+    @DisplayName("메인 페이지 조회: 건강 분석 이력이 없으면 건강 리포트 목록이 비어있다.")
+    void getMainPage_PetWithoutHealthAnalysis() {
+        log.info("테스트 시작: 건강 분석 이력 없음");
+
+        // given
+        UUID userId = UUID.randomUUID();
+        PetSummary petSummary = PetSummary.builder()
+                .petId(7L)
+                .petName("차우")
+                .imageFileUrl("https://example.com/pets/7.png")
+                .species("FELINE")
+                .breed("RAGDOLL")
+                .sex("MALE")
+                .age(2)
+                .weight(4.1)
+                .build();
+
+        PetListResponse petListResponse = PetListResponse.builder()
+                .message("반려동물 조회 성공")
+                .pets(List.of(petSummary))
+                .totalPages(1)
+                .totalElements(1L)
+                .currentPage(0)
+                .pageSize(10)
+                .build();
+
+        AnalysisListResponse emptyAnalysisResponse = AnalysisListResponse.builder()
+                .message("건강 분석 없음")
+                .pageInfo(null)
+                .data(Collections.emptyList())
+                .build();
+
+        given(petService.getPetList(userId, Pageable.unpaged())).willReturn(petListResponse);
+        given(healthAnalysisService.getAnalysisList(userId, petSummary.getPetId(), 0, 1, null))
+                .willReturn(emptyAnalysisResponse);
+
+        // when
+        MainPageResponse response = mainService.getMainPage(userId);
+
+        // then
+        assertNotNull(response);
+        assertEquals(1, response.getPetProfiles().size());
+        assertTrue(response.getHealthReports().isEmpty());
+
+        verify(petService).getPetList(userId, Pageable.unpaged());
+        verify(healthAnalysisService).getAnalysisList(userId, petSummary.getPetId(), 0, 1, null);
+
+        log.info("테스트 종료: 건강 분석 이력 없음 응답 검증 완료");
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- MainService.getMainPage 비즈니스 로직 구현
- 반려동물 목록 및 최신 건강 리포트 통합 조회 기능 추가
- 건강 리포트 콘텐츠 JSON 직렬화 로직 구현
- 반려동물/리포트 존재 여부에 따른 분기 처리 구현
- 단위 테스트 작성 (성공/예외 분기 및 서비스 호출 검증)
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-  Closes #124

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 메인 페이지에 나오는 정보들 조회 하는 기능 만들었습니다.
- 프론트와 상의 후 뉴스는 프론트에서 가져오는걸로 했습니다.
- 아직 게시판 쪽이 만들어지지 않아서 announce쪽은 null로 처리해놨습니다.