### PR TITLE
✨ Feat: 활동기록 반응 변경 및 취소 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/reaction/controller/ReactionController.java
+++ b/src/main/java/com/dodo/backend/reaction/controller/ReactionController.java
@@ -2,6 +2,7 @@ package com.dodo.backend.reaction.controller;
 
 import com.dodo.backend.common.exception.ErrorResponse;
 import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionCreateRequest;
+import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionUpdateRequest;
 import com.dodo.backend.reaction.dto.response.ReactionResponse.ReactionSimpleResponse;
 import com.dodo.backend.reaction.service.ReactionService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,7 +44,9 @@ public class ReactionController {
     @Operation(summary = "특정 활동 기록 반응 추가", description = "인증된 사용자가 특정 활동 기록에 반응을 추가합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "반응이 성공적으로 추가되었습니다.",
-                    content = @Content(schema = @Schema(implementation = ReactionSimpleResponse.class))),
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ReactionSimpleResponse.class),
+                            examples = @ExampleObject(name = "200 OK", value = "{\"message\": \"반응이 성공적으로 추가되었습니다.\"}"))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -78,6 +81,103 @@ public class ReactionController {
         log.info("활동 반응 추가 요청 - User: {}, HistoryId: {}", userId, request.getHistoryId());
 
         ReactionSimpleResponse response = reactionService.createHistoryReaction(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 특정 활동 기록에 남긴 반응을 변경합니다.
+     *
+     * @param userDetails 인증 사용자 정보
+     * @param historyId   반응 대상 활동 기록 ID
+     * @param request     반응 변경 요청 DTO
+     * @return 처리 결과 메시지 응답
+     */
+    @Operation(summary = "특정 활동 기록 반응 변경", description = "인증된 사용자가 특정 활동 기록에 남긴 반응을 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "반응이 성공적으로 변경되었습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ReactionSimpleResponse.class),
+                            examples = @ExampleObject(name = "200 OK", value = "{\"message\": \"반응이 성공적으로 변경되었습니다.\"}"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"접근 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없거나 반응을 누른 기록이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "404 Activity Not Found", value = "{\"status\": 404, \"message\": \"활동을 찾을 수 없습니다.\"}"),
+                                    @ExampleObject(name = "404 Reaction Not Found", value = "{\"status\": 404, \"message\": \"반응을 누른 기록이 없습니다.\"}")
+                            })),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @PatchMapping("/history/{historyId}")
+    public ResponseEntity<ReactionSimpleResponse> updateHistoryReaction(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long historyId,
+            @RequestBody @Valid HistoryReactionUpdateRequest request
+    ) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        log.info("활동 반응 변경 요청 - User: {}, HistoryId: {}", userId, historyId);
+
+        ReactionSimpleResponse response = reactionService.updateHistoryReaction(userId, historyId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 특정 활동 기록에 남긴 반응을 취소합니다.
+     *
+     * @param userDetails 인증 사용자 정보
+     * @param historyId   반응 대상 활동 기록 ID
+     * @return 처리 결과 메시지 응답
+     */
+    @Operation(summary = "특정 활동 기록 반응 취소", description = "인증된 사용자가 특정 활동 기록에 남긴 반응을 취소합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "반응이 성공적으로 취소되었습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ReactionSimpleResponse.class),
+                            examples = @ExampleObject(name = "200 OK", value = "{\"message\": \"반응이 성공적으로 취소되었습니다.\"}"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"접근 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "반응을 누른 기록이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"반응을 누른 기록이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @DeleteMapping("/history/{historyId}")
+    public ResponseEntity<ReactionSimpleResponse> cancelHistoryReaction(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long historyId
+    ) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        log.info("활동 반응 취소 요청 - User: {}, HistoryId: {}", userId, historyId);
+
+        ReactionSimpleResponse response = reactionService.cancelHistoryReaction(userId, historyId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/dodo/backend/reaction/dto/request/ReactionRequest.java
+++ b/src/main/java/com/dodo/backend/reaction/dto/request/ReactionRequest.java
@@ -54,4 +54,29 @@ public class ReactionRequest {
                     .build();
         }
     }
+
+    /**
+     * 특정 활동 기록에 남긴 반응을 변경할 때 사용하는 요청 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "활동 반응 변경 요청 DTO")
+    public static class HistoryReactionUpdateRequest {
+
+        @Schema(description = "변경할 반응 유형 (LIKE, DISLIKE)", example = "LIKE")
+        @NotNull(message = "잘못된 요청입니다.")
+        @Pattern(regexp = "^(?i)(LIKE|DISLIKE)$", message = "잘못된 요청입니다.")
+        private String reactionType;
+
+        /**
+         * 요청 문자열 반응 유형을 열거형으로 변환합니다.
+         *
+         * @return 변환된 반응 유형
+         */
+        public ReactionType toReactionType() {
+            return ReactionType.valueOf(this.reactionType.trim().toUpperCase(Locale.ROOT));
+        }
+    }
 }

--- a/src/main/java/com/dodo/backend/reaction/mapper/ReactionMapper.java
+++ b/src/main/java/com/dodo/backend/reaction/mapper/ReactionMapper.java
@@ -1,0 +1,25 @@
+package com.dodo.backend.reaction.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.UUID;
+
+/**
+ * 반응(Reaction) 도메인의 수정 쿼리를 담당하는 MyBatis Mapper 인터페이스입니다.
+ */
+@Mapper
+public interface ReactionMapper {
+
+    /**
+     * 특정 사용자가 특정 활동 기록에 남긴 반응 유형을 변경합니다.
+     *
+     * @param userId       반응을 변경하는 사용자 ID
+     * @param historyId    반응 대상 활동 기록 ID
+     * @param reactionType 변경할 반응 유형 문자열
+     * @return 업데이트된 행 수
+     */
+    int updateHistoryReactionType(@Param("userId") UUID userId,
+                                  @Param("historyId") Long historyId,
+                                  @Param("reactionType") String reactionType);
+}

--- a/src/main/java/com/dodo/backend/reaction/repository/ReactionRepository.java
+++ b/src/main/java/com/dodo/backend/reaction/repository/ReactionRepository.java
@@ -6,6 +6,9 @@ import com.dodo.backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 /**
  * {@link Reaction} 엔티티의 데이터베이스 접근을 담당하는 리포지토리 인터페이스입니다.
  */
@@ -20,4 +23,13 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
      * @return 반응 이력이 존재하면 true, 존재하지 않으면 false
      */
     boolean existsByUserAndHistory(User user, ActivityHistory history);
+
+    /**
+     * 특정 사용자가 특정 활동 기록에 남긴 반응 엔티티를 조회합니다.
+     *
+     * @param userId    반응을 남긴 사용자 ID
+     * @param historyId 반응 대상 활동 기록 ID
+     * @return 반응 엔티티 Optional
+     */
+    Optional<Reaction> findByUser_UsersIdAndHistory_HistoryId(UUID userId, Long historyId);
 }

--- a/src/main/java/com/dodo/backend/reaction/service/ReactionService.java
+++ b/src/main/java/com/dodo/backend/reaction/service/ReactionService.java
@@ -1,6 +1,7 @@
 package com.dodo.backend.reaction.service;
 
 import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionCreateRequest;
+import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionUpdateRequest;
 import com.dodo.backend.reaction.dto.response.ReactionResponse.ReactionSimpleResponse;
 
 import java.util.UUID;
@@ -18,4 +19,23 @@ public interface ReactionService {
      * @return 처리 결과 메시지 응답 DTO
      */
     ReactionSimpleResponse createHistoryReaction(UUID userId, HistoryReactionCreateRequest request);
+
+    /**
+     * 특정 활동 기록에 남긴 반응을 변경합니다.
+     *
+     * @param userId  요청 사용자 ID
+     * @param historyId 반응 대상 활동 기록 ID
+     * @param request 반응 변경 요청 DTO
+     * @return 처리 결과 메시지 응답 DTO
+     */
+    ReactionSimpleResponse updateHistoryReaction(UUID userId, Long historyId, HistoryReactionUpdateRequest request);
+
+    /**
+     * 특정 활동 기록에 남긴 반응을 취소합니다.
+     *
+     * @param userId 요청 사용자 ID
+     * @param historyId 반응 대상 활동 기록 ID
+     * @return 처리 결과 메시지 응답 DTO
+     */
+    ReactionSimpleResponse cancelHistoryReaction(UUID userId, Long historyId);
 }

--- a/src/main/java/com/dodo/backend/reaction/service/ReactionServiceImpl.java
+++ b/src/main/java/com/dodo/backend/reaction/service/ReactionServiceImpl.java
@@ -3,9 +3,12 @@ package com.dodo.backend.reaction.service;
 import com.dodo.backend.activityhistory.entity.ActivityHistory;
 import com.dodo.backend.activityhistory.service.ActivityHistoryService;
 import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionCreateRequest;
+import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionUpdateRequest;
 import com.dodo.backend.reaction.dto.response.ReactionResponse.ReactionSimpleResponse;
 import com.dodo.backend.reaction.entity.Reaction;
+import com.dodo.backend.reaction.entity.ReactionType;
 import com.dodo.backend.reaction.exception.ReactionException;
+import com.dodo.backend.reaction.mapper.ReactionMapper;
 import com.dodo.backend.reaction.repository.ReactionRepository;
 import com.dodo.backend.user.entity.User;
 import com.dodo.backend.user.service.UserService;
@@ -18,6 +21,7 @@ import java.util.UUID;
 
 import static com.dodo.backend.reaction.exception.ReactionErrorCode.ACCESS_DENIED;
 import static com.dodo.backend.reaction.exception.ReactionErrorCode.ACTIVITY_REACTION_ALREADY_EXISTS;
+import static com.dodo.backend.reaction.exception.ReactionErrorCode.ACTIVITY_REACTION_NOT_FOUND;
 import static com.dodo.backend.reaction.exception.ReactionErrorCode.INVALID_REQUEST;
 
 /**
@@ -29,6 +33,7 @@ import static com.dodo.backend.reaction.exception.ReactionErrorCode.INVALID_REQU
 public class ReactionServiceImpl implements ReactionService {
 
     private final ReactionRepository reactionRepository;
+    private final ReactionMapper reactionMapper;
     private final ActivityHistoryService activityHistoryService;
     private final UserService userService;
 
@@ -62,5 +67,63 @@ public class ReactionServiceImpl implements ReactionService {
                 userId, request.getHistoryId(), reaction.getReactionType());
 
         return ReactionSimpleResponse.toDto("반응이 성공적으로 추가되었습니다.");
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * 처리 순서는 요청값 검증, 사용자/활동 조회, 접근 권한 검증, 반응 존재 검증, 반응 변경 순으로 진행됩니다.
+     */
+    @Transactional
+    @Override
+    public ReactionSimpleResponse updateHistoryReaction(UUID userId, Long historyId, HistoryReactionUpdateRequest request) {
+        if (request == null || request.getReactionType() == null || historyId == null) {
+            throw new ReactionException(INVALID_REQUEST);
+        }
+
+        User user = userService.getUserById(userId);
+        ActivityHistory history = activityHistoryService.getActivityHistoryById(historyId);
+
+        if (history.getUser().getUsersId().equals(userId)) {
+            throw new ReactionException(ACCESS_DENIED);
+        }
+
+        if (!reactionRepository.existsByUserAndHistory(user, history)) {
+            throw new ReactionException(ACTIVITY_REACTION_NOT_FOUND);
+        }
+
+        ReactionType reactionType = request.toReactionType();
+        int updatedRows = reactionMapper.updateHistoryReactionType(userId, historyId, reactionType.name());
+
+        if (updatedRows == 0) {
+            throw new ReactionException(ACTIVITY_REACTION_NOT_FOUND);
+        }
+
+        log.info("활동 반응 변경 완료 - User: {}, HistoryId: {}, ReactionType: {}",
+                userId, historyId, reactionType);
+
+        return ReactionSimpleResponse.toDto("반응이 성공적으로 변경되었습니다.");
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * 처리 순서는 요청값 검증, 반응 조회, 반응 삭제 순으로 진행됩니다.
+     */
+    @Transactional
+    @Override
+    public ReactionSimpleResponse cancelHistoryReaction(UUID userId, Long historyId) {
+        if (historyId == null) {
+            throw new ReactionException(INVALID_REQUEST);
+        }
+
+        Reaction reaction = reactionRepository.findByUser_UsersIdAndHistory_HistoryId(userId, historyId)
+                .orElseThrow(() -> new ReactionException(ACTIVITY_REACTION_NOT_FOUND));
+
+        reactionRepository.delete(reaction);
+
+        log.info("활동 반응 취소 완료 - User: {}, HistoryId: {}", userId, historyId);
+
+        return ReactionSimpleResponse.toDto("반응이 성공적으로 취소되었습니다.");
     }
 }

--- a/src/main/resources/com/dodo/backend/reaction/mapper/ReactionMapper.xml
+++ b/src/main/resources/com/dodo/backend/reaction/mapper/ReactionMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!-- 반응(Reaction) 도메인의 수정 쿼리를 담당하는 MyBatis Mapper XML입니다. -->
+<mapper namespace="com.dodo.backend.reaction.mapper.ReactionMapper">
+
+    <!-- 특정 사용자가 특정 활동 기록에 남긴 반응 유형을 변경합니다.
+         1. reaction_type : 요청 값(LIKE/DISLIKE)으로 반응 유형 변경
+         2. WHERE user_id : 반응을 남긴 사용자 식별
+         3. WHERE history_id : 반응 대상 활동 기록 식별 -->
+    <update id="updateHistoryReactionType">
+        UPDATE reaction
+        SET reaction_type = #{reactionType}
+        WHERE user_id = #{userId}
+          AND history_id = #{historyId}
+    </update>
+</mapper>

--- a/src/test/java/com/dodo/backend/reaction/service/ReactionServiceTest.java
+++ b/src/test/java/com/dodo/backend/reaction/service/ReactionServiceTest.java
@@ -6,8 +6,10 @@ import com.dodo.backend.activityhistory.exception.ActivityHistoryException;
 import com.dodo.backend.activityhistory.service.ActivityHistoryService;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionCreateRequest;
+import com.dodo.backend.reaction.dto.request.ReactionRequest.HistoryReactionUpdateRequest;
 import com.dodo.backend.reaction.dto.response.ReactionResponse.ReactionSimpleResponse;
 import com.dodo.backend.reaction.entity.Reaction;
+import com.dodo.backend.reaction.mapper.ReactionMapper;
 import com.dodo.backend.reaction.exception.ReactionErrorCode;
 import com.dodo.backend.reaction.exception.ReactionException;
 import com.dodo.backend.reaction.repository.ReactionRepository;
@@ -40,6 +42,9 @@ class ReactionServiceTest {
 
     @Mock
     private ReactionRepository reactionRepository;
+
+    @Mock
+    private ReactionMapper reactionMapper;
 
     @Mock
     private ActivityHistoryService activityHistoryService;
@@ -204,5 +209,196 @@ class ReactionServiceTest {
 
         // then
         assertEquals(ActivityHistoryErrorCode.HISTORY_NOT_FOUND, exception.getErrorCode());
+    }
+
+    /**
+     * 활동 반응 변경이 정상적으로 수행되고 성공 메시지를 반환하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 변경 성공: 기존 반응 이력이 있으면 반응 유형을 변경한다.")
+    void updateHistoryReaction_Success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID ownerId = UUID.randomUUID();
+        Long historyId = 101L;
+
+        User requester = User.builder().usersId(userId).build();
+        User owner = User.builder().usersId(ownerId).build();
+        Pet pet = Pet.builder().petId(1L).build();
+        ActivityHistory history = ActivityHistory.builder()
+                .historyId(historyId)
+                .user(owner)
+                .pet(pet)
+                .build();
+
+        HistoryReactionUpdateRequest request = HistoryReactionUpdateRequest.builder()
+                .reactionType("DISLIKE")
+                .build();
+
+        given(userService.getUserById(userId)).willReturn(requester);
+        given(activityHistoryService.getActivityHistoryById(historyId)).willReturn(history);
+        given(reactionRepository.existsByUserAndHistory(requester, history)).willReturn(true);
+        given(reactionMapper.updateHistoryReactionType(userId, historyId, "DISLIKE")).willReturn(1);
+
+        // when
+        ReactionSimpleResponse response = reactionService.updateHistoryReaction(userId, historyId, request);
+
+        // then
+        assertNotNull(response);
+        assertEquals("반응이 성공적으로 변경되었습니다.", response.getMessage());
+        verify(reactionMapper, times(1)).updateHistoryReactionType(userId, historyId, "DISLIKE");
+    }
+
+    /**
+     * 반응 변경 요청이 null인 경우 INVALID_REQUEST 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 변경 실패: 요청값이 null이면 INVALID_REQUEST 예외가 발생한다.")
+    void updateHistoryReaction_Fail_InvalidRequest() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when
+        ReactionException exception = assertThrows(ReactionException.class, () ->
+                reactionService.updateHistoryReaction(userId, 101L, null)
+        );
+
+        // then
+        assertEquals(ReactionErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    /**
+     * 기존 반응 이력이 없으면 ACTIVITY_REACTION_NOT_FOUND 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 변경 실패: 반응 이력이 없으면 ACTIVITY_REACTION_NOT_FOUND 예외가 발생한다.")
+    void updateHistoryReaction_Fail_ReactionNotFound() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID ownerId = UUID.randomUUID();
+        Long historyId = 101L;
+
+        User requester = User.builder().usersId(userId).build();
+        User owner = User.builder().usersId(ownerId).build();
+        Pet pet = Pet.builder().petId(1L).build();
+        ActivityHistory history = ActivityHistory.builder()
+                .historyId(historyId)
+                .user(owner)
+                .pet(pet)
+                .build();
+
+        HistoryReactionUpdateRequest request = HistoryReactionUpdateRequest.builder()
+                .reactionType("LIKE")
+                .build();
+
+        given(userService.getUserById(userId)).willReturn(requester);
+        given(activityHistoryService.getActivityHistoryById(historyId)).willReturn(history);
+        given(reactionRepository.existsByUserAndHistory(requester, history)).willReturn(false);
+
+        // when
+        ReactionException exception = assertThrows(ReactionException.class, () ->
+                reactionService.updateHistoryReaction(userId, historyId, request)
+        );
+
+        // then
+        assertEquals(ReactionErrorCode.ACTIVITY_REACTION_NOT_FOUND, exception.getErrorCode());
+    }
+
+    /**
+     * 본인 활동 기록에 반응 변경을 시도하면 ACCESS_DENIED 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 변경 실패: 본인 활동 기록이면 ACCESS_DENIED 예외가 발생한다.")
+    void updateHistoryReaction_Fail_AccessDeniedForOwnHistory() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 101L;
+
+        User requester = User.builder().usersId(userId).build();
+        Pet pet = Pet.builder().petId(1L).build();
+        ActivityHistory history = ActivityHistory.builder()
+                .historyId(historyId)
+                .user(requester)
+                .pet(pet)
+                .build();
+
+        HistoryReactionUpdateRequest request = HistoryReactionUpdateRequest.builder()
+                .reactionType("LIKE")
+                .build();
+
+        given(userService.getUserById(userId)).willReturn(requester);
+        given(activityHistoryService.getActivityHistoryById(historyId)).willReturn(history);
+
+        // when
+        ReactionException exception = assertThrows(ReactionException.class, () ->
+                reactionService.updateHistoryReaction(userId, historyId, request)
+        );
+
+        // then
+        assertEquals(ReactionErrorCode.ACCESS_DENIED, exception.getErrorCode());
+    }
+
+    /**
+     * 활동 반응 취소가 정상적으로 수행되고 성공 메시지를 반환하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 취소 성공: 기존 반응 이력이 있으면 반응을 삭제한다.")
+    void cancelHistoryReaction_Success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 101L;
+
+        Reaction reaction = Reaction.builder().reactionId(1L).build();
+
+        given(reactionRepository.findByUser_UsersIdAndHistory_HistoryId(userId, historyId))
+                .willReturn(Optional.of(reaction));
+
+        // when
+        ReactionSimpleResponse response = reactionService.cancelHistoryReaction(userId, historyId);
+
+        // then
+        assertNotNull(response);
+        assertEquals("반응이 성공적으로 취소되었습니다.", response.getMessage());
+        verify(reactionRepository, times(1)).delete(reaction);
+    }
+
+    /**
+     * 취소 대상 반응 이력이 없으면 ACTIVITY_REACTION_NOT_FOUND 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 취소 실패: 반응 이력이 없으면 ACTIVITY_REACTION_NOT_FOUND 예외가 발생한다.")
+    void cancelHistoryReaction_Fail_ReactionNotFound() {
+        // given
+        UUID userId = UUID.randomUUID();
+        Long historyId = 101L;
+
+        given(reactionRepository.findByUser_UsersIdAndHistory_HistoryId(userId, historyId))
+                .willReturn(Optional.empty());
+
+        // when
+        ReactionException exception = assertThrows(ReactionException.class, () ->
+                reactionService.cancelHistoryReaction(userId, historyId)
+        );
+
+        // then
+        assertEquals(ReactionErrorCode.ACTIVITY_REACTION_NOT_FOUND, exception.getErrorCode());
+    }
+
+    /**
+     * 취소 요청의 historyId가 null이면 INVALID_REQUEST 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("활동 반응 취소 실패: historyId가 null이면 INVALID_REQUEST 예외가 발생한다.")
+    void cancelHistoryReaction_Fail_InvalidRequest() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when
+        ReactionException exception = assertThrows(ReactionException.class, () ->
+                reactionService.cancelHistoryReaction(userId, null)
+        );
+
+        // then
+        assertEquals(ReactionErrorCode.INVALID_REQUEST, exception.getErrorCode());
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

<br>

- 활동기록 반응 변경 기능 추가 (PATCH /reactions/history/{historyId})
- 활동기록 반응 취소 기능 추가 (DELETE /reactions/history/{historyId})
- 반응 변경 요청 DTO 및 유효성 검증 추가 (LIKE, DISLIKE)
- 토큰 사용자 + historyId 기준 반응 조회 후 JPA delete 처리
- Swagger 응답 예시 분리 (추가/변경/취소 메시지)
- 반응 서비스 단위 테스트 추가 및 성공/실패 케이스 검증

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

- Closes #134

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

활동 기록 반응 변경 및 취소 기능 구현했습니다.