### PR TITLE
✨ Feat: Cloudinary 이미지 업로드 기능 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,6 +48,9 @@ jobs:
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           FCM_CERTIFICATION: ${{ secrets.FCM_CERTIFICATION }}
+          CLOUDINARY_CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
+          CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
+          CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
         run: |
           cat > src/main/resources/application.yml <<EOF
           spring:
@@ -78,6 +81,10 @@ jobs:
                     timeout: 5000
                     starttls:
                       enable: true
+            servlet:
+              multipart:
+                max-file-size: 10MB
+                max-request-size: 50MB
           mybatis:
             mapper-locations: classpath:com/dodo/backend/**/mapper/*.xml
             type-aliases-package: com.dodo.backend
@@ -108,6 +115,10 @@ jobs:
             secret: ${JWT_SECRET}
             access-token-validity: 3600000
             refresh-token-validity: 1209600000
+          cloudinary:
+            cloud-name: ${CLOUDINARY_CLOUD_NAME}
+            api-key: ${CLOUDINARY_API_KEY}
+            api-secret: ${CLOUDINARY_API_SECRET}
           EOF
 
       - name: 빌드

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           FCM_CERTIFICATION: ${{ secrets.FCM_CERTIFICATION }}
+          CLOUDINARY_CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
+          CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
+          CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
         run: |
           cat > src/main/resources/application.yml <<EOF
           spring:
@@ -86,6 +89,10 @@ jobs:
                     timeout: 5000
                     starttls:
                       enable: true
+            servlet:
+              multipart:
+                max-file-size: 10MB
+                max-request-size: 50MB
           mybatis:
             mapper-locations: classpath:com/dodo/backend/**/mapper/*.xml
             type-aliases-package: com.dodo.backend
@@ -116,6 +123,10 @@ jobs:
             secret: ${JWT_SECRET:-test_jwt_secret_key_must_be_very_long_to_pass_validation_check}
             access-token-validity: 3600000
             refresh-token-validity: 1209600000
+          cloudinary:
+            cloud-name: ${CLOUDINARY_CLOUD_NAME:-test-cloud}
+            api-key: ${CLOUDINARY_API_KEY:-test-key}
+            api-secret: ${CLOUDINARY_API_SECRET:-test-secret}
           EOF
 
       - name: Gradle 빌드 및 테스트

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'com.cloudinary:cloudinary-http44:1.39.0'
+	implementation 'org.apache.tika:tika-core:2.9.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/dodo/backend/common/config/CloudinaryConfig.java
+++ b/src/main/java/com/dodo/backend/common/config/CloudinaryConfig.java
@@ -1,0 +1,28 @@
+package com.dodo.backend.common.config;
+
+import com.cloudinary.Cloudinary;
+import com.cloudinary.utils.ObjectUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Cloudinary 클라이언트 설정 클래스입니다.
+ */
+@Configuration
+public class CloudinaryConfig {
+
+    @Bean
+    public Cloudinary cloudinary(
+            @Value("${cloudinary.cloud-name}") String cloudName,
+            @Value("${cloudinary.api-key}") String apiKey,
+            @Value("${cloudinary.api-secret}") String apiSecret
+    ) {
+        return new Cloudinary(ObjectUtils.asMap(
+                "cloud_name", cloudName,
+                "api_key", apiKey,
+                "api_secret", apiSecret,
+                "secure", true
+        ));
+    }
+}

--- a/src/main/java/com/dodo/backend/imagefile/controller/ImageFileController.java
+++ b/src/main/java/com/dodo/backend/imagefile/controller/ImageFileController.java
@@ -1,0 +1,69 @@
+package com.dodo.backend.imagefile.controller;
+
+import com.dodo.backend.common.exception.ErrorResponse;
+import com.dodo.backend.imagefile.dto.response.ImageFileResponse.ImageUploadResponse;
+import com.dodo.backend.imagefile.service.ImageFileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * 이미지 파일 업로드 API 컨트롤러입니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/files")
+@Tag(name = "Image File API", description = "이미지 파일 업로드 API")
+public class ImageFileController {
+
+    private final ImageFileService imageFileService;
+
+    /**
+     * 이미지 파일을 Cloudinary에 업로드하고 URL 목록을 반환합니다.
+     */
+    @Operation(summary = "이미지 업로드", description = "여러 장의 이미지 파일을 업로드하고 URL 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "이미지 업로드에 성공하였습니다.",
+                    content = @Content(schema = @Schema(implementation = ImageUploadResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"접근 권한이 없습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ImageUploadResponse> uploadImages(
+            @RequestParam("files") List<MultipartFile> files
+    ) {
+        return ResponseEntity.ok(imageFileService.uploadImages(files));
+    }
+}

--- a/src/main/java/com/dodo/backend/imagefile/dto/response/ImageFileResponse.java
+++ b/src/main/java/com/dodo/backend/imagefile/dto/response/ImageFileResponse.java
@@ -1,0 +1,35 @@
+package com.dodo.backend.imagefile.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 이미지 파일 업로드 응답 DTO 모음입니다.
+ */
+@Schema(description = "이미지 파일 응답 DTO 모음")
+public class ImageFileResponse {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "이미지 업로드 응답 DTO")
+    public static class ImageUploadResponse {
+
+        @Schema(description = "응답 메시지", example = "이미지 업로드에 성공하였습니다.")
+        private String message;
+
+        @Schema(description = "업로드된 이미지 URL 목록")
+        private List<String> imageUrls;
+
+        public static ImageUploadResponse toDto(String message, List<String> imageUrls) {
+            return ImageUploadResponse.builder()
+                    .message(message)
+                    .imageUrls(imageUrls)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dodo/backend/imagefile/service/ImageFileService.java
+++ b/src/main/java/com/dodo/backend/imagefile/service/ImageFileService.java
@@ -1,5 +1,8 @@
 package com.dodo.backend.imagefile.service;
 
+import com.dodo.backend.imagefile.dto.response.ImageFileResponse.ImageUploadResponse;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.util.List;
 import java.util.Map;
 
@@ -15,4 +18,12 @@ public interface ImageFileService {
      * @return 펫 ID(Key)와 이미지 URL(Value)을 매핑한 Map 객체
      */
     Map<Long, String> getProfileUrlsByPetIds(List<Long> petIds);
+
+    /**
+     * 이미지 파일 목록을 업로드하고 URL 목록을 반환합니다.
+     *
+     * @param files 업로드할 이미지 파일 목록
+     * @return 업로드 응답 DTO
+     */
+    ImageUploadResponse uploadImages(List<MultipartFile> files);
 }

--- a/src/main/java/com/dodo/backend/imagefile/service/ImageFileServiceImpl.java
+++ b/src/main/java/com/dodo/backend/imagefile/service/ImageFileServiceImpl.java
@@ -1,16 +1,26 @@
 package com.dodo.backend.imagefile.service;
 
+import com.cloudinary.Cloudinary;
+import com.cloudinary.utils.ObjectUtils;
+import com.dodo.backend.imagefile.dto.response.ImageFileResponse.ImageUploadResponse;
 import com.dodo.backend.imagefile.entity.ImageFile;
 import com.dodo.backend.imagefile.repository.ImageFileRepository;
+import com.dodo.backend.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tika.Tika;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.dodo.backend.user.exception.UserErrorCode.INVALID_REQUEST;
 
 /**
  * {@link ImageFileService}의 구현체입니다.
@@ -20,7 +30,16 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ImageFileServiceImpl implements ImageFileService {
 
+    private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+            "image/gif"
+    );
+
     private final ImageFileRepository imageFileRepository;
+    private final Cloudinary cloudinary;
+    private final Tika tika = new Tika();
 
     /**
      * {@inheritDoc}
@@ -47,5 +66,65 @@ public class ImageFileServiceImpl implements ImageFileService {
                         img -> img.getPet().getPetId(),
                         ImageFile::getImageFileUrl
                 ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public ImageUploadResponse uploadImages(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            throw new UserException(INVALID_REQUEST);
+        }
+
+        List<String> imageUrls = files.stream()
+                .map(this::uploadSingleImage)
+                .toList();
+
+        return ImageUploadResponse.toDto("이미지 업로드에 성공하였습니다.", imageUrls);
+    }
+
+    private String uploadSingleImage(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new UserException(INVALID_REQUEST);
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_MIME_TYPES.contains(contentType)) {
+            throw new UserException(INVALID_REQUEST);
+        }
+
+        String detectedMimeType = detectMimeType(file);
+        if (!ALLOWED_MIME_TYPES.contains(detectedMimeType)) {
+            throw new UserException(INVALID_REQUEST);
+        }
+
+        try {
+            Map<?, ?> uploadResult = cloudinary.uploader().upload(
+                    file.getBytes(),
+                    ObjectUtils.asMap(
+                            "folder", "images",
+                            "resource_type", "image"
+                    )
+            );
+            Object url = uploadResult.get("secure_url");
+            if (url == null) {
+                throw new IllegalStateException("Cloudinary 응답에 secure_url이 없습니다.");
+            }
+            return Objects.toString(url);
+        } catch (UserException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("이미지 업로드 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    private String detectMimeType(MultipartFile file) {
+        try {
+            return tika.detect(file.getBytes());
+        } catch (Exception e) {
+            throw new UserException(INVALID_REQUEST);
+        }
     }
 }

--- a/src/test/java/com/dodo/backend/imagefile/service/ImageFileServiceTest.java
+++ b/src/test/java/com/dodo/backend/imagefile/service/ImageFileServiceTest.java
@@ -1,8 +1,12 @@
 package com.dodo.backend.imagefile.service;
 
+import com.cloudinary.Cloudinary;
+import com.cloudinary.Uploader;
+import com.dodo.backend.imagefile.dto.response.ImageFileResponse.ImageUploadResponse;
 import com.dodo.backend.imagefile.entity.ImageFile;
 import com.dodo.backend.imagefile.repository.ImageFileRepository;
 import com.dodo.backend.pet.entity.Pet;
+import com.dodo.backend.user.exception.UserException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
@@ -18,6 +23,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -37,6 +45,12 @@ class ImageFileServiceTest {
 
     @Mock
     private ImageFileRepository imageFileRepository;
+
+    @Mock
+    private Cloudinary cloudinary;
+
+    @Mock
+    private Uploader uploader;
 
     /**
      * 펫 ID 목록을 입력받아 이미지 URL을 정상적으로 조회하는 시나리오를 테스트합니다.
@@ -107,5 +121,43 @@ class ImageFileServiceTest {
         verify(imageFileRepository, never()).findAllByPet_PetIdIn(anyList());
 
         log.info("테스트 종료: 프로필 이미지 조회 (빈 리스트)");
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 성공: 파일 목록 업로드 후 URL 목록을 반환한다.")
+    void uploadImages_Success() throws Exception {
+        // given
+        byte[] jpegBytes = new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00};
+        byte[] pngBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+        MockMultipartFile file1 = new MockMultipartFile("files", "a.jpg", "image/jpeg", jpegBytes);
+        MockMultipartFile file2 = new MockMultipartFile("files", "b.png", "image/png", pngBytes);
+
+        given(cloudinary.uploader()).willReturn(uploader);
+        given(uploader.upload(any(byte[].class), any(Map.class)))
+                .willReturn(Map.of("secure_url", "https://res.cloudinary.com/demo/image/upload/v1/images/a.jpg"))
+                .willReturn(Map.of("secure_url", "https://res.cloudinary.com/demo/image/upload/v1/images/b.png"));
+
+        // when
+        ImageUploadResponse response = imageFileService.uploadImages(List.of(file1, file2));
+
+        // then
+        assertNotNull(response);
+        assertEquals("이미지 업로드에 성공하였습니다.", response.getMessage());
+        assertEquals(2, response.getImageUrls().size());
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 실패: 이미지가 아닌 파일이면 예외가 발생한다.")
+    void uploadImages_Fail_InvalidFileType() {
+        // given
+        MockMultipartFile file = new MockMultipartFile("files", "a.txt", "text/plain", "text".getBytes());
+
+        // when
+        UserException exception = assertThrows(UserException.class, () ->
+                imageFileService.uploadImages(List.of(file))
+        );
+
+        // then
+        assertNotNull(exception.getErrorCode());
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- multipart/form-data 기반 다중 이미지 업로드 기능 추가 (/files/upload)
- Cloudinary 연동 설정 및 업로드 후 secure_url 목록 반환 로직 구현
- MIME 화이트리스트 + Apache Tika 기반 실제 파일 타입 검증 적용
- 업로드 응답 DTO/ScalarApiReference 문서화 및 예외 응답 코드 반영
- 업로드 용량 제한 설정(파일 10MB, 요청 50MB) 및 CI/CD 환경 변수 반영
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-  Closes #140

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 확장자 이미지 MIME 타입 검사하고  Apache Tika 기반 실제 파일 타입 검증까지 적용했습니다.
- 파일 하나당 10MB 넘으면 안되고 연속 파일로 최대 50MB까지 파일 업로드 가능하게 했습니다.
- 타입은 jpeg, png, webp, gif 만 가능합니다.