### PR TITLE
✨ Feat: 주변 인기 활동 경로 조회 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
+++ b/src/main/java/com/dodo/backend/activityhistory/controller/ActivityHistoryController.java
@@ -30,6 +30,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 import static com.dodo.backend.activityhistory.dto.request.ActivityHistoryRequest.*;
@@ -368,6 +369,65 @@ public class ActivityHistoryController {
         ActivityHistoryPageResponse response = activityHistoryService.getMyActivityHistory(userId, pageable);
 
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 주변 인기 활동 기록을 커서 기반으로 조회합니다.
+     *
+     * @param userDetails  인증 객체
+     * @param latitude     현재 위도
+     * @param longitude    현재 경도
+     * @param limit        요청 크기(기본 10)
+     * @param reactionType 정렬 기준 반응 타입(LIKE/DISLIKE)
+     * @param cursor       커서(historyId)
+     * @return 주변 인기 활동 목록
+     */
+    @Operation(summary = "주변 인기 활동 조회", description = "반응 타입(LIKE/DISLIKE) 기준으로 주변 인기 활동을 커서 기반 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 데이터를 조회했습니다.",
+                    content = @Content(schema = @Schema(implementation = ActivityHistoryPageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "주변 활동 기록을 조회할 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"주변 활동 기록을 조회할 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @GetMapping("/popular")
+    public ResponseEntity<PopularActivityHistoryResponse> getPopularActivityHistories(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam BigDecimal latitude,
+            @RequestParam BigDecimal longitude,
+            @RequestParam(defaultValue = "10") Integer limit,
+            @RequestParam String reactionType,
+            @RequestParam(required = false) Long cursor
+    ) {
+        UUID userId = UUID.fromString(userDetails.getUsername());
+
+        return ResponseEntity.ok(
+                activityHistoryService.getPopularActivities(
+                        userId,
+                        latitude,
+                        longitude,
+                        limit,
+                        reactionType,
+                        cursor
+                )
+        );
     }
 
     /**

--- a/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
+++ b/src/main/java/com/dodo/backend/activityhistory/dto/response/ActivityHistoryResponse.java
@@ -489,4 +489,111 @@ public class ActivityHistoryResponse {
         @Schema(description = "측정 시간", example = "2025-09-30T14:00:00")
         private LocalDateTime measuredAt;
     }
+
+    /**
+     * 주변 인기 활동 조회 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "주변 인기 활동 목록 응답 DTO")
+    public static class PopularActivityHistoryResponse {
+
+        @Schema(description = "응답 메시지", example = "성공적으로 데이터를 조회했습니다.")
+        private String message;
+
+        @Schema(description = "다음 페이지 커서(historyId)", example = "202")
+        private Long nextCursor;
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        private boolean hasNext;
+
+        @Schema(description = "주변 인기 활동 목록")
+        private List<PopularActivityItem> activities;
+
+        public static PopularActivityHistoryResponse toDto(
+                String message,
+                Long nextCursor,
+                boolean hasNext,
+                List<PopularActivityItem> activities
+        ) {
+            return PopularActivityHistoryResponse.builder()
+                    .message(message)
+                    .nextCursor(nextCursor)
+                    .hasNext(hasNext)
+                    .activities(activities)
+                    .build();
+        }
+    }
+
+    /**
+     * 주변 인기 활동 단건 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "주변 인기 활동 단건 DTO")
+    public static class PopularActivityItem {
+
+        @Schema(description = "활동 기록 ID", example = "205")
+        private Long historyId;
+
+        @Schema(description = "작성자 닉네임", example = "달리기왕")
+        private String nickname;
+
+        @Schema(description = "활동 거리(km)", example = "10.5")
+        private BigDecimal distance;
+
+        @Schema(description = "사용자와의 거리(km)", example = "1.2")
+        private BigDecimal distanceFromUser;
+
+        @Schema(description = "경로 좌표 리스트")
+        private List<SimpleRoutePointDto> routePoints;
+
+        @Schema(description = "좋아요 수", example = "150")
+        private long likeCount;
+
+        @Schema(description = "싫어요 수", example = "2")
+        private long dislikeCount;
+
+        @Schema(description = "내 반응 (LIKE, DISLIKE, NONE)", example = "LIKE")
+        private String reactionForMe;
+
+        public static PopularActivityItem toDto(
+                ActivityHistory history,
+                BigDecimal distanceFromUser,
+                List<SimpleRoutePointDto> routePoints,
+                long likeCount,
+                long dislikeCount,
+                String reactionForMe
+        ) {
+            return PopularActivityItem.builder()
+                    .historyId(history.getHistoryId())
+                    .nickname(history.getUser().getNickname())
+                    .distance(history.getDistance())
+                    .distanceFromUser(distanceFromUser)
+                    .routePoints(routePoints)
+                    .likeCount(likeCount)
+                    .dislikeCount(dislikeCount)
+                    .reactionForMe(reactionForMe)
+                    .build();
+        }
+    }
+
+    /**
+     * 주변 인기 활동 응답용 단순 경로 좌표 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "주변 인기 활동 단순 경로 좌표 DTO")
+    public static class SimpleRoutePointDto {
+
+        @Schema(description = "위도", example = "37.5123")
+        private BigDecimal latitude;
+
+        @Schema(description = "경도", example = "127.0123")
+        private BigDecimal longitude;
+    }
+
 }

--- a/src/main/java/com/dodo/backend/activityhistory/repository/ActivityHistoryRepository.java
+++ b/src/main/java/com/dodo/backend/activityhistory/repository/ActivityHistoryRepository.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * {@link ActivityHistory} 엔티티의 데이터베이스 접근을 담당하는 리포지토리 인터페이스입니다.
@@ -99,6 +100,7 @@ public interface ActivityHistoryRepository extends JpaRepository<ActivityHistory
     @Query("""
             SELECT ah
             FROM ActivityHistory ah
+            JOIN FETCH ah.user u
             WHERE ah.activityHistoryStatus = :status
               AND (:cursor IS NULL OR ah.historyId < :cursor)
             ORDER BY (
@@ -114,5 +116,34 @@ public interface ActivityHistoryRepository extends JpaRepository<ActivityHistory
             @Param("reactionType") ReactionType reactionType,
             @Param("cursor") Long cursor,
             Pageable pageable
+    );
+
+    /**
+     * 활동 기록 목록의 반응 수를 타입별로 집계합니다.
+     */
+    @Query("""
+            SELECT r.history.historyId AS historyId, COUNT(r) AS reactionCount
+            FROM Reaction r
+            WHERE r.history.historyId IN :historyIds
+              AND r.reactionType = :reactionType
+            GROUP BY r.history.historyId
+            """)
+    List<Object[]> countGroupedByHistoryIdsAndReactionType(
+            @Param("historyIds") List<Long> historyIds,
+            @Param("reactionType") ReactionType reactionType
+    );
+
+    /**
+     * 특정 사용자의 활동 기록별 반응 타입을 조회합니다.
+     */
+    @Query("""
+            SELECT r.history.historyId AS historyId, r.reactionType AS reactionType
+            FROM Reaction r
+            WHERE r.user.usersId = :userId
+              AND r.history.historyId IN :historyIds
+            """)
+    List<Object[]> findMyReactionsByUserAndHistoryIds(
+            @Param("userId") UUID userId,
+            @Param("historyIds") List<Long> historyIds
     );
 }

--- a/src/main/java/com/dodo/backend/activityhistory/repository/ActivityHistoryRepository.java
+++ b/src/main/java/com/dodo/backend/activityhistory/repository/ActivityHistoryRepository.java
@@ -3,10 +3,13 @@ package com.dodo.backend.activityhistory.repository;
 import com.dodo.backend.activityhistory.entity.ActivityHistory;
 import com.dodo.backend.activityhistory.entity.ActivityHistoryStatus;
 import com.dodo.backend.pet.entity.Pet;
+import com.dodo.backend.reaction.entity.ReactionType;
 import com.dodo.backend.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -83,5 +86,33 @@ public interface ActivityHistoryRepository extends JpaRepository<ActivityHistory
             Long petId,
             LocalDateTime startDateTime,
             LocalDateTime endDateTime
+    );
+
+    /**
+     * 주변 인기 활동을 반응 타입 기준으로 조회합니다.
+     * <p>
+     * - 상태가 COMPLETED인 활동만 조회
+     * - cursor가 있으면 historyId가 cursor보다 작은 데이터만 조회
+     * - reactionType(LIKE/DISLIKE) 카운트 내림차순 + historyId 내림차순 정렬
+     * </p>
+     */
+    @Query("""
+            SELECT ah
+            FROM ActivityHistory ah
+            WHERE ah.activityHistoryStatus = :status
+              AND (:cursor IS NULL OR ah.historyId < :cursor)
+            ORDER BY (
+                SELECT COUNT(r)
+                FROM Reaction r
+                WHERE r.history = ah
+                  AND r.reactionType = :reactionType
+            ) DESC,
+            ah.historyId DESC
+            """)
+    List<ActivityHistory> findPopularByReactionTypeWithCursor(
+            @Param("status") ActivityHistoryStatus status,
+            @Param("reactionType") ReactionType reactionType,
+            @Param("cursor") Long cursor,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryService.java
@@ -6,6 +6,7 @@ import com.dodo.backend.activityhistory.dto.response.ActivityHistoryResponse.*;
 import com.dodo.backend.activityhistory.entity.ActivityHistory;
 import org.springframework.data.domain.Pageable;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -112,6 +113,26 @@ public interface ActivityHistoryService {
      * @return 상세 경로 및 활동 정보 응답 DTO
      */
     ActivityRouteResponse getActivityRoute(UUID userId, Long historyId);
+
+    /**
+     * 주변 인기 활동 기록 목록을 커서 기반으로 조회합니다.
+     *
+     * @param userId       요청 사용자 UUID
+     * @param latitude     사용자 현재 위도
+     * @param longitude    사용자 현재 경도
+     * @param limit        페이지 크기
+     * @param reactionType 정렬 기준 반응 타입 (LIKE/DISLIKE)
+     * @param cursor       마지막으로 조회한 historyId (없으면 null)
+     * @return 주변 인기 활동 목록 응답
+     */
+    PopularActivityHistoryResponse getPopularActivities(
+            UUID userId,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            Integer limit,
+            String reactionType,
+            Long cursor
+    );
 
     /**
      * 건강 분석용 활동 기록 데이터를 조회합니다.

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
@@ -11,6 +11,9 @@ import com.dodo.backend.activityhistory.repository.ActivityHistoryRepository;
 import com.dodo.backend.imagefile.service.ImageFileService;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.pet.service.PetService;
+import com.dodo.backend.reaction.entity.ReactionType;
+import com.dodo.backend.reaction.repository.ReactionRepository;
+import com.dodo.backend.routepoint.entity.RoutePoint;
 import com.dodo.backend.routepoint.service.RoutePointService;
 import com.dodo.backend.user.entity.User;
 import com.dodo.backend.user.service.UserService;
@@ -18,16 +21,20 @@ import com.dodo.backend.userpet.service.UserPetService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.dodo.backend.activityhistory.exception.ActivityHistoryErrorCode.*;
 
@@ -48,6 +55,7 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     private final ImageFileService imageFileService;
     private final ActivityHistoryMapper activityHistoryMapper;
     private final RoutePointService routePointService;
+    private final ReactionRepository reactionRepository;
 
     /**
      * 활동 기록을 생성합니다.
@@ -360,6 +368,122 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     }
 
     /**
+     * 주변 인기 활동 기록을 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public PopularActivityHistoryResponse getPopularActivities(
+            UUID userId,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            Integer limit,
+            String reactionType,
+            Long cursor
+    ) {
+        if (latitude == null || longitude == null || reactionType == null) {
+            throw new ActivityHistoryException(INVALID_REQUEST);
+        }
+
+        int safeLimit = (limit == null) ? 10 : limit;
+        if (safeLimit <= 0) {
+            throw new ActivityHistoryException(INVALID_REQUEST);
+        }
+        ReactionType parsedReactionType = toReactionType(reactionType);
+
+        Pageable pageable = PageRequest.of(0, safeLimit + 1);
+        List<ActivityHistory> candidates = activityHistoryRepository.findPopularByReactionTypeWithCursor(
+                ActivityHistoryStatus.COMPLETED,
+                parsedReactionType,
+                cursor,
+                pageable
+        );
+
+        boolean hasNext = candidates.size() > safeLimit;
+        List<ActivityHistory> activities = hasNext ? candidates.subList(0, safeLimit) : candidates;
+        Long nextCursor = hasNext ? activities.get(activities.size() - 1).getHistoryId() : null;
+
+        List<Long> historyIds = activities.stream()
+                .map(ActivityHistory::getHistoryId)
+                .toList();
+
+        if (historyIds.isEmpty()) {
+            return PopularActivityHistoryResponse.toDto(
+                    "성공적으로 데이터를 조회했습니다.",
+                    null,
+                    false,
+                    List.of()
+            );
+        }
+
+        Map<Long, Long> likeCountMap = reactionRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.LIKE)
+                .stream()
+                .collect(Collectors.toMap(
+                        ReactionRepository.HistoryReactionCountProjection::getHistoryId,
+                        ReactionRepository.HistoryReactionCountProjection::getReactionCount
+                ));
+        Map<Long, Long> dislikeCountMap = reactionRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.DISLIKE)
+                .stream()
+                .collect(Collectors.toMap(
+                        ReactionRepository.HistoryReactionCountProjection::getHistoryId,
+                        ReactionRepository.HistoryReactionCountProjection::getReactionCount
+                ));
+        Map<Long, String> myReactionMap = reactionRepository.findByUser_UsersIdAndHistory_HistoryIdIn(userId, historyIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        reaction -> reaction.getHistory().getHistoryId(),
+                        reaction -> reaction.getReactionType().name(),
+                        (left, right) -> left
+                ));
+
+        Map<Long, List<SimpleRoutePointDto>> routePointMap = routePointService.getRoutePointsByHistoryIds(historyIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        routePoint -> routePoint.getActivityHistory().getHistoryId(),
+                        Collectors.mapping(
+                                routePoint -> SimpleRoutePointDto.builder()
+                                        .latitude(routePoint.getLatitude())
+                                        .longitude(routePoint.getLongitude())
+                                        .build(),
+                                Collectors.toList()
+                        )
+                ));
+
+        List<PopularActivityItem> items = activities.stream()
+                .map(history -> {
+                    Long historyId = history.getHistoryId();
+                    BigDecimal baseLatitude = history.getStartLatitude();
+                    BigDecimal baseLongitude = history.getStartLongitude();
+
+                    if ((baseLatitude == null || baseLongitude == null)
+                            && routePointMap.containsKey(historyId)
+                            && !routePointMap.get(historyId).isEmpty()) {
+                        SimpleRoutePointDto firstPoint = routePointMap.get(historyId).get(0);
+                        baseLatitude = firstPoint.getLatitude();
+                        baseLongitude = firstPoint.getLongitude();
+                    }
+
+                    BigDecimal distanceFromUser = calculateDistanceInKm(latitude, longitude, baseLatitude, baseLongitude);
+
+                    return PopularActivityItem.toDto(
+                            history,
+                            distanceFromUser,
+                            routePointMap.getOrDefault(historyId, List.of()),
+                            likeCountMap.getOrDefault(historyId, 0L),
+                            dislikeCountMap.getOrDefault(historyId, 0L),
+                            myReactionMap.getOrDefault(historyId, "NONE")
+                    );
+                })
+                .toList();
+
+        return PopularActivityHistoryResponse.toDto(
+                "성공적으로 데이터를 조회했습니다.",
+                nextCursor,
+                hasNext,
+                items
+        );
+    }
+
+    /**
      * 건강 분석 범위에 해당하는 활동 기록을 조회합니다.
      *
      * @param petId 반려동물 ID
@@ -471,5 +595,46 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     public ActivityHistory getActivityHistoryById(Long historyId) {
         return activityHistoryRepository.findById(historyId)
                 .orElseThrow(() -> new ActivityHistoryException(HISTORY_NOT_FOUND));
+    }
+
+    /**
+     * 두 좌표 간 거리를 하버사인 공식으로 계산합니다. 단위는 km입니다.
+     */
+    private BigDecimal calculateDistanceInKm(
+            BigDecimal userLatitude,
+            BigDecimal userLongitude,
+            BigDecimal targetLatitude,
+            BigDecimal targetLongitude
+    ) {
+        if (targetLatitude == null || targetLongitude == null) {
+            return BigDecimal.ZERO;
+        }
+
+        double earthRadiusKm = 6371.0d;
+        double lat1 = Math.toRadians(userLatitude.doubleValue());
+        double lon1 = Math.toRadians(userLongitude.doubleValue());
+        double lat2 = Math.toRadians(targetLatitude.doubleValue());
+        double lon2 = Math.toRadians(targetLongitude.doubleValue());
+
+        double dLat = lat2 - lat1;
+        double dLon = lon2 - lon1;
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        double distanceKm = earthRadiusKm * c;
+
+        return BigDecimal.valueOf(distanceKm).setScale(1, RoundingMode.HALF_UP);
+    }
+
+    private ReactionType toReactionType(String reactionType) {
+        String normalized = reactionType.trim().toUpperCase(Locale.ROOT);
+        if ("LIKE".equals(normalized)) {
+            return ReactionType.LIKE;
+        }
+        if ("DISLIKE".equals(normalized)) {
+            return ReactionType.DISLIKE;
+        }
+        throw new ActivityHistoryException(INVALID_REQUEST);
     }
 }

--- a/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
+++ b/src/main/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceImpl.java
@@ -12,7 +12,6 @@ import com.dodo.backend.imagefile.service.ImageFileService;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.pet.service.PetService;
 import com.dodo.backend.reaction.entity.ReactionType;
-import com.dodo.backend.reaction.repository.ReactionRepository;
 import com.dodo.backend.routepoint.entity.RoutePoint;
 import com.dodo.backend.routepoint.service.RoutePointService;
 import com.dodo.backend.user.entity.User;
@@ -55,7 +54,6 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
     private final ImageFileService imageFileService;
     private final ActivityHistoryMapper activityHistoryMapper;
     private final RoutePointService routePointService;
-    private final ReactionRepository reactionRepository;
 
     /**
      * 활동 기록을 생성합니다.
@@ -415,23 +413,23 @@ public class ActivityHistoryServiceImpl implements ActivityHistoryService {
             );
         }
 
-        Map<Long, Long> likeCountMap = reactionRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.LIKE)
+        Map<Long, Long> likeCountMap = activityHistoryRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.LIKE)
                 .stream()
                 .collect(Collectors.toMap(
-                        ReactionRepository.HistoryReactionCountProjection::getHistoryId,
-                        ReactionRepository.HistoryReactionCountProjection::getReactionCount
+                        row -> (Long) row[0],
+                        row -> ((Number) row[1]).longValue()
                 ));
-        Map<Long, Long> dislikeCountMap = reactionRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.DISLIKE)
+        Map<Long, Long> dislikeCountMap = activityHistoryRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.DISLIKE)
                 .stream()
                 .collect(Collectors.toMap(
-                        ReactionRepository.HistoryReactionCountProjection::getHistoryId,
-                        ReactionRepository.HistoryReactionCountProjection::getReactionCount
+                        row -> (Long) row[0],
+                        row -> ((Number) row[1]).longValue()
                 ));
-        Map<Long, String> myReactionMap = reactionRepository.findByUser_UsersIdAndHistory_HistoryIdIn(userId, historyIds)
+        Map<Long, String> myReactionMap = activityHistoryRepository.findMyReactionsByUserAndHistoryIds(userId, historyIds)
                 .stream()
                 .collect(Collectors.toMap(
-                        reaction -> reaction.getHistory().getHistoryId(),
-                        reaction -> reaction.getReactionType().name(),
+                        row -> (Long) row[0],
+                        row -> ((ReactionType) row[1]).name(),
                         (left, right) -> left
                 ));
 

--- a/src/main/java/com/dodo/backend/reaction/repository/ReactionRepository.java
+++ b/src/main/java/com/dodo/backend/reaction/repository/ReactionRepository.java
@@ -3,10 +3,15 @@ package com.dodo.backend.reaction.repository;
 import com.dodo.backend.activityhistory.entity.ActivityHistory;
 import com.dodo.backend.board.entity.Board;
 import com.dodo.backend.reaction.entity.Reaction;
+import com.dodo.backend.reaction.entity.ReactionType;
 import com.dodo.backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -51,4 +56,29 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
      * @return 반응 엔티티 Optional
      */
     Optional<Reaction> findByUser_UsersIdAndBoard_BoardId(UUID userId, Long boardId);
+
+    /**
+     * 특정 사용자가 지정한 활동 기록 목록에 남긴 반응을 조회합니다.
+     */
+    List<Reaction> findByUser_UsersIdAndHistory_HistoryIdIn(UUID userId, Collection<Long> historyIds);
+
+    /**
+     * 지정한 활동 기록 목록에 대해 특정 반응 타입 개수를 historyId별로 집계합니다.
+     */
+    @Query("""
+            SELECT r.history.historyId AS historyId, COUNT(r) AS reactionCount
+            FROM Reaction r
+            WHERE r.history.historyId IN :historyIds
+              AND r.reactionType = :reactionType
+            GROUP BY r.history.historyId
+            """)
+    List<HistoryReactionCountProjection> countGroupedByHistoryIdsAndReactionType(
+            @Param("historyIds") Collection<Long> historyIds,
+            @Param("reactionType") ReactionType reactionType
+    );
+
+    interface HistoryReactionCountProjection {
+        Long getHistoryId();
+        Long getReactionCount();
+    }
 }

--- a/src/main/java/com/dodo/backend/reaction/service/ReactionServiceImpl.java
+++ b/src/main/java/com/dodo/backend/reaction/service/ReactionServiceImpl.java
@@ -223,4 +223,5 @@ public class ReactionServiceImpl implements ReactionService {
 
         return ReactionSimpleResponse.toDto("반응이 성공적으로 취소되었습니다.");
     }
+
 }

--- a/src/main/java/com/dodo/backend/routepoint/repository/RoutePointRepository.java
+++ b/src/main/java/com/dodo/backend/routepoint/repository/RoutePointRepository.java
@@ -3,6 +3,7 @@ package com.dodo.backend.routepoint.repository;
 import com.dodo.backend.routepoint.entity.RoutePoint;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -21,4 +22,14 @@ public interface RoutePointRepository extends JpaRepository<RoutePoint, Long> {
      * @return 시간순으로 정렬된 RoutePoint 리스트
      */
     List<RoutePoint> findAllByActivityHistory_HistoryIdOrderByRoutePointsMeasuredAtAsc(Long historyId);
+
+    /**
+     * 여러 활동 기록의 경로 좌표를 조회합니다.
+     * <p>
+     * historyId 기준 오름차순, 좌표 측정 시각 오름차순으로 정렬합니다.
+     * </p>
+     */
+    List<RoutePoint> findAllByActivityHistory_HistoryIdInOrderByActivityHistory_HistoryIdAscRoutePointsMeasuredAtAsc(
+            Collection<Long> historyIds
+    );
 }

--- a/src/main/java/com/dodo/backend/routepoint/service/RoutePointService.java
+++ b/src/main/java/com/dodo/backend/routepoint/service/RoutePointService.java
@@ -1,5 +1,6 @@
 package com.dodo.backend.routepoint.service;
 
+import com.dodo.backend.routepoint.entity.RoutePoint;
 import com.dodo.backend.routepoint.socket.request.WebSocketRequest;
 
 import java.math.BigDecimal;
@@ -41,4 +42,12 @@ public interface RoutePointService {
      * @return 시간순 정렬된 경로 데이터 Map 리스트
      */
     List<Map<String, Object>> getRoutePoints(Long historyId);
+
+    /**
+     * 여러 활동 기록의 경로 좌표를 조회합니다.
+     *
+     * @param historyIds 조회할 활동 기록 ID 목록
+     * @return historyId 및 측정 시간 기준 오름차순 좌표 리스트
+     */
+    List<RoutePoint> getRoutePointsByHistoryIds(List<Long> historyIds);
 }

--- a/src/main/java/com/dodo/backend/routepoint/service/RoutePointServiceImpl.java
+++ b/src/main/java/com/dodo/backend/routepoint/service/RoutePointServiceImpl.java
@@ -178,4 +178,16 @@ public class RoutePointServiceImpl implements RoutePointService {
                 })
                 .collect(Collectors.toList());
     }
+
+    /**
+     * 여러 활동 기록의 좌표를 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public List<RoutePoint> getRoutePointsByHistoryIds(List<Long> historyIds) {
+        if (historyIds == null || historyIds.isEmpty()) {
+            return List.of();
+        }
+        return routePointRepository.findAllByActivityHistory_HistoryIdInOrderByActivityHistory_HistoryIdAscRoutePointsMeasuredAtAsc(historyIds);
+    }
 }

--- a/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
+++ b/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
@@ -15,7 +15,6 @@ import com.dodo.backend.imagefile.service.ImageFileService;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.pet.service.PetService;
 import com.dodo.backend.reaction.entity.ReactionType;
-import com.dodo.backend.reaction.repository.ReactionRepository;
 import com.dodo.backend.routepoint.service.RoutePointService;
 import com.dodo.backend.user.entity.User;
 import com.dodo.backend.user.service.UserService;
@@ -75,9 +74,6 @@ class ActivityHistoryServiceTest {
 
     @Mock
     private RoutePointService routePointService;
-
-    @Mock
-    private ReactionRepository reactionRepository;
 
     /**
      * 활동 기록 생성 성공 시나리오를 테스트합니다.
@@ -1144,12 +1140,12 @@ class ActivityHistoryServiceTest {
                 any(Pageable.class)
         )).willReturn(List.of(history1, history2));
 
-        given(reactionRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.LIKE))
-                .willReturn(List.of(newCountProjection(205L, 150L)));
-        given(reactionRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.DISLIKE))
-                .willReturn(List.of(newCountProjection(205L, 2L)));
-        given(reactionRepository.findByUser_UsersIdAndHistory_HistoryIdIn(userId, historyIds))
-                .willReturn(List.of());
+        given(activityHistoryRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.LIKE))
+                .willReturn(List.<Object[]>of(new Object[]{205L, 150L}));
+        given(activityHistoryRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.DISLIKE))
+                .willReturn(List.<Object[]>of(new Object[]{205L, 2L}));
+        given(activityHistoryRepository.findMyReactionsByUserAndHistoryIds(userId, historyIds))
+                .willReturn(List.<Object[]>of(new Object[]{205L, ReactionType.LIKE}));
         given(routePointService.getRoutePointsByHistoryIds(historyIds)).willReturn(List.of());
 
         // when
@@ -1172,7 +1168,7 @@ class ActivityHistoryServiceTest {
         assertEquals(205L, first.getHistoryId());
         assertEquals(150L, first.getLikeCount());
         assertEquals(2L, first.getDislikeCount());
-        assertEquals("NONE", first.getReactionForMe());
+        assertEquals("LIKE", first.getReactionForMe());
 
         ActivityHistoryResponse.PopularActivityItem second = response.getActivities().get(1);
         assertEquals("NONE", second.getReactionForMe());
@@ -1201,20 +1197,6 @@ class ActivityHistoryServiceTest {
 
         // then
         assertEquals(ActivityHistoryErrorCode.INVALID_REQUEST, exception.getErrorCode());
-    }
-
-    private ReactionRepository.HistoryReactionCountProjection newCountProjection(Long historyId, Long count) {
-        return new ReactionRepository.HistoryReactionCountProjection() {
-            @Override
-            public Long getHistoryId() {
-                return historyId;
-            }
-
-            @Override
-            public Long getReactionCount() {
-                return count;
-            }
-        };
     }
 
     private ActivityHistory buildCompletedHistory(

--- a/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
+++ b/src/test/java/com/dodo/backend/activityhistory/service/ActivityHistoryServiceTest.java
@@ -14,6 +14,8 @@ import com.dodo.backend.activityhistory.repository.ActivityHistoryRepository;
 import com.dodo.backend.imagefile.service.ImageFileService;
 import com.dodo.backend.pet.entity.Pet;
 import com.dodo.backend.pet.service.PetService;
+import com.dodo.backend.reaction.entity.ReactionType;
+import com.dodo.backend.reaction.repository.ReactionRepository;
 import com.dodo.backend.routepoint.service.RoutePointService;
 import com.dodo.backend.user.entity.User;
 import com.dodo.backend.user.service.UserService;
@@ -73,6 +75,9 @@ class ActivityHistoryServiceTest {
 
     @Mock
     private RoutePointService routePointService;
+
+    @Mock
+    private ReactionRepository reactionRepository;
 
     /**
      * 활동 기록 생성 성공 시나리오를 테스트합니다.
@@ -1113,4 +1118,120 @@ class ActivityHistoryServiceTest {
         assertEquals(ActivityHistoryErrorCode.VIEW_PERMISSION_DENIED, exception.getErrorCode());
         verify(routePointService, times(0)).getRoutePoints(any());
     }
+
+    /**
+     * 주변 인기 활동 조회 성공 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("주변 인기 활동 조회 성공: 반응 수/내 반응/커서 정보가 정상 계산된다.")
+    void getPopularActivities_Success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User writer = User.builder().usersId(UUID.randomUUID()).nickname("달리기왕").build();
+        List<Long> historyIds = List.of(205L, 202L);
+
+        ActivityHistory history1 = buildCompletedHistory(
+                205L, writer, BigDecimal.valueOf(10.5), BigDecimal.valueOf(37.5123), BigDecimal.valueOf(127.0123)
+        );
+        ActivityHistory history2 = buildCompletedHistory(
+                202L, writer, BigDecimal.valueOf(3.2), BigDecimal.valueOf(37.3123), BigDecimal.valueOf(127.1123)
+        );
+
+        given(activityHistoryRepository.findPopularByReactionTypeWithCursor(
+                eq(ActivityHistoryStatus.COMPLETED),
+                eq(ReactionType.LIKE),
+                eq(null),
+                any(Pageable.class)
+        )).willReturn(List.of(history1, history2));
+
+        given(reactionRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.LIKE))
+                .willReturn(List.of(newCountProjection(205L, 150L)));
+        given(reactionRepository.countGroupedByHistoryIdsAndReactionType(historyIds, ReactionType.DISLIKE))
+                .willReturn(List.of(newCountProjection(205L, 2L)));
+        given(reactionRepository.findByUser_UsersIdAndHistory_HistoryIdIn(userId, historyIds))
+                .willReturn(List.of());
+        given(routePointService.getRoutePointsByHistoryIds(historyIds)).willReturn(List.of());
+
+        // when
+        ActivityHistoryResponse.PopularActivityHistoryResponse response = activityHistoryService.getPopularActivities(
+                userId,
+                BigDecimal.valueOf(37.5),
+                BigDecimal.valueOf(127.0),
+                10,
+                "LIKE",
+                null
+        );
+
+        // then
+        assertNotNull(response);
+        assertFalse(response.isHasNext());
+        assertNull(response.getNextCursor());
+        assertEquals(2, response.getActivities().size());
+
+        ActivityHistoryResponse.PopularActivityItem first = response.getActivities().get(0);
+        assertEquals(205L, first.getHistoryId());
+        assertEquals(150L, first.getLikeCount());
+        assertEquals(2L, first.getDislikeCount());
+        assertEquals("NONE", first.getReactionForMe());
+
+        ActivityHistoryResponse.PopularActivityItem second = response.getActivities().get(1);
+        assertEquals("NONE", second.getReactionForMe());
+    }
+
+    /**
+     * 주변 인기 활동 조회 시 limit 유효성 검증을 테스트합니다.
+     */
+    @Test
+    @DisplayName("주변 인기 활동 조회 실패: limit이 0 이하이면 잘못된 요청 예외가 발생한다.")
+    void getPopularActivities_Fail_InvalidLimit() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when
+        ActivityHistoryException exception = assertThrows(ActivityHistoryException.class, () ->
+                activityHistoryService.getPopularActivities(
+                        userId,
+                        BigDecimal.valueOf(37.5),
+                        BigDecimal.valueOf(127.0),
+                        0,
+                        "LIKE",
+                        null
+                )
+        );
+
+        // then
+        assertEquals(ActivityHistoryErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    private ReactionRepository.HistoryReactionCountProjection newCountProjection(Long historyId, Long count) {
+        return new ReactionRepository.HistoryReactionCountProjection() {
+            @Override
+            public Long getHistoryId() {
+                return historyId;
+            }
+
+            @Override
+            public Long getReactionCount() {
+                return count;
+            }
+        };
+    }
+
+    private ActivityHistory buildCompletedHistory(
+            Long historyId,
+            User writer,
+            BigDecimal distance,
+            BigDecimal latitude,
+            BigDecimal longitude
+    ) {
+        return ActivityHistory.builder()
+                .historyId(historyId)
+                .user(writer)
+                .activityHistoryStatus(ActivityHistoryStatus.COMPLETED)
+                .distance(distance)
+                .startLatitude(latitude)
+                .startLongitude(longitude)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 위치 기반 주변 인기 활동 경로 조회 기능 추가
- LIKE/DISLIKE 기준 정렬 및 커서 기반 무한 스크롤 로직 구현
- 응답에 routePoints, likeCount, dislikeCount, reactionForMe 포함
- reactionType 유효성 검증 및 ScalarApiReference 응답 문서(200/400/401/403/404/500) 반영
- 서비스 테스트 코드 추가 및 검증 완료
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes #138
<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

ActivityHistoryServiceImpl에서 ReactionService를 의존성 주입해서 할라고 했는다 순환 참조가 발생하게 되버려서 어쩔수 없이 JPQL로 FetchJoin 해서 데이터 가져왔습니다.