### PR TITLE
✨ Feat: 활동 기록 반응 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
@@ -3,6 +3,7 @@ package com.dodo.backend.activityhistory.service;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityStartRequest;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.*;
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
@@ -131,4 +132,12 @@ public interface ActivityHistoryService {
      * @return 매핑이 일치하면 true, 아니면 false
      */
     boolean isDeviceAuthorizedForHistory(Long historyId, String devicePrincipal);
+
+    /**
+     * 활동 기록 ID로 활동 기록 엔티티를 조회합니다.
+     *
+     * @param historyId 조회할 활동 기록 ID
+     * @return 조회된 활동 기록 엔티티
+     */
+    ActivityHistory getActivityHistoryById(Long historyId);
 }

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
@@ -1,9 +1,7 @@
 package com.dodo.backend.activityhistory.service;
 
-import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityCreateRequest;
 import com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.ActivityStartRequest;
-import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse;
 import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.*;
 import com.dodo.backend.activityhistory.entity.ActivityHistory;
 import com.dodo.backend.activityhistory.entity.ActivityHistoryStatus;
@@ -24,22 +22,19 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.charset.StandardCharsets;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.*;
 import static com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCode.*;
 
 /**
- * {@link ActivityHistoryService} ?명꽣?섏씠?ㅼ쓽 援ы쁽泥??대옒?ㅼ엯?덈떎.
- * <p>
- * 諛섎젮?숇Ъ???쒕룞 湲곕줉(ActivityHistory)???앹꽦(Create), ?쒖옉(Start/Resume), 以묐떒(Cancel), 醫낅즺(Finish) ??
- * ?쒕룞 ?앸챸二쇨린瑜?愿由ы븯???듭떖 鍮꾩쫰?덉뒪 濡쒖쭅???섑뻾?⑸땲??
- * </p>
+ * {@link ActivityHistoryService} 구현체입니다.
+ *
+ * <p>반려동물의 활동 기록 생성, 시작/재개, 취소, 종료, 조회 기능을 제공합니다.</p>
  */
 @Service
 @RequiredArgsConstructor
@@ -55,32 +50,19 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     private final RoutePointService routePointService;
 
     /**
-     * ?덈줈???쒕룞 湲곕줉???앹꽦?⑸땲??
-     * <p>
-     * <ol>
-     * <li>?ъ슜??User) 諛?諛섎젮?숇Ъ(Pet) ?뺣낫瑜?議고쉶?⑸땲??</li>
-     * <li>?붿껌???좎?媛 ?대떦 諛섎젮?숇Ъ???뱀씤??APPROVED) 二쇱씤?몄? 寃利앺빀?덈떎.</li>
-     * <li>?대떦 諛섎젮?숇Ъ???대? 吏꾪뻾 以?IN_PROGRESS)?닿굅???湲?以?BEFORE)???쒕룞???덈뒗吏 ?뺤씤?섏뿬 以묐났 ?앹꽦??諛⑹??⑸땲??</li>
-     * <li>寃利앹씠 ?꾨즺?섎㈃, ?쒕룞 ?곹깭瑜?'?쒖옉 ??BEFORE)'?쇰줈 ?ㅼ젙?섏뿬 DB????ν빀?덈떎.</li>
-     * </ol>
+     * 활동 기록을 생성합니다.
      *
-     * @param userId  ?붿껌???섑뻾?섎뒗 ?ъ슜?먯쓽 UUID
-     * @param request ?앹꽦???쒕룞 ?뺣낫媛 ?닿릿 ?붿껌 DTO (petId, activityType)
-     * @return ?앹꽦???쒕룞 湲곕줉??ID? ?좏삎???ы븿???묐떟 DTO
-     * @throws ActivityHistoryException 沅뚰븳???녾굅??{@code CREATE_PERMISSION_DENIED}),
-     * ?대? 吏꾪뻾 以?{@code ALREADY_IN_PROGRESS}) ?먮뒗 ?湲?以?{@code ALREADY_EXISTS_BEFORE})???쒕룞??議댁옱??寃쎌슦
+     * @param userId 요청 사용자 ID
+     * @param request 활동 기록 생성 요청
+     * @return 생성된 활동 기록 응답
      */
     @Transactional
     @Override
-    public ActivityCreateResponse createActivity(
-            UUID userId,
-            ActivityCreateRequest request) {
-
+    public ActivityCreateResponse createActivity(UUID userId, ActivityCreateRequest request) {
         User user = userService.getUserById(userId);
         Pet pet = petService.getPetById(request.getPetId());
 
         boolean isOwner = userPetService.isApprovedPetOwner(user.getUsersId(), pet.getPetId());
-
         if (!isOwner) {
             throw new ActivityHistoryException(CREATE_PERMISSION_DENIED);
         }
@@ -93,39 +75,25 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
             throw new ActivityHistoryException(ALREADY_EXISTS_BEFORE);
         }
 
-        ActivityHistory activityHistory = request.toEntity(user, pet);
-        ActivityHistory savedHistory = activityHistoryRepository.save(activityHistory);
+        ActivityHistory savedHistory = activityHistoryRepository.save(request.toEntity(user, pet));
 
-        log.info("?쒕룞 湲곕줉 ?앹꽦 ?꾨즺 - HistoryId: {}, PetId: {}, User: {}",
+        log.info("활동 기록 생성 완료 - HistoryId: {}, PetId: {}, User: {}",
                 savedHistory.getHistoryId(), pet.getPetId(), userId);
 
-        return ActivityCreateResponse.toDto(savedHistory, "?쒕룞 湲곕줉???깃났?곸쑝濡??앹꽦?섏뿀?듬땲??");
+        return ActivityCreateResponse.toDto(savedHistory, "활동 기록이 성공적으로 생성되었습니다.");
     }
 
     /**
-     * ?쒕룞 湲곕줉???쒖옉(IN_PROGRESS)?섍굅?? 以묐떒???쒕룞???ш컻?⑸땲??
-     * <p>
-     * ?쒕룞???꾩옱 ?곹깭???곕씪 ??媛吏 濡쒖쭅?쇰줈 遺꾧린?⑸땲??
-     * <ul>
-     * <li><b>?쒖옉 ??BEFORE):</b> 理쒖큹 ?쒖옉?쇰줈 媛꾩＜?섏뿬 ?쒖옉 ?쒓컙怨??꾩튂 ?뺣낫瑜?湲곕줉?섍퀬 ?곹깭瑜?蹂寃쏀빀?덈떎.</li>
-     * <li><b>痍⑥냼??CANCELED):</b> ?쒕룞 ?ш컻濡?媛꾩＜?섏뿬 ?곹깭瑜?蹂寃쏀븯怨?醫낅즺 ?쒓컙??珥덇린?뷀빀?덈떎. (湲곗〈 ?쒖옉 ?뺣낫 ?좎?)</li>
-     * </ul>
+     * 활동 기록을 시작하거나 재개합니다.
      *
-     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
-     * @param historyId ?쒕룞 湲곕줉 ID
-     * @param request   ?쒖옉 ?쒖젏??GPS ?꾩튂 ?뺣낫(?꾨룄, 寃쎈룄)
-     * @return 泥섎━ 寃곌낵 硫붿떆吏媛 ?닿릿 ?⑥닚 ?묐떟 DTO
-     * @throws ActivityHistoryException
-     * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉???녿뒗 寃쎌슦</li>
-     * <li>{@code START_PERMISSION_DENIED}: ?쒕룞 湲곕줉???뚯쑀?먭? ?꾨땶 寃쎌슦</li>
-     * <li>{@code ALREADY_IN_PROGRESS}: ?대? 吏꾪뻾 以묒씠嫄곕굹 醫낅즺???쒕룞??寃쎌슦</li>
-     * </ul>
+     * @param userId 요청 사용자 ID
+     * @param historyId 활동 기록 ID
+     * @param request 시작 위치 요청
+     * @return 처리 결과 응답
      */
     @Transactional
     @Override
     public ActivitySimpleResponse startActivity(UUID userId, Long historyId, ActivityStartRequest request) {
-
         ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
                 .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
 
@@ -143,16 +111,12 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                     request.getStartLatitude(),
                     request.getStartLongitude()
             );
-            log.info("?쒕룞 理쒖큹 ?쒖옉 - HistoryId: {}, User: {}", historyId, userId);
-            message = "?쒕룞 湲곕줉???쒖옉?섏뿀?듬땲??";
-
+            log.info("활동 시작 완료 - HistoryId: {}, User: {}", historyId, userId);
+            message = "활동 기록이 성공적으로 시작되었습니다.";
         } else if (status == ActivityHistoryStatus.CANCELED) {
-            activityHistoryMapper.resumeActivity(
-                    historyId,
-                    ActivityHistoryStatus.IN_PROGRESS.name()
-            );
-            log.info("?쒕룞 ?ш컻 - HistoryId: {}, User: {}", historyId, userId);
-            message = "?쒕룞 湲곕줉???ш컻?섏뿀?듬땲??";
+            activityHistoryMapper.resumeActivity(historyId, ActivityHistoryStatus.IN_PROGRESS.name());
+            log.info("활동 재개 완료 - HistoryId: {}, User: {}", historyId, userId);
+            message = "활동 기록이 성공적으로 재개되었습니다.";
         } else {
             throw new ActivityHistoryException(ALREADY_IN_PROGRESS);
         }
@@ -161,25 +125,15 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * 吏꾪뻾 以묒씤 ?쒕룞??痍⑥냼(以묐떒) ?곹깭濡?蹂寃쏀빀?덈떎.
-     * <p>
-     * ?쒕룞 ?곹깭瑜?'痍⑥냼??CANCELED)'?쇰줈 蹂寃쏀븯怨? 以묐떒???쒖젏(醫낅즺 ?쒓컙)??湲곕줉?⑸땲??
-     * </p>
+     * 진행 중인 활동을 취소합니다.
      *
-     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
-     * @param historyId ?쒕룞 湲곕줉 ID
-     * @return 泥섎━ 寃곌낵 硫붿떆吏媛 ?닿릿 ?⑥닚 ?묐떟 DTO
-     * @throws ActivityHistoryException
-     * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉???녿뒗 寃쎌슦</li>
-     * <li>{@code STOP_PERMISSION_DENIED}: ?쒕룞 湲곕줉???뚯쑀?먭? ?꾨땶 寃쎌슦</li>
-     * <li>{@code ALREADY_COMPLETED}: 吏꾪뻾 以묒씤 ?쒕룞(IN_PROGRESS)???꾨땶 寃쎌슦</li>
-     * </ul>
+     * @param userId 요청 사용자 ID
+     * @param historyId 활동 기록 ID
+     * @return 처리 결과 응답
      */
     @Transactional
     @Override
     public ActivitySimpleResponse cancelActivity(UUID userId, Long historyId) {
-
         ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
                 .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
 
@@ -192,31 +146,21 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         }
 
         activityHistoryMapper.cancelActivity(historyId, ActivityHistoryStatus.CANCELED.name());
+        log.info("활동 취소 완료 - HistoryId: {}, User: {}", historyId, userId);
 
-        log.info("?쒕룞 以묐떒(痍⑥냼) ?꾨즺 - HistoryId: {}, User: {}", historyId, userId);
-
-        return ActivitySimpleResponse.toDto("?쒕룞 湲곕줉???깃났?곸쑝濡?以묐떒?섏뿀?듬땲??");
+        return ActivitySimpleResponse.toDto("활동 기록이 성공적으로 중단되었습니다.");
     }
 
     /**
-     * 吏꾪뻾 以묒씤 ?쒕룞???꾨즺(COMPLETED) ?곹깭濡?蹂寃쏀븯怨?醫낅즺 泥섎━瑜??섑뻾?⑸땲??
-     * <p>
-     * <ol>
-     * <li>?쒕룞 湲곕줉 議댁옱 ?щ? 諛??붿껌??User)??沅뚰븳(?뚯쑀沅???寃利앺빀?덈떎.</li>
-     * <li>?쒕룞 ?곹깭媛 '?쒖옉 ??BEFORE)'?닿굅???대? '醫낅즺(COMPLETED)'??寃쎌슦 ?덉쇅瑜?諛쒖깮?쒗궢?덈떎.</li>
-     * <li>{@link RoutePointService}瑜??몄텧?섏뿬 珥??대룞 嫄곕━(Distance)瑜?怨꾩궛?⑸땲??</li>
-     * <li>?쒕룞 ?곹깭瑜?'?꾨즺(COMPLETED)'濡?蹂寃쏀븯怨??쒕쾭 ?쒓컙(NOW)?쇰줈 醫낅즺 ?쒓컙??湲곕줉?⑸땲??</li>
-     * <li>醫낅즺???쒕룞 ?뺣낫瑜??댁? ?묐떟 DTO瑜?諛섑솚?⑸땲??</li>
-     * </ol>
+     * 활동을 종료 처리합니다.
      *
-     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
-     * @param historyId ?쒕룞 湲곕줉 ID
-     * @return 醫낅즺???쒕룞 湲곕줉???곸꽭 ?뺣낫 DTO (?대룞 嫄곕━ ?ы븿)
+     * @param userId 요청 사용자 ID
+     * @param historyId 활동 기록 ID
+     * @return 종료 결과 응답
      */
     @Transactional
     @Override
     public ActivityFinishResponse finishActivity(UUID userId, Long historyId) {
-
         ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
                 .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
 
@@ -233,17 +177,10 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         }
 
         BigDecimal totalDistance = routePointService.calculateTotalDistance(historyId);
-
         LocalDateTime endTime = LocalDateTime.now();
 
-        activityHistoryMapper.finishActivity(
-                historyId,
-                "COMPLETED",
-                endTime,
-                totalDistance
-        );
-
-        log.info("?쒕룞 醫낅즺 ?꾨즺 - HistoryId: {}, User: {}, Distance: {}m", historyId, userId, totalDistance);
+        activityHistoryMapper.finishActivity(historyId, "COMPLETED", endTime, totalDistance);
+        log.info("활동 종료 완료 - HistoryId: {}, User: {}, Distance: {}m", historyId, userId, totalDistance);
 
         return ActivityFinishResponse.toDto(
                 activityHistory.getHistoryId(),
@@ -251,29 +188,20 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                 totalDistance,
                 activityHistory.getActivityHistoryStartAt(),
                 endTime,
-                "?쒕룞 湲곕줉???깃났?곸쑝濡?醫낅즺?섏뿀?듬땲??"
+                "활동 기록이 성공적으로 종료되었습니다."
         );
     }
 
     /**
-     * ?쒕룞 湲곕줉????젣?⑸땲??
-     * <p>
-     * ?쒕룞 湲곕줉 議댁옱 ?щ?? ?붿껌??User)???뚯쑀沅뚯쓣 寃利앺븳 ??
-     * <b>JPA Repository</b>瑜??ъ슜?섏뿬 ?곗씠?곕? ??젣?⑸땲??
-     * </p>
+     * 활동 기록을 삭제합니다.
      *
-     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
-     * @param historyId ??젣???쒕룞 湲곕줉 ID
-     * @throws ActivityHistoryException
-     * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉???녿뒗 寃쎌슦</li>
-     * <li>{@code DELETE_PERMISSION_DENIED}: ?쒕룞 湲곕줉???뚯쑀?먭? ?꾨땶 寃쎌슦</li>
-     * </ul>
+     * @param userId 요청 사용자 ID
+     * @param historyId 활동 기록 ID
+     * @return 처리 결과 응답
      */
     @Transactional
     @Override
     public ActivitySimpleResponse deleteActivity(UUID userId, Long historyId) {
-
         ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
                 .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
 
@@ -282,26 +210,22 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         }
 
         activityHistoryRepository.delete(activityHistory);
+        log.info("활동 기록 삭제 완료 - HistoryId: {}, User: {}", historyId, userId);
 
-        log.info("?쒕룞 湲곕줉 ??젣 ?꾨즺 (JPA) - HistoryId: {}, User: {}", historyId, userId);
-
-        return ActivitySimpleResponse.toDto("?쒕룞 湲곕줉???깃났?곸쑝濡???젣?섏뿀?듬땲??");
+        return ActivitySimpleResponse.toDto("활동 기록이 성공적으로 삭제되었습니다.");
     }
 
     /**
-     * ???쒕룞 湲곕줉??議고쉶?⑸땲?? (?섏씠吏?ㅼ씠??吏??
-     * <p>
-     * 1. ?ъ슜??ID濡??쒕룞 湲곕줉???섏씠吏?議고쉶?⑸땲?? (JPA媛 ?뺣젹 泥섎━)
-     * 2. 議고쉶??湲곕줉?먯꽌 諛섎젮?숇Ъ ID瑜?異붿텧?섏뿬 ?꾨줈???대?吏瑜??쇨큵 議고쉶?⑸땲??(N+1 諛⑹?).
-     * 3. ?뷀떚?곕? DTO濡?蹂?섑븯??諛섑솚?⑸땲??
-     * </p>
+     * 내 활동 기록 목록을 조회합니다.
+     *
+     * @param userId 요청 사용자 ID
+     * @param pageable 페이지 정보
+     * @return 페이징된 활동 기록 응답
      */
     @Transactional(readOnly = true)
     @Override
     public ActivityHistoryPageResponse getMyActivityHistory(UUID userId, Pageable pageable) {
-
         User user = userService.getUserById(userId);
-
         Page<ActivityHistory> historyPage = activityHistoryRepository.findAllByUser(user, pageable);
 
         List<Long> petIds = historyPage.getContent().stream()
@@ -312,32 +236,22 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         Map<Long, String> petImageMap = imageFileService.getProfileUrlsByPetIds(petIds);
 
         List<ActivityHistorySummary> summaries = historyPage.getContent().stream()
-                .map(history -> {
-                    String profileUrl = petImageMap.get(history.getPet().getPetId());
-                    return ActivityHistorySummary.toDto(history, profileUrl);
-                })
+                .map(history -> ActivityHistorySummary.toDto(history, petImageMap.get(history.getPet().getPetId())))
                 .toList();
 
         return ActivityHistoryPageResponse.toDto(
-                "?쒕룞 湲곕줉 紐⑸줉???깃났?곸쑝濡?議고쉶?덉뒿?덈떎.",
+                "활동 기록 목록을 성공적으로 조회했습니다.",
                 historyPage,
                 summaries
         );
     }
 
     /**
-     * ?뱀젙 ?쒕룞 湲곕줉???곸꽭 ?뺣낫瑜?議고쉶?⑸땲??
+     * 활동 기록 상세를 조회합니다.
      *
-     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
-     * @param historyId 議고쉶???쒕룞 湲곕줉??ID
-     * @return ?쒕룞 湲곕줉???곸꽭 ?뺣낫 DTO {@link ActivityHistoryDetailResponse}
-     * @throws ActivityHistoryException
-     * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉??議댁옱?섏? ?딅뒗 寃쎌슦</li>
-     * <li>{@code VIEW_PERMISSION_DENIED}: ?붿껌?먭? ?대떦 諛섎젮?숇Ъ??媛議?援ъ꽦?먯씠 ?꾨땶 寃쎌슦</li>
-     * <li>{@code ACTIVITY_NOT_STARTED}: ?쒕룞???꾩쭅 ?쒖옉?섏? ?딆? 寃쎌슦</li>
-     * <li>{@code INVALID_REQUEST}: ?쒕룞??吏꾪뻾 以묒씠嫄곕굹 痍⑥냼???곹깭??寃쎌슦</li>
-     * </ul>
+     * @param userId 요청 사용자 ID
+     * @param historyId 활동 기록 ID
+     * @return 활동 기록 상세 응답
      */
     @Transactional(readOnly = true)
     @Override
@@ -350,7 +264,6 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         }
 
         String status = activityHistory.getActivityHistoryStatus().name();
-
         if ("BEFORE".equals(status)) {
             throw new ActivityHistoryException(ACTIVITY_NOT_STARTED);
         }
@@ -360,7 +273,7 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         }
 
         return ActivityHistoryDetailResponse.toDto(
-                "?대떦 ?쒕룞 ?뺣낫瑜??깃났?곸쑝濡?議고쉶?덉뒿?덈떎.",
+                "해당 활동 정보를 성공적으로 조회했습니다.",
                 activityHistory.getHistoryId(),
                 activityHistory.getPet().getPetId(),
                 activityHistory.getDistance(),
@@ -374,22 +287,15 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * ?뱀젙 諛섎젮?숇Ъ???꾩옱 ?쒕룞 ?곹깭瑜?議고쉶?⑸땲??
-     * <p>
-     * 1. 諛섎젮?숇Ъ 議댁옱 ?щ?? ?붿껌?먯쓽 議고쉶 沅뚰븳??寃利앺빀?덈떎.
-     * 2. 媛??理쒓렐???쒕룞 湲곕줉??議고쉶?섏뿬 ?곹깭蹂꾨줈 硫붿떆吏? ID ?ы븿 ?щ?瑜?寃곗젙?⑸땲??
-     * - IN_PROGRESS, BEFORE, CANCELED: ?≪뀡???꾩슂???곹깭?대?濡?historyId瑜?諛섑솚?⑸땲??
-     * - COMPLETED: ?꾨즺???곹깭?대?濡?ID瑜?諛섑솚?섏? ?딆뒿?덈떎.
-     * </p>
+     * 반려동물의 현재 활동 상태를 조회합니다.
      *
-     * @param userId ?붿껌???ъ슜?먯쓽 UUID
-     * @param petId  ?곹깭瑜?議고쉶??諛섎젮?숇Ъ??ID
-     * @return ?쒕룞 ?곹깭 ?묐떟 DTO {@link ActivityStatusResponse}
+     * @param userId 요청 사용자 ID
+     * @param petId 반려동물 ID
+     * @return 활동 상태 응답
      */
     @Transactional(readOnly = true)
     @Override
     public ActivityStatusResponse getPetActivityStatus(UUID userId, Long petId) {
-
         Pet pet = petService.getPetById(petId);
 
         if (!userPetService.isApprovedPetOwner(userId, petId)) {
@@ -400,9 +306,11 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * ?붾컮?댁뒪 ?좏겙 subject? 諛섎젮?숇Ъ ID??留ㅽ븨??寃利앺븳 ???쒕룞 ?곹깭瑜?議고쉶?⑸땲??
+     * 디바이스 토큰 기반으로 반려동물의 현재 활동 상태를 조회합니다.
+     *
+     * @param devicePrincipal 디바이스 principal
+     * @param petId 반려동물 ID
+     * @return 활동 상태 응답
      */
     @Transactional(readOnly = true)
     @Override
@@ -417,30 +325,17 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * ?뱀젙 ?쒕룞 湲곕줉???곸꽭 寃쎈줈(GPS 醫뚰몴 由ъ뒪??瑜?議고쉶?⑸땲??
-     * <p>
-     * 1. ?쒕룞 湲곕줉(History)??議댁옱 ?щ?瑜??뺤씤?⑸땲??
-     * 2. ?붿껌???ъ슜??User)媛 ?대떦 諛섎젮?숇Ъ???뱀씤??蹂댄샇?먯씤吏 沅뚰븳??寃利앺빀?덈떎.
-     * 3. RoutePointService瑜??듯빐 寃쎈줈 ?곗씠?곕? Map 由ъ뒪???뺥깭濡?議고쉶?⑸땲?? (Entity 吏곸젒 ?섏〈 ?쒓굅)
-     * 4. 議고쉶???곗씠?곕? Response DTO濡?蹂?섑븯??諛섑솚?⑸땲??
-     * </p>
+     * 활동 기록의 경로 정보를 조회합니다.
      *
-     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
-     * @param historyId 議고쉶???쒕룞 湲곕줉??ID
-     * @return ?곸꽭 寃쎈줈 諛??쒕룞 ?뺣낫 ?묐떟 DTO {@link ActivityRouteResponse}
-     * @throws ActivityHistoryException
-     * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉??議댁옱?섏? ?딅뒗 寃쎌슦</li>
-     * <li>{@code VIEW_PERMISSION_DENIED}: ?붿껌?먭? ?대떦 諛섎젮?숇Ъ??蹂댄샇?먭? ?꾨땶 寃쎌슦</li>
-     * </ul>
+     * @param userId 요청 사용자 ID
+     * @param historyId 활동 기록 ID
+     * @return 활동 경로 응답
      */
     @Transactional(readOnly = true)
     @Override
     public ActivityRouteResponse getActivityRoute(UUID userId, Long historyId) {
-
         ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
                 .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
-
 
         if (!userPetService.isApprovedPetOwner(userId, activityHistory.getPet().getPetId())) {
             throw new ActivityHistoryException(VIEW_PERMISSION_DENIED);
@@ -460,22 +355,18 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         return ActivityRouteResponse.toDto(
                 activityHistory,
                 routePointDtos,
-                "?곸꽭 寃쎈줈瑜?媛?몄삤?붾뜲 ?깃났?덉뒿?덈떎."
+                "상세 경로를 가져오는데 성공했습니다."
         );
     }
 
     /**
-     * 嫄닿컯 遺꾩꽍 由ы룷???앹꽦???꾪빐 遺꾩꽍 ?⑥쐞蹂??쒕룞 湲곕줉??議고쉶?섍퀬 Map ?뺥깭濡?蹂?섑빀?덈떎.
-     * <p>
-     * 遺꾩꽍 ?⑥쐞???곕씪 ?쒕줈 ?ㅻⅨ Repository 硫붿꽌?쒕? ?몄텧?섎ŉ,
-     * 諛섑솚 ???뷀떚?곕? ?몃?濡??몄텧?섏? ?딄퀬 ?꾩슂???꾨뱶留?異붿텧?⑸땲??
-     * </p>
+     * 건강 분석 범위에 해당하는 활동 기록을 조회합니다.
      *
-     * @param petId         諛섎젮?숇Ъ ID
-     * @param analysisType  遺꾩꽍 ?⑥쐞 (DAILY/WEEKLY/MONTHLY)
-     * @param startDateTime 議고쉶 ?쒖옉 ?쒓컖 (?ы븿)
-     * @param endDateTime   議고쉶 醫낅즺 ?쒓컖 (誘명룷???먮뒗 踰붿쐞 ?곹븳)
-     * @return ?쒕룞 ?곗씠??紐⑸줉 (historyId, distance, startAt, endAt, status, activityType ??
+     * @param petId 반려동물 ID
+     * @param analysisType 분석 범위(DAILY, WEEKLY, MONTHLY)
+     * @param startDateTime 조회 시작 시각
+     * @param endDateTime 조회 종료 시각
+     * @return 분석용 활동 기록 목록
      */
     @Transactional(readOnly = true)
     @Override
@@ -488,22 +379,25 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         List<ActivityHistory> activityHistories;
 
         if ("DAILY".equals(analysisType)) {
-            activityHistories = activityHistoryRepository.findAllByPet_PetIdAndActivityHistoryStartAtGreaterThanEqualAndActivityHistoryStartAtLessThanOrderByActivityHistoryStartAtAsc(
-                    petId,
-                    startDateTime,
-                    endDateTime
-            );
+            activityHistories = activityHistoryRepository
+                    .findAllByPet_PetIdAndActivityHistoryStartAtGreaterThanEqualAndActivityHistoryStartAtLessThanOrderByActivityHistoryStartAtAsc(
+                            petId,
+                            startDateTime,
+                            endDateTime
+                    );
         } else if ("WEEKLY".equals(analysisType)) {
-            activityHistories = activityHistoryRepository.findAllByPet_PetIdAndActivityHistoryStartAtGreaterThanEqualOrderByActivityHistoryStartAtAsc(
-                    petId,
-                    startDateTime
-            );
+            activityHistories = activityHistoryRepository
+                    .findAllByPet_PetIdAndActivityHistoryStartAtGreaterThanEqualOrderByActivityHistoryStartAtAsc(
+                            petId,
+                            startDateTime
+                    );
         } else {
-            activityHistories = activityHistoryRepository.findAllByPet_PetIdAndActivityHistoryStartAtBetweenOrderByActivityHistoryStartAtAsc(
-                    petId,
-                    startDateTime,
-                    endDateTime
-            );
+            activityHistories = activityHistoryRepository
+                    .findAllByPet_PetIdAndActivityHistoryStartAtBetweenOrderByActivityHistoryStartAtAsc(
+                            petId,
+                            startDateTime,
+                            endDateTime
+                    );
         }
 
         List<Map<String, Object>> result = new java.util.ArrayList<>();
@@ -523,10 +417,10 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * ?뱀젙 諛섎젮?숇Ъ??理쒖떊 ?쒕룞 ?곹깭瑜?議고쉶???곹깭 硫붿떆吏? historyId瑜?議고빀???묐떟 DTO瑜??앹꽦?⑸땲??
+     * 반려동물의 최신 활동 상태 메시지를 생성합니다.
      *
-     * @param pet 議고쉶 ???諛섎젮?숇Ъ ?뷀떚??
-     * @return ?쒕룞 ?곹깭 ?묐떟 DTO
+     * @param pet 반려동물 엔티티
+     * @return 활동 상태 응답
      */
     private ActivityStatusResponse buildActivityStatusResponse(Pet pet) {
         return activityHistoryRepository.findFirstByPetOrderByHistoryIdDesc(pet)
@@ -534,28 +428,30 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                     String status = history.getActivityHistoryStatus().name();
 
                     if ("IN_PROGRESS".equals(status)) {
-                        return ActivityStatusResponse.toDto("?쒕룞 湲곕줉以묒씤 ?좎셿?숇Ъ?낅땲??", history.getHistoryId());
+                        return ActivityStatusResponse.toDto("활동 기록중인 애완동물입니다.", history.getHistoryId());
                     } else if ("BEFORE".equals(status)) {
-                        return ActivityStatusResponse.toDto("?쒕룞 ?쒖옉 ???곹깭?낅땲??", history.getHistoryId());
+                        return ActivityStatusResponse.toDto("활동 시작 전 상태입니다.", history.getHistoryId());
                     } else if ("CANCELED".equals(status)) {
-                        return ActivityStatusResponse.toDto("?쒕룞??以묐떒???곹깭?낅땲??", history.getHistoryId());
+                        return ActivityStatusResponse.toDto("활동이 중단된 상태입니다.", history.getHistoryId());
                     } else {
-                        return ActivityStatusResponse.toDto("?꾩옱 吏꾪뻾 以묒씤 ?쒕룞???놁뒿?덈떎.", null);
+                        return ActivityStatusResponse.toDto("현재 진행 중인 활동이 없습니다.", null);
                     }
                 })
-                .orElseGet(() -> ActivityStatusResponse.toDto("?쒕룞 湲곕줉???놁뒿?덈떎.", null));
+                .orElseGet(() -> ActivityStatusResponse.toDto("활동 기록이 없습니다.", null));
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * ?쒕룞 湲곕줉???곌껐??諛섎젮?숇Ъ ID濡??앹꽦???붾컮?댁뒪 UUID? ?꾩옱 Principal 媛믪쓣 鍮꾧탳?섏뿬 沅뚰븳??寃利앺빀?덈떎.
+     * 활동 기록에 연결된 반려동물의 디바이스 principal 권한을 확인합니다.
+     *
+     * @param historyId 활동 기록 ID
+     * @param devicePrincipal 디바이스 principal
+     * @return 권한 여부
      */
     @Transactional(readOnly = true)
     @Override
     public boolean isDeviceAuthorizedForHistory(Long historyId, String devicePrincipal) {
         ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
-                .orElseThrow(() -> new IllegalArgumentException("?대떦 ?쒕룞 湲곕줉??李얠쓣 ???놁뒿?덈떎."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 활동 기록을 찾을 수 없습니다."));
 
         Long petId = activityHistory.getPet().getPetId();
         String expectedDevicePrincipal = UUID.nameUUIDFromBytes(("DEVICE:" + petId).getBytes(StandardCharsets.UTF_8))
@@ -565,7 +461,10 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * {@inheritDoc}
+     * 활동 기록 ID로 엔티티를 조회합니다.
+     *
+     * @param historyId 활동 기록 ID
+     * @return 활동 기록 엔티티
      */
     @Transactional(readOnly = true)
     @Override
@@ -574,4 +473,3 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                 .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
     }
 }
-

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
@@ -35,10 +35,10 @@ import static com.dodo.backend.activityhistory.dto.request.ActivityHistoryReques
 import static com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCode.*;
 
 /**
- * {@link ActivityHistoryService} 인터페이스의 구현체 클래스입니다.
+ * {@link ActivityHistoryService} ?명꽣?섏씠?ㅼ쓽 援ы쁽泥??대옒?ㅼ엯?덈떎.
  * <p>
- * 반려동물의 활동 기록(ActivityHistory)의 생성(Create), 시작(Start/Resume), 중단(Cancel), 종료(Finish) 등
- * 활동 생명주기를 관리하는 핵심 비즈니스 로직을 수행합니다.
+ * 諛섎젮?숇Ъ???쒕룞 湲곕줉(ActivityHistory)???앹꽦(Create), ?쒖옉(Start/Resume), 以묐떒(Cancel), 醫낅즺(Finish) ??
+ * ?쒕룞 ?앸챸二쇨린瑜?愿由ы븯???듭떖 鍮꾩쫰?덉뒪 濡쒖쭅???섑뻾?⑸땲??
  * </p>
  */
 @Service
@@ -55,20 +55,20 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     private final RoutePointService routePointService;
 
     /**
-     * 새로운 활동 기록을 생성합니다.
+     * ?덈줈???쒕룞 湲곕줉???앹꽦?⑸땲??
      * <p>
      * <ol>
-     * <li>사용자(User) 및 반려동물(Pet) 정보를 조회합니다.</li>
-     * <li>요청한 유저가 해당 반려동물의 승인된(APPROVED) 주인인지 검증합니다.</li>
-     * <li>해당 반려동물이 이미 진행 중(IN_PROGRESS)이거나 대기 중(BEFORE)인 활동이 있는지 확인하여 중복 생성을 방지합니다.</li>
-     * <li>검증이 완료되면, 활동 상태를 '시작 전(BEFORE)'으로 설정하여 DB에 저장합니다.</li>
+     * <li>?ъ슜??User) 諛?諛섎젮?숇Ъ(Pet) ?뺣낫瑜?議고쉶?⑸땲??</li>
+     * <li>?붿껌???좎?媛 ?대떦 諛섎젮?숇Ъ???뱀씤??APPROVED) 二쇱씤?몄? 寃利앺빀?덈떎.</li>
+     * <li>?대떦 諛섎젮?숇Ъ???대? 吏꾪뻾 以?IN_PROGRESS)?닿굅???湲?以?BEFORE)???쒕룞???덈뒗吏 ?뺤씤?섏뿬 以묐났 ?앹꽦??諛⑹??⑸땲??</li>
+     * <li>寃利앹씠 ?꾨즺?섎㈃, ?쒕룞 ?곹깭瑜?'?쒖옉 ??BEFORE)'?쇰줈 ?ㅼ젙?섏뿬 DB????ν빀?덈떎.</li>
      * </ol>
      *
-     * @param userId  요청을 수행하는 사용자의 UUID
-     * @param request 생성할 활동 정보가 담긴 요청 DTO (petId, activityType)
-     * @return 생성된 활동 기록의 ID와 유형을 포함한 응답 DTO
-     * @throws ActivityHistoryException 권한이 없거나({@code CREATE_PERMISSION_DENIED}),
-     * 이미 진행 중({@code ALREADY_IN_PROGRESS}) 또는 대기 중({@code ALREADY_EXISTS_BEFORE})인 활동이 존재할 경우
+     * @param userId  ?붿껌???섑뻾?섎뒗 ?ъ슜?먯쓽 UUID
+     * @param request ?앹꽦???쒕룞 ?뺣낫媛 ?닿릿 ?붿껌 DTO (petId, activityType)
+     * @return ?앹꽦???쒕룞 湲곕줉??ID? ?좏삎???ы븿???묐떟 DTO
+     * @throws ActivityHistoryException 沅뚰븳???녾굅??{@code CREATE_PERMISSION_DENIED}),
+     * ?대? 吏꾪뻾 以?{@code ALREADY_IN_PROGRESS}) ?먮뒗 ?湲?以?{@code ALREADY_EXISTS_BEFORE})???쒕룞??議댁옱??寃쎌슦
      */
     @Transactional
     @Override
@@ -96,30 +96,30 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         ActivityHistory activityHistory = request.toEntity(user, pet);
         ActivityHistory savedHistory = activityHistoryRepository.save(activityHistory);
 
-        log.info("활동 기록 생성 완료 - HistoryId: {}, PetId: {}, User: {}",
+        log.info("?쒕룞 湲곕줉 ?앹꽦 ?꾨즺 - HistoryId: {}, PetId: {}, User: {}",
                 savedHistory.getHistoryId(), pet.getPetId(), userId);
 
-        return ActivityCreateResponse.toDto(savedHistory, "활동 기록이 성공적으로 생성되었습니다.");
+        return ActivityCreateResponse.toDto(savedHistory, "?쒕룞 湲곕줉???깃났?곸쑝濡??앹꽦?섏뿀?듬땲??");
     }
 
     /**
-     * 활동 기록을 시작(IN_PROGRESS)하거나, 중단된 활동을 재개합니다.
+     * ?쒕룞 湲곕줉???쒖옉(IN_PROGRESS)?섍굅?? 以묐떒???쒕룞???ш컻?⑸땲??
      * <p>
-     * 활동의 현재 상태에 따라 두 가지 로직으로 분기됩니다:
+     * ?쒕룞???꾩옱 ?곹깭???곕씪 ??媛吏 濡쒖쭅?쇰줈 遺꾧린?⑸땲??
      * <ul>
-     * <li><b>시작 전(BEFORE):</b> 최초 시작으로 간주하여 시작 시간과 위치 정보를 기록하고 상태를 변경합니다.</li>
-     * <li><b>취소됨(CANCELED):</b> 활동 재개로 간주하여 상태를 변경하고 종료 시간을 초기화합니다. (기존 시작 정보 유지)</li>
+     * <li><b>?쒖옉 ??BEFORE):</b> 理쒖큹 ?쒖옉?쇰줈 媛꾩＜?섏뿬 ?쒖옉 ?쒓컙怨??꾩튂 ?뺣낫瑜?湲곕줉?섍퀬 ?곹깭瑜?蹂寃쏀빀?덈떎.</li>
+     * <li><b>痍⑥냼??CANCELED):</b> ?쒕룞 ?ш컻濡?媛꾩＜?섏뿬 ?곹깭瑜?蹂寃쏀븯怨?醫낅즺 ?쒓컙??珥덇린?뷀빀?덈떎. (湲곗〈 ?쒖옉 ?뺣낫 ?좎?)</li>
      * </ul>
      *
-     * @param userId    요청한 사용자의 UUID
-     * @param historyId 활동 기록 ID
-     * @param request   시작 시점의 GPS 위치 정보(위도, 경도)
-     * @return 처리 결과 메시지가 담긴 단순 응답 DTO
+     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
+     * @param historyId ?쒕룞 湲곕줉 ID
+     * @param request   ?쒖옉 ?쒖젏??GPS ?꾩튂 ?뺣낫(?꾨룄, 寃쎈룄)
+     * @return 泥섎━ 寃곌낵 硫붿떆吏媛 ?닿릿 ?⑥닚 ?묐떟 DTO
      * @throws ActivityHistoryException
      * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 없는 경우</li>
-     * <li>{@code START_PERMISSION_DENIED}: 활동 기록의 소유자가 아닌 경우</li>
-     * <li>{@code ALREADY_IN_PROGRESS}: 이미 진행 중이거나 종료된 활동인 경우</li>
+     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉???녿뒗 寃쎌슦</li>
+     * <li>{@code START_PERMISSION_DENIED}: ?쒕룞 湲곕줉???뚯쑀?먭? ?꾨땶 寃쎌슦</li>
+     * <li>{@code ALREADY_IN_PROGRESS}: ?대? 吏꾪뻾 以묒씠嫄곕굹 醫낅즺???쒕룞??寃쎌슦</li>
      * </ul>
      */
     @Transactional
@@ -143,16 +143,16 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                     request.getStartLatitude(),
                     request.getStartLongitude()
             );
-            log.info("활동 최초 시작 - HistoryId: {}, User: {}", historyId, userId);
-            message = "활동 기록이 시작되었습니다.";
+            log.info("?쒕룞 理쒖큹 ?쒖옉 - HistoryId: {}, User: {}", historyId, userId);
+            message = "?쒕룞 湲곕줉???쒖옉?섏뿀?듬땲??";
 
         } else if (status == ActivityHistoryStatus.CANCELED) {
             activityHistoryMapper.resumeActivity(
                     historyId,
                     ActivityHistoryStatus.IN_PROGRESS.name()
             );
-            log.info("활동 재개 - HistoryId: {}, User: {}", historyId, userId);
-            message = "활동 기록이 재개되었습니다.";
+            log.info("?쒕룞 ?ш컻 - HistoryId: {}, User: {}", historyId, userId);
+            message = "?쒕룞 湲곕줉???ш컻?섏뿀?듬땲??";
         } else {
             throw new ActivityHistoryException(ALREADY_IN_PROGRESS);
         }
@@ -161,19 +161,19 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * 진행 중인 활동을 취소(중단) 상태로 변경합니다.
+     * 吏꾪뻾 以묒씤 ?쒕룞??痍⑥냼(以묐떒) ?곹깭濡?蹂寃쏀빀?덈떎.
      * <p>
-     * 활동 상태를 '취소됨(CANCELED)'으로 변경하고, 중단된 시점(종료 시간)을 기록합니다.
+     * ?쒕룞 ?곹깭瑜?'痍⑥냼??CANCELED)'?쇰줈 蹂寃쏀븯怨? 以묐떒???쒖젏(醫낅즺 ?쒓컙)??湲곕줉?⑸땲??
      * </p>
      *
-     * @param userId    요청한 사용자의 UUID
-     * @param historyId 활동 기록 ID
-     * @return 처리 결과 메시지가 담긴 단순 응답 DTO
+     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
+     * @param historyId ?쒕룞 湲곕줉 ID
+     * @return 泥섎━ 寃곌낵 硫붿떆吏媛 ?닿릿 ?⑥닚 ?묐떟 DTO
      * @throws ActivityHistoryException
      * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 없는 경우</li>
-     * <li>{@code STOP_PERMISSION_DENIED}: 활동 기록의 소유자가 아닌 경우</li>
-     * <li>{@code ALREADY_COMPLETED}: 진행 중인 활동(IN_PROGRESS)이 아닌 경우</li>
+     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉???녿뒗 寃쎌슦</li>
+     * <li>{@code STOP_PERMISSION_DENIED}: ?쒕룞 湲곕줉???뚯쑀?먭? ?꾨땶 寃쎌슦</li>
+     * <li>{@code ALREADY_COMPLETED}: 吏꾪뻾 以묒씤 ?쒕룞(IN_PROGRESS)???꾨땶 寃쎌슦</li>
      * </ul>
      */
     @Transactional
@@ -193,25 +193,25 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
 
         activityHistoryMapper.cancelActivity(historyId, ActivityHistoryStatus.CANCELED.name());
 
-        log.info("활동 중단(취소) 완료 - HistoryId: {}, User: {}", historyId, userId);
+        log.info("?쒕룞 以묐떒(痍⑥냼) ?꾨즺 - HistoryId: {}, User: {}", historyId, userId);
 
-        return ActivitySimpleResponse.toDto("활동 기록이 성공적으로 중단되었습니다.");
+        return ActivitySimpleResponse.toDto("?쒕룞 湲곕줉???깃났?곸쑝濡?以묐떒?섏뿀?듬땲??");
     }
 
     /**
-     * 진행 중인 활동을 완료(COMPLETED) 상태로 변경하고 종료 처리를 수행합니다.
+     * 吏꾪뻾 以묒씤 ?쒕룞???꾨즺(COMPLETED) ?곹깭濡?蹂寃쏀븯怨?醫낅즺 泥섎━瑜??섑뻾?⑸땲??
      * <p>
      * <ol>
-     * <li>활동 기록 존재 여부 및 요청자(User)의 권한(소유권)을 검증합니다.</li>
-     * <li>활동 상태가 '시작 전(BEFORE)'이거나 이미 '종료(COMPLETED)'된 경우 예외를 발생시킵니다.</li>
-     * <li>{@link RoutePointService}를 호출하여 총 이동 거리(Distance)를 계산합니다.</li>
-     * <li>활동 상태를 '완료(COMPLETED)'로 변경하고 서버 시간(NOW)으로 종료 시간을 기록합니다.</li>
-     * <li>종료된 활동 정보를 담은 응답 DTO를 반환합니다.</li>
+     * <li>?쒕룞 湲곕줉 議댁옱 ?щ? 諛??붿껌??User)??沅뚰븳(?뚯쑀沅???寃利앺빀?덈떎.</li>
+     * <li>?쒕룞 ?곹깭媛 '?쒖옉 ??BEFORE)'?닿굅???대? '醫낅즺(COMPLETED)'??寃쎌슦 ?덉쇅瑜?諛쒖깮?쒗궢?덈떎.</li>
+     * <li>{@link RoutePointService}瑜??몄텧?섏뿬 珥??대룞 嫄곕━(Distance)瑜?怨꾩궛?⑸땲??</li>
+     * <li>?쒕룞 ?곹깭瑜?'?꾨즺(COMPLETED)'濡?蹂寃쏀븯怨??쒕쾭 ?쒓컙(NOW)?쇰줈 醫낅즺 ?쒓컙??湲곕줉?⑸땲??</li>
+     * <li>醫낅즺???쒕룞 ?뺣낫瑜??댁? ?묐떟 DTO瑜?諛섑솚?⑸땲??</li>
      * </ol>
      *
-     * @param userId    요청한 사용자의 UUID
-     * @param historyId 활동 기록 ID
-     * @return 종료된 활동 기록의 상세 정보 DTO (이동 거리 포함)
+     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
+     * @param historyId ?쒕룞 湲곕줉 ID
+     * @return 醫낅즺???쒕룞 湲곕줉???곸꽭 ?뺣낫 DTO (?대룞 嫄곕━ ?ы븿)
      */
     @Transactional
     @Override
@@ -243,7 +243,7 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                 totalDistance
         );
 
-        log.info("활동 종료 완료 - HistoryId: {}, User: {}, Distance: {}m", historyId, userId, totalDistance);
+        log.info("?쒕룞 醫낅즺 ?꾨즺 - HistoryId: {}, User: {}, Distance: {}m", historyId, userId, totalDistance);
 
         return ActivityFinishResponse.toDto(
                 activityHistory.getHistoryId(),
@@ -251,23 +251,23 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                 totalDistance,
                 activityHistory.getActivityHistoryStartAt(),
                 endTime,
-                "활동 기록이 성공적으로 종료되었습니다."
+                "?쒕룞 湲곕줉???깃났?곸쑝濡?醫낅즺?섏뿀?듬땲??"
         );
     }
 
     /**
-     * 활동 기록을 삭제합니다.
+     * ?쒕룞 湲곕줉????젣?⑸땲??
      * <p>
-     * 활동 기록 존재 여부와 요청자(User)의 소유권을 검증한 후,
-     * <b>JPA Repository</b>를 사용하여 데이터를 삭제합니다.
+     * ?쒕룞 湲곕줉 議댁옱 ?щ?? ?붿껌??User)???뚯쑀沅뚯쓣 寃利앺븳 ??
+     * <b>JPA Repository</b>瑜??ъ슜?섏뿬 ?곗씠?곕? ??젣?⑸땲??
      * </p>
      *
-     * @param userId    요청한 사용자의 UUID
-     * @param historyId 삭제할 활동 기록 ID
+     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
+     * @param historyId ??젣???쒕룞 湲곕줉 ID
      * @throws ActivityHistoryException
      * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 없는 경우</li>
-     * <li>{@code DELETE_PERMISSION_DENIED}: 활동 기록의 소유자가 아닌 경우</li>
+     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉???녿뒗 寃쎌슦</li>
+     * <li>{@code DELETE_PERMISSION_DENIED}: ?쒕룞 湲곕줉???뚯쑀?먭? ?꾨땶 寃쎌슦</li>
      * </ul>
      */
     @Transactional
@@ -283,17 +283,17 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
 
         activityHistoryRepository.delete(activityHistory);
 
-        log.info("활동 기록 삭제 완료 (JPA) - HistoryId: {}, User: {}", historyId, userId);
+        log.info("?쒕룞 湲곕줉 ??젣 ?꾨즺 (JPA) - HistoryId: {}, User: {}", historyId, userId);
 
-        return ActivitySimpleResponse.toDto("활동 기록이 성공적으로 삭제되었습니다.");
+        return ActivitySimpleResponse.toDto("?쒕룞 湲곕줉???깃났?곸쑝濡???젣?섏뿀?듬땲??");
     }
 
     /**
-     * 내 활동 기록을 조회합니다. (페이지네이션 지원)
+     * ???쒕룞 湲곕줉??議고쉶?⑸땲?? (?섏씠吏?ㅼ씠??吏??
      * <p>
-     * 1. 사용자 ID로 활동 기록을 페이징 조회합니다. (JPA가 정렬 처리)
-     * 2. 조회된 기록에서 반려동물 ID를 추출하여 프로필 이미지를 일괄 조회합니다 (N+1 방지).
-     * 3. 엔티티를 DTO로 변환하여 반환합니다.
+     * 1. ?ъ슜??ID濡??쒕룞 湲곕줉???섏씠吏?議고쉶?⑸땲?? (JPA媛 ?뺣젹 泥섎━)
+     * 2. 議고쉶??湲곕줉?먯꽌 諛섎젮?숇Ъ ID瑜?異붿텧?섏뿬 ?꾨줈???대?吏瑜??쇨큵 議고쉶?⑸땲??(N+1 諛⑹?).
+     * 3. ?뷀떚?곕? DTO濡?蹂?섑븯??諛섑솚?⑸땲??
      * </p>
      */
     @Transactional(readOnly = true)
@@ -319,24 +319,24 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                 .toList();
 
         return ActivityHistoryPageResponse.toDto(
-                "활동 기록 목록을 성공적으로 조회했습니다.",
+                "?쒕룞 湲곕줉 紐⑸줉???깃났?곸쑝濡?議고쉶?덉뒿?덈떎.",
                 historyPage,
                 summaries
         );
     }
 
     /**
-     * 특정 활동 기록의 상세 정보를 조회합니다.
+     * ?뱀젙 ?쒕룞 湲곕줉???곸꽭 ?뺣낫瑜?議고쉶?⑸땲??
      *
-     * @param userId    요청한 사용자의 UUID
-     * @param historyId 조회할 활동 기록의 ID
-     * @return 활동 기록의 상세 정보 DTO {@link ActivityHistoryDetailResponse}
+     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
+     * @param historyId 議고쉶???쒕룞 湲곕줉??ID
+     * @return ?쒕룞 湲곕줉???곸꽭 ?뺣낫 DTO {@link ActivityHistoryDetailResponse}
      * @throws ActivityHistoryException
      * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 존재하지 않는 경우</li>
-     * <li>{@code VIEW_PERMISSION_DENIED}: 요청자가 해당 반려동물의 가족 구성원이 아닌 경우</li>
-     * <li>{@code ACTIVITY_NOT_STARTED}: 활동이 아직 시작되지 않은 경우</li>
-     * <li>{@code INVALID_REQUEST}: 활동이 진행 중이거나 취소된 상태인 경우</li>
+     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉??議댁옱?섏? ?딅뒗 寃쎌슦</li>
+     * <li>{@code VIEW_PERMISSION_DENIED}: ?붿껌?먭? ?대떦 諛섎젮?숇Ъ??媛議?援ъ꽦?먯씠 ?꾨땶 寃쎌슦</li>
+     * <li>{@code ACTIVITY_NOT_STARTED}: ?쒕룞???꾩쭅 ?쒖옉?섏? ?딆? 寃쎌슦</li>
+     * <li>{@code INVALID_REQUEST}: ?쒕룞??吏꾪뻾 以묒씠嫄곕굹 痍⑥냼???곹깭??寃쎌슦</li>
      * </ul>
      */
     @Transactional(readOnly = true)
@@ -360,7 +360,7 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         }
 
         return ActivityHistoryDetailResponse.toDto(
-                "해당 활동 정보를 성공적으로 조회했습니다.",
+                "?대떦 ?쒕룞 ?뺣낫瑜??깃났?곸쑝濡?議고쉶?덉뒿?덈떎.",
                 activityHistory.getHistoryId(),
                 activityHistory.getPet().getPetId(),
                 activityHistory.getDistance(),
@@ -374,17 +374,17 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * 특정 반려동물의 현재 활동 상태를 조회합니다.
+     * ?뱀젙 諛섎젮?숇Ъ???꾩옱 ?쒕룞 ?곹깭瑜?議고쉶?⑸땲??
      * <p>
-     * 1. 반려동물 존재 여부와 요청자의 조회 권한을 검증합니다.
-     * 2. 가장 최근의 활동 기록을 조회하여 상태별로 메시지와 ID 포함 여부를 결정합니다.
-     * - IN_PROGRESS, BEFORE, CANCELED: 액션이 필요한 상태이므로 historyId를 반환합니다.
-     * - COMPLETED: 완료된 상태이므로 ID를 반환하지 않습니다.
+     * 1. 諛섎젮?숇Ъ 議댁옱 ?щ?? ?붿껌?먯쓽 議고쉶 沅뚰븳??寃利앺빀?덈떎.
+     * 2. 媛??理쒓렐???쒕룞 湲곕줉??議고쉶?섏뿬 ?곹깭蹂꾨줈 硫붿떆吏? ID ?ы븿 ?щ?瑜?寃곗젙?⑸땲??
+     * - IN_PROGRESS, BEFORE, CANCELED: ?≪뀡???꾩슂???곹깭?대?濡?historyId瑜?諛섑솚?⑸땲??
+     * - COMPLETED: ?꾨즺???곹깭?대?濡?ID瑜?諛섑솚?섏? ?딆뒿?덈떎.
      * </p>
      *
-     * @param userId 요청한 사용자의 UUID
-     * @param petId  상태를 조회할 반려동물의 ID
-     * @return 활동 상태 응답 DTO {@link ActivityStatusResponse}
+     * @param userId ?붿껌???ъ슜?먯쓽 UUID
+     * @param petId  ?곹깭瑜?議고쉶??諛섎젮?숇Ъ??ID
+     * @return ?쒕룞 ?곹깭 ?묐떟 DTO {@link ActivityStatusResponse}
      */
     @Transactional(readOnly = true)
     @Override
@@ -402,7 +402,7 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     /**
      * {@inheritDoc}
      * <p>
-     * 디바이스 토큰 subject와 반려동물 ID의 매핑을 검증한 뒤 활동 상태를 조회합니다.
+     * ?붾컮?댁뒪 ?좏겙 subject? 諛섎젮?숇Ъ ID??留ㅽ븨??寃利앺븳 ???쒕룞 ?곹깭瑜?議고쉶?⑸땲??
      */
     @Transactional(readOnly = true)
     @Override
@@ -417,21 +417,21 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * 특정 활동 기록의 상세 경로(GPS 좌표 리스트)를 조회합니다.
+     * ?뱀젙 ?쒕룞 湲곕줉???곸꽭 寃쎈줈(GPS 醫뚰몴 由ъ뒪??瑜?議고쉶?⑸땲??
      * <p>
-     * 1. 활동 기록(History)의 존재 여부를 확인합니다.
-     * 2. 요청한 사용자(User)가 해당 반려동물의 승인된 보호자인지 권한을 검증합니다.
-     * 3. RoutePointService를 통해 경로 데이터를 Map 리스트 형태로 조회합니다. (Entity 직접 의존 제거)
-     * 4. 조회된 데이터를 Response DTO로 변환하여 반환합니다.
+     * 1. ?쒕룞 湲곕줉(History)??議댁옱 ?щ?瑜??뺤씤?⑸땲??
+     * 2. ?붿껌???ъ슜??User)媛 ?대떦 諛섎젮?숇Ъ???뱀씤??蹂댄샇?먯씤吏 沅뚰븳??寃利앺빀?덈떎.
+     * 3. RoutePointService瑜??듯빐 寃쎈줈 ?곗씠?곕? Map 由ъ뒪???뺥깭濡?議고쉶?⑸땲?? (Entity 吏곸젒 ?섏〈 ?쒓굅)
+     * 4. 議고쉶???곗씠?곕? Response DTO濡?蹂?섑븯??諛섑솚?⑸땲??
      * </p>
      *
-     * @param userId    요청한 사용자의 UUID
-     * @param historyId 조회할 활동 기록의 ID
-     * @return 상세 경로 및 활동 정보 응답 DTO {@link ActivityRouteResponse}
+     * @param userId    ?붿껌???ъ슜?먯쓽 UUID
+     * @param historyId 議고쉶???쒕룞 湲곕줉??ID
+     * @return ?곸꽭 寃쎈줈 諛??쒕룞 ?뺣낫 ?묐떟 DTO {@link ActivityRouteResponse}
      * @throws ActivityHistoryException
      * <ul>
-     * <li>{@code HISTORY_NOT_FOUND}: 해당 ID의 활동 기록이 존재하지 않는 경우</li>
-     * <li>{@code VIEW_PERMISSION_DENIED}: 요청자가 해당 반려동물의 보호자가 아닌 경우</li>
+     * <li>{@code HISTORY_NOT_FOUND}: ?대떦 ID???쒕룞 湲곕줉??議댁옱?섏? ?딅뒗 寃쎌슦</li>
+     * <li>{@code VIEW_PERMISSION_DENIED}: ?붿껌?먭? ?대떦 諛섎젮?숇Ъ??蹂댄샇?먭? ?꾨땶 寃쎌슦</li>
      * </ul>
      */
     @Transactional(readOnly = true)
@@ -460,22 +460,22 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
         return ActivityRouteResponse.toDto(
                 activityHistory,
                 routePointDtos,
-                "상세 경로를 가져오는데 성공했습니다."
+                "?곸꽭 寃쎈줈瑜?媛?몄삤?붾뜲 ?깃났?덉뒿?덈떎."
         );
     }
 
     /**
-     * 건강 분석 리포트 생성을 위해 분석 단위별 활동 기록을 조회하고 Map 형태로 변환합니다.
+     * 嫄닿컯 遺꾩꽍 由ы룷???앹꽦???꾪빐 遺꾩꽍 ?⑥쐞蹂??쒕룞 湲곕줉??議고쉶?섍퀬 Map ?뺥깭濡?蹂?섑빀?덈떎.
      * <p>
-     * 분석 단위에 따라 서로 다른 Repository 메서드를 호출하며,
-     * 반환 시 엔티티를 외부로 노출하지 않고 필요한 필드만 추출합니다.
+     * 遺꾩꽍 ?⑥쐞???곕씪 ?쒕줈 ?ㅻⅨ Repository 硫붿꽌?쒕? ?몄텧?섎ŉ,
+     * 諛섑솚 ???뷀떚?곕? ?몃?濡??몄텧?섏? ?딄퀬 ?꾩슂???꾨뱶留?異붿텧?⑸땲??
      * </p>
      *
-     * @param petId         반려동물 ID
-     * @param analysisType  분석 단위 (DAILY/WEEKLY/MONTHLY)
-     * @param startDateTime 조회 시작 시각 (포함)
-     * @param endDateTime   조회 종료 시각 (미포함 또는 범위 상한)
-     * @return 활동 데이터 목록 (historyId, distance, startAt, endAt, status, activityType 등)
+     * @param petId         諛섎젮?숇Ъ ID
+     * @param analysisType  遺꾩꽍 ?⑥쐞 (DAILY/WEEKLY/MONTHLY)
+     * @param startDateTime 議고쉶 ?쒖옉 ?쒓컖 (?ы븿)
+     * @param endDateTime   議고쉶 醫낅즺 ?쒓컖 (誘명룷???먮뒗 踰붿쐞 ?곹븳)
+     * @return ?쒕룞 ?곗씠??紐⑸줉 (historyId, distance, startAt, endAt, status, activityType ??
      */
     @Transactional(readOnly = true)
     @Override
@@ -523,10 +523,10 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
-     * 특정 반려동물의 최신 활동 상태를 조회해 상태 메시지와 historyId를 조합한 응답 DTO를 생성합니다.
+     * ?뱀젙 諛섎젮?숇Ъ??理쒖떊 ?쒕룞 ?곹깭瑜?議고쉶???곹깭 硫붿떆吏? historyId瑜?議고빀???묐떟 DTO瑜??앹꽦?⑸땲??
      *
-     * @param pet 조회 대상 반려동물 엔티티
-     * @return 활동 상태 응답 DTO
+     * @param pet 議고쉶 ???諛섎젮?숇Ъ ?뷀떚??
+     * @return ?쒕룞 ?곹깭 ?묐떟 DTO
      */
     private ActivityStatusResponse buildActivityStatusResponse(Pet pet) {
         return activityHistoryRepository.findFirstByPetOrderByHistoryIdDesc(pet)
@@ -534,28 +534,28 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
                     String status = history.getActivityHistoryStatus().name();
 
                     if ("IN_PROGRESS".equals(status)) {
-                        return ActivityStatusResponse.toDto("활동 기록중인 애완동물입니다.", history.getHistoryId());
+                        return ActivityStatusResponse.toDto("?쒕룞 湲곕줉以묒씤 ?좎셿?숇Ъ?낅땲??", history.getHistoryId());
                     } else if ("BEFORE".equals(status)) {
-                        return ActivityStatusResponse.toDto("활동 시작 전 상태입니다.", history.getHistoryId());
+                        return ActivityStatusResponse.toDto("?쒕룞 ?쒖옉 ???곹깭?낅땲??", history.getHistoryId());
                     } else if ("CANCELED".equals(status)) {
-                        return ActivityStatusResponse.toDto("활동이 중단된 상태입니다.", history.getHistoryId());
+                        return ActivityStatusResponse.toDto("?쒕룞??以묐떒???곹깭?낅땲??", history.getHistoryId());
                     } else {
-                        return ActivityStatusResponse.toDto("현재 진행 중인 활동이 없습니다.", null);
+                        return ActivityStatusResponse.toDto("?꾩옱 吏꾪뻾 以묒씤 ?쒕룞???놁뒿?덈떎.", null);
                     }
                 })
-                .orElseGet(() -> ActivityStatusResponse.toDto("활동 기록이 없습니다.", null));
+                .orElseGet(() -> ActivityStatusResponse.toDto("?쒕룞 湲곕줉???놁뒿?덈떎.", null));
     }
 
     /**
      * {@inheritDoc}
      * <p>
-     * 활동 기록에 연결된 반려동물 ID로 생성한 디바이스 UUID와 현재 Principal 값을 비교하여 권한을 검증합니다.
+     * ?쒕룞 湲곕줉???곌껐??諛섎젮?숇Ъ ID濡??앹꽦???붾컮?댁뒪 UUID? ?꾩옱 Principal 媛믪쓣 鍮꾧탳?섏뿬 沅뚰븳??寃利앺빀?덈떎.
      */
     @Transactional(readOnly = true)
     @Override
     public boolean isDeviceAuthorizedForHistory(Long historyId, String devicePrincipal) {
         ActivityHistory activityHistory = activityHistoryRepository.findById(historyId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 활동 기록을 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("?대떦 ?쒕룞 湲곕줉??李얠쓣 ???놁뒿?덈떎."));
 
         Long petId = activityHistory.getPet().getPetId();
         String expectedDevicePrincipal = UUID.nameUUIDFromBytes(("DEVICE:" + petId).getBytes(StandardCharsets.UTF_8))
@@ -563,4 +563,15 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
 
         return expectedDevicePrincipal.equals(devicePrincipal);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public ActivityHistory getActivityHistoryById(Long historyId) {
+        return activityHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
+    }
 }
+

--- a/src/main/java/com/dodo/backend/board/entity/Board.java
+++ b/src/main/java/com/dodo/backend/board/entity/Board.java
@@ -1,0 +1,78 @@
+package com.dodo.backend.board.entity;
+
+import com.dodo.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 게시글(Board) 정보를 관리하는 엔티티입니다.
+ * <p>
+ * 데이터베이스 {@code board} 테이블과 매핑되며, 작성자, 제목/본문, 조회수,
+ * 게시글 상태 및 게시판 유형 정보를 포함합니다.
+ */
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "board")
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long boardId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @CreatedDate
+    @Column(name = "board_created_at", nullable = false, updatable = false)
+    private LocalDateTime boardCreatedAt;
+
+    @Column(name = "board_title", length = 255, nullable = false)
+    private String boardTitle;
+
+    @Column(name = "board_content", columnDefinition = "TEXT")
+    private String boardContent;
+
+    @Builder.Default
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount = 0;
+
+    @LastModifiedDate
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_status", nullable = false)
+    private BoardStatus boardStatus;
+
+    @Column(name = "board_status_updated_at", nullable = false)
+    private LocalDateTime boardStatusUpdatedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "board_type", nullable = false)
+    private BoardType boardType;
+
+    /**
+     * 영속화 직전에 기본값이 누락된 필드를 보정합니다.
+     */
+    @PrePersist
+    private void prePersist() {
+        if (viewCount == null) {
+            viewCount = 0;
+        }
+
+        if (boardStatusUpdatedAt == null) {
+            boardStatusUpdatedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/dodo/backend/board/entity/BoardStatus.java
+++ b/src/main/java/com/dodo/backend/board/entity/BoardStatus.java
@@ -1,0 +1,10 @@
+package com.dodo.backend.board.entity;
+
+/**
+ * 게시글 상태를 정의하는 열거형입니다.
+ */
+public enum BoardStatus {
+    PUBLISHED,
+    DRAFT,
+    DELETED
+}

--- a/src/main/java/com/dodo/backend/board/entity/BoardType.java
+++ b/src/main/java/com/dodo/backend/board/entity/BoardType.java
@@ -1,0 +1,9 @@
+package com.dodo.backend.board.entity;
+
+/**
+ * 게시글이 속한 게시판 유형을 정의하는 열거형입니다.
+ */
+public enum BoardType {
+    NOTICE,
+    FREE
+}

--- a/src/main/java/com/dodo/backend/common/config/OpenApiConfig.java
+++ b/src/main/java/com/dodo/backend/common/config/OpenApiConfig.java
@@ -50,7 +50,8 @@ public class OpenApiConfig {
 
         return new OpenAPI()
                 .info(info)
-		.addServersItem(new Server().url("https://api.dodok.p-e.kr"))
+                .addServersItem(new Server().url("http://localhost:8080"))
+                .addServersItem(new Server().url("https://api.dodok.p-e.kr"))
                 .addSecurityItem(securityRequirement)
                 .components(components);
     }

--- a/src/main/java/com/dodo/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dodo/backend/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.dodo.backend.fence.exception.FenceException;
 import com.dodo.backend.healthanalysis.exception.HealthAnalysisException;
 import com.dodo.backend.pet.exception.PetException;
 import com.dodo.backend.petweight.exception.PetWeightException;
+import com.dodo.backend.reaction.exception.ReactionException;
 import com.dodo.backend.user.exception.UserErrorCode;
 import com.dodo.backend.user.exception.UserException;
 import com.dodo.backend.userpet.exception.UserPetException;
@@ -99,6 +100,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HealthAnalysisException.class)
     protected ResponseEntity<ErrorResponse> handleHealthAnalysisException(HealthAnalysisException e) {
         log.error("HealthAnalysisException occurred: {}", e.getErrorCode());
+        return toResponseEntity(e.getErrorCode());
+    }
+
+    /**
+     * 반응(Reaction) 도메인 비즈니스 로직에서 발생하는 {@link ReactionException}을 처리합니다.
+     */
+    @ExceptionHandler(ReactionException.class)
+    protected ResponseEntity<ErrorResponse> handleReactionException(ReactionException e) {
+        log.error("ReactionException occurred: {}", e.getErrorCode());
         return toResponseEntity(e.getErrorCode());
     }
 

--- a/src/main/java/com/dodo/backend/reaction/controller/ReactionController.java
+++ b/src/main/java/com/dodo/backend/reaction/controller/ReactionController.java
@@ -1,0 +1,83 @@
+package com.dodo.backend.reaction.controller;
+
+import com.dodo.backend.common.exception.ErrorResponse;
+import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionCreateRequest;
+import com.dodo.backend.reaction.dto.response.ReactionResponse.ReactionSimpleResponse;
+import com.dodo.backend.reaction.service.ReactionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+/**
+ * 반응(Reaction) 도메인의 HTTP 요청을 처리하는 컨트롤러입니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reactions")
+@Tag(name = "Reaction API", description = "반응 관련 API")
+@Slf4j
+public class ReactionController {
+
+    private final ReactionService reactionService;
+
+    /**
+     * 특정 활동 기록에 반응을 추가합니다.
+     *
+     * @param userDetails 인증 사용자 정보
+     * @param request     반응 추가 요청 DTO
+     * @return 처리 결과 메시지 응답
+     */
+    @Operation(summary = "특정 활동 기록 반응 추가", description = "인증된 사용자가 특정 활동 기록에 반응을 추가합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "반응이 성공적으로 추가되었습니다.",
+                    content = @Content(schema = @Schema(implementation = ReactionSimpleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"접근 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"활동을 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "이미 반응을 누른 활동입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "409 Conflict", value = "{\"status\": 409, \"message\": \"이미 반응을 누른 활동입니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @PostMapping("/history")
+    public ResponseEntity<ReactionSimpleResponse> createHistoryReaction(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid HistoryReactionCreateRequest request
+    ) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        log.info("활동 반응 추가 요청 - User: {}, HistoryId: {}", userId, request.getHistoryId());
+
+        ReactionSimpleResponse response = reactionService.createHistoryReaction(userId, request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/dodo/backend/reaction/dto/request/ReactionRequest.java
+++ b/src/main/java/com/dodo/backend/reaction/dto/request/ReactionRequest.java
@@ -1,0 +1,57 @@
+package com.dodo.backend.reaction.dto.request;
+
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.reaction.entity.Reaction;
+import com.dodo.backend.reaction.entity.ReactionType;
+import com.dodo.backend.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Locale;
+
+/**
+ * 반응(Reaction) 도메인과 관련된 요청 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
+ */
+@Schema(description = "반응 도메인 요청 DTO 그룹")
+public class ReactionRequest {
+
+    /**
+     * 특정 활동 기록에 반응을 추가할 때 사용하는 요청 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "활동 반응 추가 요청 DTO")
+    public static class HistoryReactionCreateRequest {
+
+        @Schema(description = "활동 기록 ID", example = "101")
+        @NotNull(message = "잘못된 요청입니다.")
+        private Long historyId;
+
+        @Schema(description = "반응 유형 (LIKE, DISLIKE)", example = "LIKE")
+        @NotNull(message = "잘못된 요청입니다.")
+        @Pattern(regexp = "^(?i)(LIKE|DISLIKE)$", message = "잘못된 요청입니다.")
+        private String reactionType;
+
+        /**
+         * 요청 데이터를 기반으로 활동 반응 엔티티를 생성합니다.
+         *
+         * @param user    반응을 남긴 사용자 엔티티
+         * @param history 반응 대상 활동 기록 엔티티
+         * @return 생성된 반응 엔티티
+         */
+        public Reaction toEntity(User user, ActivityHistory history) {
+            return Reaction.builder()
+                    .user(user)
+                    .history(history)
+                    .reactionType(ReactionType.valueOf(this.reactionType.trim().toUpperCase(Locale.ROOT)))
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dodo/backend/reaction/dto/response/ReactionResponse.java
+++ b/src/main/java/com/dodo/backend/reaction/dto/response/ReactionResponse.java
@@ -1,0 +1,38 @@
+package com.dodo.backend.reaction.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 반응(Reaction) 도메인과 관련된 응답 데이터를 캡슐화하는 DTO 그룹 클래스입니다.
+ */
+@Schema(description = "반응 도메인 응답 DTO 그룹")
+public class ReactionResponse {
+
+    /**
+     * 메시지만 반환하는 단순 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "반응 처리 단순 응답 DTO")
+    public static class ReactionSimpleResponse {
+
+        @Schema(description = "처리 결과 메시지", example = "반응이 성공적으로 추가되었습니다.")
+        private String message;
+
+        /**
+         * 메시지를 기반으로 단순 응답 DTO를 생성합니다.
+         *
+         * @param message 클라이언트에 전달할 처리 결과 메시지
+         * @return 메시지를 포함한 응답 DTO
+         */
+        public static ReactionSimpleResponse toDto(String message) {
+            return ReactionSimpleResponse.builder()
+                    .message(message)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dodo/backend/reaction/entity/Reaction.java
+++ b/src/main/java/com/dodo/backend/reaction/entity/Reaction.java
@@ -1,0 +1,52 @@
+package com.dodo.backend.reaction.entity;
+
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.board.entity.Board;
+import com.dodo.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 게시글 및 활동 기록에 대한 반응 정보를 관리하는 엔티티입니다.
+ * <p>
+ * 데이터베이스 {@code reaction} 테이블과 매핑되며, 반응 주체 사용자와 대상 게시글,
+ * 선택적으로 연결되는 활동 기록, 반응 유형 및 생성 시각을 포함합니다.
+ */
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "reaction")
+public class Reaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reaction_id")
+    private Long reactionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "history_id")
+    private ActivityHistory history;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @CreatedDate
+    @Column(name = "reaction_created_at", nullable = false, updatable = false)
+    private LocalDateTime reactionCreatedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reaction_type", nullable = false)
+    private ReactionType reactionType;
+}

--- a/src/main/java/com/dodo/backend/reaction/entity/ReactionType.java
+++ b/src/main/java/com/dodo/backend/reaction/entity/ReactionType.java
@@ -1,0 +1,9 @@
+package com.dodo.backend.reaction.entity;
+
+/**
+ * 반응 유형을 정의하는 열거형입니다.
+ */
+public enum ReactionType {
+    LIKE,
+    DISLIKE
+}

--- a/src/main/java/com/dodo/backend/reaction/exception/ReactionErrorCode.java
+++ b/src/main/java/com/dodo/backend/reaction/exception/ReactionErrorCode.java
@@ -1,0 +1,97 @@
+package com.dodo.backend.reaction.exception;
+
+import com.dodo.backend.common.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 반응(Reaction) 도메인에서 발생하는 예외 상황을 관리하는 에러 코드 정의 열거형입니다.
+ * <p>
+ * 활동 반응 및 게시물 반응의 등록/취소 과정에서 발생하는 오류를
+ * HTTP 상태 코드와 클라이언트 응답 메시지로 함께 관리합니다.
+ */
+@AllArgsConstructor
+@Getter
+public enum ReactionErrorCode implements BaseErrorCode {
+
+    /**
+     * 클라이언트의 요청 형식이 잘못되었거나 파라미터가 유효하지 않을 때 사용합니다.
+     * <p>
+     * HTTP {@code 400 Bad Request}를 반환합니다.
+     */
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    /**
+     * 인증되지 않은 사용자가 로그인 필요한 기능을 요청할 때 사용합니다.
+     * <p>
+     * HTTP {@code 401 Unauthorized}를 반환합니다.
+     */
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 기능입니다."),
+
+    /**
+     * 요청한 리소스 또는 기능에 대한 접근 권한이 없을 때 사용합니다.
+     * <p>
+     * HTTP {@code 403 Forbidden}을 반환합니다.
+     */
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    /**
+     * 요청한 활동 기록을 찾을 수 없을 때 사용합니다.
+     * <p>
+     * HTTP {@code 404 Not Found}를 반환합니다.
+     */
+    ACTIVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "활동을 찾을 수 없습니다."),
+
+    /**
+     * 동일 활동에 이미 반응이 존재하는 상태에서 다시 반응을 등록할 때 사용합니다.
+     * <p>
+     * HTTP {@code 409 Conflict}를 반환합니다.
+     */
+    ACTIVITY_REACTION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 반응을 누른 활동입니다."),
+
+    /**
+     * 활동 반응 취소 요청 시 기존 반응 기록이 없을 때 사용합니다.
+     * <p>
+     * HTTP {@code 404 Not Found}를 반환합니다.
+     */
+    ACTIVITY_REACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "반응을 누른 기록이 없습니다."),
+
+    /**
+     * 요청한 게시물을 찾을 수 없을 때 사용합니다.
+     * <p>
+     * HTTP {@code 404 Not Found}를 반환합니다.
+     */
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
+
+    /**
+     * 동일 게시물에 이미 반응이 존재하는 상태에서 다시 반응을 등록할 때 사용합니다.
+     * <p>
+     * HTTP {@code 409 Conflict}를 반환합니다.
+     */
+    BOARD_REACTION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 반응을 누른 게시물입니다."),
+
+    /**
+     * 게시물 반응 취소 요청 시 기존 반응 기록이 없을 때 사용합니다.
+     * <p>
+     * HTTP {@code 404 Not Found}를 반환합니다.
+     */
+    BOARD_REACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 누른 기록이 없습니다."),
+
+    /**
+     * 서버 내부에서 예기치 못한 오류가 발생했을 때 사용합니다.
+     * <p>
+     * HTTP {@code 500 Internal Server Error}를 반환합니다.
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    /**
+     * 에러 상황에 해당하는 HTTP 상태 코드입니다.
+     */
+    private final HttpStatus httpStatus;
+
+    /**
+     * 클라이언트에 전달할 에러 메시지입니다.
+     */
+    private final String message;
+}

--- a/src/main/java/com/dodo/backend/reaction/exception/ReactionException.java
+++ b/src/main/java/com/dodo/backend/reaction/exception/ReactionException.java
@@ -1,0 +1,20 @@
+package com.dodo.backend.reaction.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 반응(Reaction) 도메인 비즈니스 로직 수행 중 발생하는 전용 예외 클래스입니다.
+ * <p>
+ * 반응 등록, 취소, 조회와 관련한 예외 상황을 {@link ReactionErrorCode}로 표현하며,
+ * 전역 예외 처리기에서 표준 에러 응답으로 변환됩니다.
+ */
+@AllArgsConstructor
+@Getter
+public class ReactionException extends RuntimeException {
+
+    /**
+     * 발생한 예외의 구체적인 분류를 나타내는 에러 코드입니다.
+     */
+    private final ReactionErrorCode errorCode;
+}

--- a/src/main/java/com/dodo/backend/reaction/repository/ReactionRepository.java
+++ b/src/main/java/com/dodo/backend/reaction/repository/ReactionRepository.java
@@ -1,0 +1,23 @@
+package com.dodo.backend.reaction.repository;
+
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.reaction.entity.Reaction;
+import com.dodo.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * {@link Reaction} 엔티티의 데이터베이스 접근을 담당하는 리포지토리 인터페이스입니다.
+ */
+@Repository
+public interface ReactionRepository extends JpaRepository<Reaction, Long> {
+
+    /**
+     * 특정 사용자가 특정 활동 기록에 반응을 남긴 이력이 이미 존재하는지 확인합니다.
+     *
+     * @param user    반응을 남긴 사용자 엔티티
+     * @param history 반응 대상 활동 기록 엔티티
+     * @return 반응 이력이 존재하면 true, 존재하지 않으면 false
+     */
+    boolean existsByUserAndHistory(User user, ActivityHistory history);
+}

--- a/src/main/java/com/dodo/backend/reaction/service/ReactionService.java
+++ b/src/main/java/com/dodo/backend/reaction/service/ReactionService.java
@@ -1,0 +1,21 @@
+package com.dodo.backend.reaction.service;
+
+import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionCreateRequest;
+import com.dodo.backend.reaction.dto.response.ReactionResponse.ReactionSimpleResponse;
+
+import java.util.UUID;
+
+/**
+ * 반응(Reaction) 도메인의 비즈니스 로직을 처리하는 서비스 인터페이스입니다.
+ */
+public interface ReactionService {
+
+    /**
+     * 특정 활동 기록에 반응을 추가합니다.
+     *
+     * @param userId  요청 사용자 ID
+     * @param request 반응 추가 요청 DTO
+     * @return 처리 결과 메시지 응답 DTO
+     */
+    ReactionSimpleResponse createHistoryReaction(UUID userId, HistoryReactionCreateRequest request);
+}

--- a/src/main/java/com/dodo/backend/reaction/service/ReactionServiceImpl.java
+++ b/src/main/java/com/dodo/backend/reaction/service/ReactionServiceImpl.java
@@ -1,0 +1,66 @@
+package com.dodo.backend.reaction.service;
+
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.activityhistory.service.ActivityHistoryService;
+import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionCreateRequest;
+import com.dodo.backend.reaction.dto.response.ReactionResponse.ReactionSimpleResponse;
+import com.dodo.backend.reaction.entity.Reaction;
+import com.dodo.backend.reaction.exception.ReactionException;
+import com.dodo.backend.reaction.repository.ReactionRepository;
+import com.dodo.backend.user.entity.User;
+import com.dodo.backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static com.dodo.backend.reaction.exception.ReactionErrorCode.ACCESS_DENIED;
+import static com.dodo.backend.reaction.exception.ReactionErrorCode.ACTIVITY_REACTION_ALREADY_EXISTS;
+import static com.dodo.backend.reaction.exception.ReactionErrorCode.INVALID_REQUEST;
+
+/**
+ * {@link ReactionService} 인터페이스의 구현체로, 반응 도메인의 비즈니스 로직을 수행합니다.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ReactionServiceImpl implements ReactionService {
+
+    private final ReactionRepository reactionRepository;
+    private final ActivityHistoryService activityHistoryService;
+    private final UserService userService;
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * 처리 순서는 요청값 검증, 사용자/활동 조회, 접근 권한 검증, 중복 반응 검증, 반응 저장 순으로 진행됩니다.
+     */
+    @Transactional
+    @Override
+    public ReactionSimpleResponse createHistoryReaction(UUID userId, HistoryReactionCreateRequest request) {
+        if (request == null || request.getHistoryId() == null || request.getReactionType() == null) {
+            throw new ReactionException(INVALID_REQUEST);
+        }
+
+        User user = userService.getUserById(userId);
+        ActivityHistory history = activityHistoryService.getActivityHistoryById(request.getHistoryId());
+
+        if (history.getUser().getUsersId().equals(userId)) {
+            throw new ReactionException(ACCESS_DENIED);
+        }
+
+        if (reactionRepository.existsByUserAndHistory(user, history)) {
+            throw new ReactionException(ACTIVITY_REACTION_ALREADY_EXISTS);
+        }
+
+        Reaction reaction = request.toEntity(user, history);
+        reactionRepository.save(reaction);
+
+        log.info("활동 반응 추가 완료 - User: {}, HistoryId: {}, ReactionType: {}",
+                userId, request.getHistoryId(), reaction.getReactionType());
+
+        return ReactionSimpleResponse.toDto("반응이 성공적으로 추가되었습니다.");
+    }
+}

--- a/src/test/java/com/dodo/backend/reaction/service/ReactionServiceTest.java
+++ b/src/test/java/com/dodo/backend/reaction/service/ReactionServiceTest.java
@@ -1,0 +1,208 @@
+package com.dodo.backend.reaction.service;
+
+import com.dodo.backend.activityhistory.entity.ActivityHistory;
+import com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCode;
+import com.dodo.backend.activityhistory.exception.ActivityHistoryException;
+import com.dodo.backend.activityhistory.service.ActivityHistoryService;
+import com.dodo.backend.pet.entity.Pet;
+import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionCreateRequest;
+import com.dodo.backend.reaction.dto.response.ReactionResponse.ReactionSimpleResponse;
+import com.dodo.backend.reaction.entity.Reaction;
+import com.dodo.backend.reaction.exception.ReactionErrorCode;
+import com.dodo.backend.reaction.exception.ReactionException;
+import com.dodo.backend.reaction.repository.ReactionRepository;
+import com.dodo.backend.user.entity.User;
+import com.dodo.backend.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@link ReactionServiceImpl}의 활동 반응 추가 로직을 검증하는 단위 테스트 클래스입니다.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReactionServiceTest {
+
+    @InjectMocks
+    private ReactionServiceImpl reactionService;
+
+    @Mock
+    private ReactionRepository reactionRepository;
+
+    @Mock
+    private ActivityHistoryService activityHistoryService;
+
+    @Mock
+    private UserService userService;
+
+    /**
+     * 활동 반응 추가가 정상적으로 저장되고 성공 메시지를 반환하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 추가 성공: 다른 사용자의 활동 기록에 반응을 저장한다.")
+    void createHistoryReaction_Success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID ownerId = UUID.randomUUID();
+        Long historyId = 101L;
+
+        User requester = User.builder().usersId(userId).build();
+        User owner = User.builder().usersId(ownerId).build();
+        Pet pet = Pet.builder().petId(1L).build();
+        ActivityHistory history = ActivityHistory.builder()
+                .historyId(historyId)
+                .user(owner)
+                .pet(pet)
+                .build();
+
+        HistoryReactionCreateRequest request = HistoryReactionCreateRequest.builder()
+                .historyId(historyId)
+                .reactionType("LIKE")
+                .build();
+
+        given(userService.getUserById(userId)).willReturn(requester);
+        given(activityHistoryService.getActivityHistoryById(historyId)).willReturn(history);
+        given(reactionRepository.existsByUserAndHistory(requester, history)).willReturn(false);
+        given(reactionRepository.save(any(Reaction.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ReactionSimpleResponse response = reactionService.createHistoryReaction(userId, request);
+
+        // then
+        assertNotNull(response);
+        assertEquals("반응이 성공적으로 추가되었습니다.", response.getMessage());
+        verify(reactionRepository, times(1)).save(any(Reaction.class));
+    }
+
+    /**
+     * 요청값이 비어있는 경우 INVALID_REQUEST 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 추가 실패: 요청값이 null이면 INVALID_REQUEST 예외가 발생한다.")
+    void createHistoryReaction_Fail_InvalidRequest() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when
+        ReactionException exception = assertThrows(ReactionException.class, () ->
+                reactionService.createHistoryReaction(userId, null)
+        );
+
+        // then
+        assertEquals(ReactionErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    /**
+     * 자신의 활동 기록에 반응을 시도하면 ACCESS_DENIED 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 추가 실패: 본인 활동 기록에는 반응할 수 없다.")
+    void createHistoryReaction_Fail_AccessDeniedForOwnHistory() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 101L;
+
+        User requester = User.builder().usersId(userId).build();
+        Pet pet = Pet.builder().petId(1L).build();
+        ActivityHistory ownHistory = ActivityHistory.builder()
+                .historyId(historyId)
+                .user(requester)
+                .pet(pet)
+                .build();
+
+        HistoryReactionCreateRequest request = HistoryReactionCreateRequest.builder()
+                .historyId(historyId)
+                .reactionType("LIKE")
+                .build();
+
+        given(userService.getUserById(userId)).willReturn(requester);
+        given(activityHistoryService.getActivityHistoryById(historyId)).willReturn(ownHistory);
+
+        // when
+        ReactionException exception = assertThrows(ReactionException.class, () ->
+                reactionService.createHistoryReaction(userId, request)
+        );
+
+        // then
+        assertEquals(ReactionErrorCode.ACCESS_DENIED, exception.getErrorCode());
+    }
+
+    /**
+     * 동일 사용자/활동에 반응 이력이 이미 존재하면 CONFLICT 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 추가 실패: 이미 반응을 누른 활동이면 CONFLICT 예외가 발생한다.")
+    void createHistoryReaction_Fail_AlreadyReacted() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID ownerId = UUID.randomUUID();
+        Long historyId = 101L;
+
+        User requester = User.builder().usersId(userId).build();
+        User owner = User.builder().usersId(ownerId).build();
+        Pet pet = Pet.builder().petId(1L).build();
+        ActivityHistory history = ActivityHistory.builder()
+                .historyId(historyId)
+                .user(owner)
+                .pet(pet)
+                .build();
+
+        HistoryReactionCreateRequest request = HistoryReactionCreateRequest.builder()
+                .historyId(historyId)
+                .reactionType("DISLIKE")
+                .build();
+
+        given(userService.getUserById(userId)).willReturn(requester);
+        given(activityHistoryService.getActivityHistoryById(historyId)).willReturn(history);
+        given(reactionRepository.existsByUserAndHistory(requester, history)).willReturn(true);
+
+        // when
+        ReactionException exception = assertThrows(ReactionException.class, () ->
+                reactionService.createHistoryReaction(userId, request)
+        );
+
+        // then
+        assertEquals(ReactionErrorCode.ACTIVITY_REACTION_ALREADY_EXISTS, exception.getErrorCode());
+    }
+
+    /**
+     * 활동 기록이 없을 때 활동 도메인 예외가 전파되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 추가 실패: 활동 기록이 없으면 HISTORY_NOT_FOUND 예외가 전파된다.")
+    void createHistoryReaction_Fail_HistoryNotFound() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 999L;
+
+        User requester = User.builder().usersId(userId).build();
+        HistoryReactionCreateRequest request = HistoryReactionCreateRequest.builder()
+                .historyId(historyId)
+                .reactionType("LIKE")
+                .build();
+
+        given(userService.getUserById(userId)).willReturn(requester);
+        given(activityHistoryService.getActivityHistoryById(historyId))
+                .willThrow(new ActivityHistoryException(ActivityHistoryErrorCode.HISTORY_NOT_FOUND));
+
+        // when
+        ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
+                reactionService.createHistoryReaction(userId, request)
+        );
+
+        // then
+        assertEquals(ActivityHistoryErrorCode.HISTORY_NOT_FOUND, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 활동 기록 반응 생성 기능 추가 (`POST /reactions/history`)
- 본인 활동 기록 반응 차단 및 중복 반응 방지 로직 구현
- `Reaction` 엔티티 nullable 정책 정리 (`user_id` not null, `history_id/board_id` nullable)
- `ReactionErrorCode`, `ReactionException`, `ReactionRepository` 추가
- 요청 DTO 검증(`@Valid`, `@Pattern`) 및 서비스/컨트롤러 로직 구현
- `ActivityHistoryService`에 활동 기록 엔티티 조회 메서드 추가
- `ReactionServiceTest` 단위 테스트 작성 및 `given/when/then` 주석 정리
- OpenAPI 서버 목록에 로컬 테스트 주소(`http://localhost:8080`) 추가
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #132

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

활동 기록에 좋아요 싫어요 달 수 있는 기능 구현했고 로컬에서 ScalarApiReference를 로컬에서 테스트 할수 있게 로컬 아이피 추가했습니다.