### PR TITLE
✨ Feat: 닉네임 중복 확인 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/dodo/backend/common/config/SecurityConfig.java
@@ -77,6 +77,7 @@ public class SecurityConfig {
                                 "/auth/reissue",
                                 "/auth/devices",
                                 "/auth/reissue/devices",
+                                "/users/nickname/check",
                                 "/ws-dodo"
                         ).permitAll()
                         .requestMatchers(

--- a/src/main/java/com/dodo/backend/user/controller/UserController.java
+++ b/src/main/java/com/dodo/backend/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.dodo.backend.user.dto.request.UserRequest.UserRegisterRequest;
 import com.dodo.backend.user.dto.request.UserRequest.UserUpdateRequest;
 import com.dodo.backend.user.dto.request.UserRequest.WithdrawalRequest;
 import com.dodo.backend.user.dto.response.UserResponse;
+import com.dodo.backend.user.dto.response.UserResponse.NicknameCheckResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserInfoResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserRegisterResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserUpdateResponse;
@@ -35,6 +36,38 @@ import java.util.UUID;
 public class UserController {
 
     private final UserService userService;
+
+    /**
+     * 회원가입 전 입력한 닉네임이 이미 사용 중인지 확인합니다.
+     *
+     * @param nickname 중복 여부를 확인할 닉네임
+     * @return 닉네임과 중복 여부가 포함된 응답 DTO
+     */
+    @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임의 중복 여부를 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 중복 확인이 완료되었습니다.",
+                    content = @Content(schema = @Schema(implementation = NicknameCheckResponse.class))),
+            @ApiResponse(responseCode = "400", description = "닉네임 형식이 올바르지 않습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"닉네임 형식이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"사용자를 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @GetMapping("/nickname/check")
+    public ResponseEntity<NicknameCheckResponse> checkNicknameDuplication(
+            @RequestParam String nickname) {
+
+        log.info("닉네임 중복 확인 요청 - nickname: {}", nickname);
+
+        return ResponseEntity.ok(userService.checkNicknameDuplication(nickname));
+    }
 
     /**
      * 회원가입 프로세스의 마지막 단계로, 추가 정보를 입력받아 계정을 활성화합니다.

--- a/src/main/java/com/dodo/backend/user/dto/response/UserResponse.java
+++ b/src/main/java/com/dodo/backend/user/dto/response/UserResponse.java
@@ -154,4 +154,31 @@ public class UserResponse {
                     .build();
         }
     }
+
+    /**
+     * 닉네임 중복 확인 결과를 반환하는 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "닉네임 중복 확인 응답")
+    public static class NicknameCheckResponse {
+
+        @Schema(description = "응답 메시지", example = "닉네임 중복 확인이 완료되었습니다.")
+        private String message;
+
+        @Schema(description = "확인한 닉네임", example = "도도")
+        private String nickname;
+
+        @Schema(description = "닉네임 중복 여부", example = "false")
+        private Boolean duplicated;
+
+        public static NicknameCheckResponse toDto(String nickname, Boolean duplicated) {
+            return NicknameCheckResponse.builder()
+                    .message("닉네임 중복 확인이 완료되었습니다.")
+                    .nickname(nickname)
+                    .duplicated(duplicated)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/dodo/backend/user/service/UserService.java
+++ b/src/main/java/com/dodo/backend/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.dodo.backend.user.service;
 import com.dodo.backend.user.dto.request.UserRequest.UserRegisterRequest;
 import com.dodo.backend.user.dto.request.UserRequest.UserUpdateRequest;
 import com.dodo.backend.user.dto.response.UserResponse.UserInfoResponse;
+import com.dodo.backend.user.dto.response.UserResponse.NicknameCheckResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserRegisterResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserUpdateResponse;
 import com.dodo.backend.user.entity.User;
@@ -76,6 +77,14 @@ public interface UserService {
      * @param enabled 변경할 알림 수신 여부 (true: 수신 허용, false: 수신 거부)
      */
     void updateNotification(UUID userId, Boolean enabled);
+
+    /**
+     * 닉네임 중복 여부를 확인합니다.
+     *
+     * @param nickname 확인할 닉네임
+     * @return 닉네임 중복 확인 결과 응답 DTO
+     */
+    NicknameCheckResponse checkNicknameDuplication(String nickname);
 
     /**
      * ID로 사용자 엔티티를 조회합니다.

--- a/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
@@ -6,6 +6,7 @@ import com.dodo.backend.mail.service.MailService;
 import com.dodo.backend.user.dto.request.UserRequest;
 import com.dodo.backend.user.dto.request.UserRequest.UserRegisterRequest;
 import com.dodo.backend.user.dto.response.UserResponse.UserInfoResponse;
+import com.dodo.backend.user.dto.response.UserResponse.NicknameCheckResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserRegisterResponse;
 import com.dodo.backend.user.dto.response.UserResponse.UserUpdateResponse;
 import com.dodo.backend.user.entity.User;
@@ -279,6 +280,17 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
         userMapper.updateNotificationStatus(userId, enabled);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public NicknameCheckResponse checkNicknameDuplication(String nickname) {
+        boolean duplicated = userRepository.existsByNickname(nickname);
+
+        return NicknameCheckResponse.toDto(nickname, duplicated);
     }
 
     /**

--- a/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dodo/backend/user/service/UserServiceImpl.java
@@ -37,6 +37,10 @@ import static com.dodo.backend.user.exception.UserErrorCode.*;
 @Slf4j
 public class UserServiceImpl implements UserService {
 
+    private static final String NICKNAME_PATTERN = "^[가-힣a-zA-Z0-9 ]*$";
+    private static final int NICKNAME_MIN_LENGTH = 2;
+    private static final int NICKNAME_MAX_LENGTH = 10;
+
     private final UserRepository userRepository;
     private final UserMapper userMapper;
     private final JwtTokenProvider jwtTokenProvider;
@@ -283,11 +287,29 @@ public class UserServiceImpl implements UserService {
     }
 
     /**
-     * {@inheritDoc}
+     * 회원가입 전 입력한 닉네임의 형식을 검증하고 중복 여부를 확인합니다.
+     * <p>
+     * 닉네임은 2자 이상 10자 이하이며, 한글, 영문, 숫자, 공백만 사용할 수 있습니다.
+     *
+     * @param nickname 중복 여부를 확인할 닉네임
+     * @return 닉네임과 중복 여부가 포함된 응답 DTO
+     * @throws UserException 닉네임이 비어 있거나 형식이 올바르지 않은 경우
      */
     @Transactional(readOnly = true)
     @Override
     public NicknameCheckResponse checkNicknameDuplication(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new UserException(INVALID_REQUEST);
+        }
+
+        if (nickname.length() < NICKNAME_MIN_LENGTH || nickname.length() > NICKNAME_MAX_LENGTH) {
+            throw new UserException(INVALID_REQUEST);
+        }
+
+        if (!nickname.matches(NICKNAME_PATTERN)) {
+            throw new UserException(INVALID_REQUEST);
+        }
+
         boolean duplicated = userRepository.existsByNickname(nickname);
 
         return NicknameCheckResponse.toDto(nickname, duplicated);

--- a/src/test/java/com/dodo/backend/user/controller/UserControllerTest.java
+++ b/src/test/java/com/dodo/backend/user/controller/UserControllerTest.java
@@ -1,0 +1,49 @@
+package com.dodo.backend.user.controller;
+
+import com.dodo.backend.user.dto.response.UserResponse.NicknameCheckResponse;
+import com.dodo.backend.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@link UserController}의 HTTP 요청 처리 로직을 검증하는 테스트 클래스입니다.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+    @Mock
+    private UserService userService;
+
+    /**
+     * 닉네임 중복 확인 요청 시 200 상태 코드와 중복 확인 결과를 반환하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("닉네임 중복 확인 성공")
+    void checkNicknameDuplicationSuccessTest() {
+        //given
+        UserController userController = new UserController(userService);
+        String nickname = "도도";
+        NicknameCheckResponse serviceResponse = NicknameCheckResponse.toDto(nickname, false);
+
+        given(userService.checkNicknameDuplication(nickname)).willReturn(serviceResponse);
+
+        //when
+        ResponseEntity<NicknameCheckResponse> response = userController.checkNicknameDuplication(nickname);
+
+        //then
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getNickname()).isEqualTo(nickname);
+        assertThat(response.getBody().getDuplicated()).isFalse();
+
+        verify(userService).checkNicknameDuplication(nickname);
+    }
+}

--- a/src/test/java/com/dodo/backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/dodo/backend/user/service/UserServiceImplTest.java
@@ -401,6 +401,60 @@ class UserServiceImplTest {
             assertThat(response.getNickname()).isEqualTo(nickname);
             assertThat(response.getDuplicated()).isFalse();
         }
+
+        /**
+         * 공백만 있는 닉네임을 확인하면 잘못된 요청 예외가 발생하는지 검증합니다.
+         */
+        @Test
+        @DisplayName("공백 닉네임이면 UserException이 발생한다")
+        void checkNicknameDuplicationBlankNicknameTest() {
+            //given
+            String nickname = "   ";
+
+            //when
+            UserException exception = assertThrows(UserException.class, () -> {
+                userService.checkNicknameDuplication(nickname);
+            });
+
+            //then
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.INVALID_REQUEST);
+        }
+
+        /**
+         * 길이 조건을 만족하지 않는 닉네임을 확인하면 잘못된 요청 예외가 발생하는지 검증합니다.
+         */
+        @Test
+        @DisplayName("길이 조건을 만족하지 않는 닉네임이면 UserException이 발생한다")
+        void checkNicknameDuplicationInvalidLengthTest() {
+            //given
+            String nickname = "가";
+
+            //when
+            UserException exception = assertThrows(UserException.class, () -> {
+                userService.checkNicknameDuplication(nickname);
+            });
+
+            //then
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.INVALID_REQUEST);
+        }
+
+        /**
+         * 허용되지 않는 문자가 포함된 닉네임을 확인하면 잘못된 요청 예외가 발생하는지 검증합니다.
+         */
+        @Test
+        @DisplayName("허용되지 않는 문자가 포함된 닉네임이면 UserException이 발생한다")
+        void checkNicknameDuplicationInvalidPatternTest() {
+            //given
+            String nickname = "도도!";
+
+            //when
+            UserException exception = assertThrows(UserException.class, () -> {
+                userService.checkNicknameDuplication(nickname);
+            });
+
+            //then
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.INVALID_REQUEST);
+        }
     }
 
     private User createTestUser(String email, UserStatus status) {

--- a/src/test/java/com/dodo/backend/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/dodo/backend/user/service/UserServiceImplTest.java
@@ -67,15 +67,15 @@ class UserServiceImplTest {
         @Test
         @DisplayName("신규 유저는 REGISTER 상태로 저장")
         void newMemberRegistrationTest() {
-            // given
+            //given
             String email = "new_user@test.com";
             String name = "신규유저";
             log.info("신규 유저 저장 테스트 시작 - 이메일: {}", email);
 
-            // when
+            //when
             Map<String, Object> result = userService.findOrSaveSocialUser(email, name, "");
 
-            // then
+            //then
             assertThat(result.get("isNewMember")).isEqualTo(true);
             User savedUser = userRepository.findByEmail(email).orElseThrow();
             assertThat(savedUser.getUserStatus()).isEqualTo(UserStatus.REGISTER);
@@ -85,16 +85,16 @@ class UserServiceImplTest {
         @Test
         @DisplayName("정지된 계정은 접근 제한 예외 발생")
         void suspendedUserTest() {
-            // given
+            //given
             String email = "suspended@test.com";
             User suspendedUser = createTestUser(email, UserStatus.SUSPENDED);
             userRepository.save(suspendedUser);
             log.info("정지 계정 로그인 차단 테스트 시작 - 이메일: {}", email);
 
-            // when
+            //when
             Map<String, Object> result = userService.findOrSaveSocialUser(email, "정지유저", "");
 
-            // then
+            //then
             assertThat(result.get("isNewMember")).isEqualTo(false);
             assertThat(result.get("status")).isEqualTo(UserStatus.SUSPENDED);
             log.info("정지 계정 상태 반환 확인 완료");
@@ -108,7 +108,7 @@ class UserServiceImplTest {
         @Test
         @DisplayName("정보 입력 완료 시 ACTIVE 상태로 변경")
         void completeRegistrationSuccessTest() {
-            // given
+            //given
             String email = "register@test.com";
             userRepository.save(createTestUser(email, UserStatus.REGISTER));
             em.flush();
@@ -121,10 +121,10 @@ class UserServiceImplTest {
                     .hasFamily(true)
                     .build();
 
-            // when
+            //when
             userService.registerAdditionalInfo(request, email);
 
-            // then
+            //then
             em.clear();
             User updatedUser = userRepository.findByEmail(email).orElseThrow();
             assertThat(updatedUser.getUserStatus()).isEqualTo(UserStatus.ACTIVE);
@@ -134,7 +134,7 @@ class UserServiceImplTest {
         @Test
         @DisplayName("중복 닉네임 사용 시 예외 발생")
         void duplicatedNicknameTest() {
-            // given
+            //given
             String existingNick = "중복닉네임";
             User existingUser = User.builder()
                     .email("existing@test.com")
@@ -159,7 +159,7 @@ class UserServiceImplTest {
                     .hasFamily(false)
                     .build();
 
-            // when & then
+            //when
             UserException exception = assertThrows(UserException.class, () -> {
                 userService.registerAdditionalInfo(request, newEmail);
             });
@@ -176,7 +176,7 @@ class UserServiceImplTest {
         @Test
         @DisplayName("선택적 필드 수정 시 요청 데이터만 변경되고 응답에 반영됨")
         void updateUserInfoPartialSuccessTest() {
-            // given
+            //given
             String email = "update@test.com";
             User user = User.builder()
                     .email(email)
@@ -201,10 +201,10 @@ class UserServiceImplTest {
                     .hasFamily(null)
                     .build();
 
-            // when
+            //when
             UserResponse.UserUpdateResponse response = userService.updateUserInfo(user.getUsersId(), request);
 
-            // then
+            //then
             assertThat(response.getNickname()).isEqualTo("변경닉네임");
             assertThat(response.getRegion()).isEqualTo("부산");
             assertThat(response.getHasFamily()).isTrue();
@@ -219,7 +219,7 @@ class UserServiceImplTest {
         @Test
         @DisplayName("이미 존재하는 닉네임으로 수정 시도 시 UserException 발생")
         void updateUserInfoDuplicateNicknameTest() {
-            // given
+            //given
             String takenNickname = "이미있는닉네임";
             User otherUser = User.builder()
                     .email("other@test.com")
@@ -244,7 +244,7 @@ class UserServiceImplTest {
                     .nickname(takenNickname)
                     .build();
 
-            // when & then
+            //when
             UserException exception = assertThrows(UserException.class, () -> {
                 userService.updateUserInfo(targetUser.getUsersId(), request);
             });
@@ -256,7 +256,7 @@ class UserServiceImplTest {
         @Test
         @DisplayName("본인의 현재 닉네임 유지 시 예외 없이 수정 성공")
         void updateUserInfoSameNicknameSuccessTest() {
-            // given
+            //given
             String myNickname = "나의닉네임";
             User user = User.builder()
                     .email("me@test.com")
@@ -279,10 +279,10 @@ class UserServiceImplTest {
                     .region("인천")
                     .build();
 
-            // when
+            //when
             UserResponse.UserUpdateResponse response = userService.updateUserInfo(user.getUsersId(), request);
 
-            // then
+            //then
             assertThat(response.getNickname()).isEqualTo(myNickname);
             assertThat(response.getRegion()).isEqualTo("인천");
             log.info("본인 닉네임 유지 수정 성공 확인");
@@ -306,17 +306,17 @@ class UserServiceImplTest {
         @Test
         @DisplayName("알림 수신 여부를 ON -> OFF로 성공적으로 변경")
         void updateNotificationSuccessTest() {
-            // given
+            //given
             User user = createTestUser("notify@test.com", UserStatus.ACTIVE);
             userRepository.save(user);
             em.flush();
             em.clear();
             log.info("알림 설정 변경 테스트 시작 (True -> False)");
 
-            // when
+            //when
             userService.updateNotification(user.getUsersId(), false);
 
-            // then
+            //then
             em.flush();
             em.clear();
             User updatedUser = userRepository.findById(user.getUsersId()).orElseThrow();
@@ -334,17 +334,72 @@ class UserServiceImplTest {
         @Test
         @DisplayName("존재하지 않는 유저의 설정을 변경하려 하면 예외 발생")
         void updateNotificationUserNotFoundTest() {
-            // given
+            //given
             UUID nonExistentUserId = UUID.randomUUID();
             log.info("존재하지 않는 유저 알림 변경 테스트 시작");
 
-            // when & then
+            //when
             UserException exception = assertThrows(UserException.class, () -> {
                 userService.updateNotification(nonExistentUserId, false);
             });
 
             assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
             log.info("존재하지 않는 유저 예외 발생 확인 완료");
+        }
+    }
+
+    /**
+     * 닉네임 중복 확인 기능을 검증하는 내부 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("닉네임 중복 확인 테스트")
+    class CheckNicknameDuplicationTest {
+
+        /**
+         * 이미 존재하는 닉네임을 확인하면 중복 여부가 true로 반환되는지 검증합니다.
+         */
+        @Test
+        @DisplayName("이미 존재하는 닉네임이면 duplicated true를 반환한다")
+        void checkNicknameDuplicationDuplicatedTest() {
+            //given
+            String nickname = "중복닉네임";
+            User user = User.builder()
+                    .email("nickname-check@test.com")
+                    .name("닉네임테스터")
+                    .nickname(nickname)
+                    .profileUrl("")
+                    .region("서울")
+                    .notificationEnabled(true)
+                    .role(UserRole.USER)
+                    .userStatus(UserStatus.ACTIVE)
+                    .userCreatedAt(LocalDateTime.now())
+                    .hasFamily(false)
+                    .build();
+            userRepository.save(user);
+
+            //when
+            UserResponse.NicknameCheckResponse response = userService.checkNicknameDuplication(nickname);
+
+            //then
+            assertThat(response.getNickname()).isEqualTo(nickname);
+            assertThat(response.getDuplicated()).isTrue();
+        }
+
+        /**
+         * 존재하지 않는 닉네임을 확인하면 중복 여부가 false로 반환되는지 검증합니다.
+         */
+        @Test
+        @DisplayName("존재하지 않는 닉네임이면 duplicated false를 반환한다")
+        void checkNicknameDuplicationAvailableTest() {
+            //given
+            String nickname = "사용가능";
+
+            //when
+            UserResponse.NicknameCheckResponse response = userService.checkNicknameDuplication(nickname);
+
+            //then
+            assertThat(response.getNickname()).isEqualTo(nickname);
+            assertThat(response.getDuplicated()).isFalse();
         }
     }
 


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 회원가입 전 닉네임 중복 여부 확인 API 추가
- JWT 없이 호출 가능하도록 SecurityConfig permitAll 설정
- Scalar 문서에서 인증 요구가 표시되지 않도록 OpenAPI security 제외
- 닉네임 중복 확인 컨트롤러 및 서비스 테스트 추가
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #147 
<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)
<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |
<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 급하게 닉네임 중복 확인 기능 만들었고 JWT Token은 필요없습니다.