### PR TITLE
✨ Feat: 펫 디바이스 ID 중복 확인 기능 구현

### DIFF
--- a/src/main/java/com/dodo/backend/pet/controller/PetController.java
+++ b/src/main/java/com/dodo/backend/pet/controller/PetController.java
@@ -544,11 +544,9 @@ public class PetController {
     })
     @PostMapping("/device/check")
     public ResponseEntity<PetDeviceCheckResponse> checkDeviceId(
-            @Valid @RequestBody PetDeviceCheckRequest request,
-            @AuthenticationPrincipal UserDetails userDetails) {
+            @Valid @RequestBody PetDeviceCheckRequest request) {
 
-        UUID userId = UUID.fromString(userDetails.getUsername());
-        log.info("디바이스 ID 중복 확인 요청 - User: {}, DeviceId: {}", userId, request.getDeviceId());
+        log.info("디바이스 ID 중복 확인 요청 - DeviceId: {}", request.getDeviceId());
 
         return ResponseEntity.ok(petService.checkDeviceIdAvailability(request));
     }

--- a/src/main/java/com/dodo/backend/pet/controller/PetController.java
+++ b/src/main/java/com/dodo/backend/pet/controller/PetController.java
@@ -523,7 +523,7 @@ public class PetController {
      */
     @Operation(summary = "디바이스 ID 중복 확인", description = "펫 등록 전에 디바이스 ID가 이미 다른 반려동물에 등록되어 있는지 확인합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용 가능한 디바이스 ID입니다.",
+            @ApiResponse(responseCode = "200", description = "디바이스 ID 중복 확인 결과",
                     content = @Content(schema = @Schema(implementation = PetDeviceCheckResponse.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
                     content = @Content(mediaType = "application/json",
@@ -533,10 +533,6 @@ public class PetController {
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
-            @ApiResponse(responseCode = "409", description = "이미 다른 반려동물에 등록된 디바이스 ID입니다.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "409 Conflict", value = "{\"status\": 409, \"message\": \"이미 다른 반려동물에 등록된 디바이스 ID입니다.\"}"))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),

--- a/src/main/java/com/dodo/backend/pet/controller/PetController.java
+++ b/src/main/java/com/dodo/backend/pet/controller/PetController.java
@@ -515,6 +515,45 @@ public class PetController {
     }
 
     /**
+     * 디바이스 ID 중복 여부를 확인합니다.
+     *
+     * @param request     확인할 디바이스 ID
+     * @param userDetails 인증된 사용자 정보
+     * @return 디바이스 ID 사용 가능 여부 응답
+     */
+    @Operation(summary = "디바이스 ID 중복 확인", description = "펫 등록 전에 디바이스 ID가 이미 다른 반려동물에 등록되어 있는지 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용 가능한 디바이스 ID입니다.",
+                    content = @Content(schema = @Schema(implementation = PetDeviceCheckResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "이미 다른 반려동물에 등록된 디바이스 ID입니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "409 Conflict", value = "{\"status\": 409, \"message\": \"이미 다른 반려동물에 등록된 디바이스 ID입니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @PostMapping("/device/check")
+    public ResponseEntity<PetDeviceCheckResponse> checkDeviceId(
+            @Valid @RequestBody PetDeviceCheckRequest request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        UUID userId = UUID.fromString(userDetails.getUsername());
+        log.info("디바이스 ID 중복 확인 요청 - User: {}, DeviceId: {}", userId, request.getDeviceId());
+
+        return ResponseEntity.ok(petService.checkDeviceIdAvailability(request));
+    }
+
+    /**
      * 반려동물 상세 정보를 조회합니다.
      *
      * @param petId       조회할 반려동물 ID

--- a/src/main/java/com/dodo/backend/pet/dto/request/PetRequest.java
+++ b/src/main/java/com/dodo/backend/pet/dto/request/PetRequest.java
@@ -180,6 +180,20 @@ public class PetRequest {
     }
 
     /**
+     * 디바이스 ID 중복 확인 요청 DTO입니다.
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "디바이스 ID 중복 확인 요청")
+    public static class PetDeviceCheckRequest {
+        @NotBlank(message = "디바이스 ID는 필수입니다.")
+        @Schema(description = "확인할 디바이스 ID", example = "ABC123XYZ")
+        private String deviceId;
+    }
+
+    /**
      * 반려동물 특이사항 생성을 위한 요청 DTO입니다.
      */
     @Getter

--- a/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/dodo/backend/pet/dto/response/PetResponse.java
@@ -505,6 +505,29 @@ public class PetResponse {
     }
 
     /**
+     * 디바이스 ID 중복 확인 응답 DTO입니다.
+     */
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "디바이스 ID 중복 확인 결과 응답")
+    public static class PetDeviceCheckResponse {
+
+        @Schema(description = "처리 결과 메시지", example = "사용 가능한 디바이스 ID입니다.")
+        private String message;
+
+        @Schema(description = "디바이스 ID 사용 가능 여부", example = "true")
+        private boolean available;
+
+        public static PetDeviceCheckResponse toDto(String message, boolean available) {
+            return PetDeviceCheckResponse.builder()
+                    .message(message)
+                    .available(available)
+                    .build();
+        }
+    }
+
+    /**
      * 반려동물 특이사항 생성 결과 응답 DTO입니다.
      */
     @Getter

--- a/src/main/java/com/dodo/backend/pet/service/PetService.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetService.java
@@ -115,6 +115,14 @@ public interface PetService {
     PetDeviceUpdateResponse updateDevice(UUID userId, Long petId, PetDeviceUpdateRequest request);
 
     /**
+     * 디바이스 ID 중복 여부를 확인합니다.
+     *
+     * @param request 확인할 디바이스 ID가 포함된 요청 DTO
+     * @return 디바이스 ID 사용 가능 여부 응답
+     */
+    PetDeviceCheckResponse checkDeviceIdAvailability(PetDeviceCheckRequest request);
+
+    /**
      * 반려동물 특이사항을 생성합니다.
      *
      * @param userId  요청한 사용자 ID

--- a/src/main/java/com/dodo/backend/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetServiceImpl.java
@@ -534,7 +534,7 @@ public class PetServiceImpl implements PetService {
     @Override
     public PetDeviceCheckResponse checkDeviceIdAvailability(PetDeviceCheckRequest request) {
         if (petRepository.existsByDeviceId(request.getDeviceId())) {
-            throw new PetException(DEVICE_ID_DUPLICATED);
+            return PetDeviceCheckResponse.toDto("이미 다른 반려동물에 등록된 디바이스 ID입니다.", false);
         }
 
         return PetDeviceCheckResponse.toDto("사용 가능한 디바이스 ID입니다.", true);

--- a/src/main/java/com/dodo/backend/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetServiceImpl.java
@@ -3,6 +3,7 @@ package com.dodo.backend.pet.service;
 import com.dodo.backend.activityhistory.entity.ActivityHistory;
 import com.dodo.backend.activityhistory.repository.ActivityHistoryRepository;
 import com.dodo.backend.imagefile.service.ImageFileService;
+import com.dodo.backend.pet.dto.request.PetRequest.PetDeviceCheckRequest;
 import com.dodo.backend.pet.dto.request.PetRequest.PetDeviceUpdateRequest;
 import com.dodo.backend.pet.dto.request.PetRequest.PetFamilyJoinRequest;
 import com.dodo.backend.pet.dto.request.PetRequest.PetRegisterRequest;
@@ -85,6 +86,10 @@ public class PetServiceImpl implements PetService {
             if (petRepository.existsByRegistrationNumber(request.getRegistrationNumber())) {
                 throw new PetException(REGISTRATION_NUMBER_DUPLICATED);
             }
+        }
+
+        if (petRepository.existsByDeviceId(request.getDeviceId())) {
+            throw new PetException(DEVICE_ID_DUPLICATED);
         }
 
         Pet pet = request.toEntity();
@@ -517,6 +522,22 @@ public class PetServiceImpl implements PetService {
                 newDeviceId,
                 "디바이스가 성공적으로 재등록되었습니다."
         );
+    }
+
+    /**
+     * 디바이스 ID 중복 여부를 확인합니다.
+     *
+     * @param request 확인할 디바이스 ID가 포함된 요청 DTO
+     * @return 디바이스 ID 사용 가능 여부 응답
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public PetDeviceCheckResponse checkDeviceIdAvailability(PetDeviceCheckRequest request) {
+        if (petRepository.existsByDeviceId(request.getDeviceId())) {
+            throw new PetException(DEVICE_ID_DUPLICATED);
+        }
+
+        return PetDeviceCheckResponse.toDto("사용 가능한 디바이스 ID입니다.", true);
     }
 
     /**

--- a/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
+++ b/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
@@ -174,6 +174,37 @@ class PetServiceTest {
     }
 
     /**
+     * 이미 등록된 디바이스 ID로 펫 등록을 시도할 때 예외 발생을 테스트합니다.
+     */
+    @Test
+    @DisplayName("펫 등록 실패: 이미 다른 펫이 사용 중인 디바이스 ID면 예외가 발생한다.")
+    void registerPet_Fail_DuplicateDeviceId() {
+        log.info("디바이스 ID 중복으로 인한 펫 등록 실패 테스트를 시작합니다.");
+        // given
+        UUID userId = UUID.randomUUID();
+        String duplicateDeviceId = "DUPLICATE_DEV";
+        PetRequest.PetRegisterRequest request = PetRequest.PetRegisterRequest.builder()
+                .deviceId(duplicateDeviceId)
+                .build();
+
+        log.info("사용자는 존재하고 디바이스 ID가 이미 등록된 상황을 설정합니다.");
+        given(userPetService.existsUser(userId)).willReturn(true);
+        given(petRepository.existsByDeviceId(duplicateDeviceId)).willReturn(true);
+
+        // when
+        log.info("중복된 디바이스 ID로 펫 등록 요청 시 예외가 발생하는지 확인합니다.");
+        PetException exception = assertThrows(PetException.class, () ->
+                petService.registerPet(userId, request)
+        );
+
+        // then
+        log.info("발생한 예외 코드가 DEVICE_ID_DUPLICATED인지 검증합니다.");
+        assertEquals(PetErrorCode.DEVICE_ID_DUPLICATED, exception.getErrorCode());
+        verify(petRepository, times(0)).save(any(Pet.class));
+        log.info("디바이스 ID 중복 펫 등록 실패 테스트가 통과되었습니다.");
+    }
+
+    /**
      * 반려동물 정보 수정 성공 시나리오를 테스트합니다.
      */
     @Test
@@ -567,6 +598,62 @@ class PetServiceTest {
         assertEquals(PetErrorCode.DEVICE_ID_DUPLICATED, exception.getErrorCode());
         verify(petMapper, times(0)).updatePetDevice(any(), any());
         log.info("ID 중복 재등록 실패 테스트가 통과되었습니다.");
+    }
+
+    /**
+     * 디바이스 ID 중복 확인 성공 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("디바이스 ID 중복 확인 성공: 사용 가능한 ID면 true를 반환한다.")
+    void checkDeviceIdAvailability_Success() {
+        log.info("디바이스 ID 중복 확인 성공 테스트를 시작합니다.");
+        // given
+        String deviceId = "AVAILABLE_DEV";
+        PetRequest.PetDeviceCheckRequest request = PetRequest.PetDeviceCheckRequest.builder()
+                .deviceId(deviceId)
+                .build();
+
+        log.info("요청한 디바이스 ID가 존재하지 않는 상황을 설정합니다.");
+        given(petRepository.existsByDeviceId(deviceId)).willReturn(false);
+
+        // when
+        log.info("디바이스 ID 중복 확인 서비스 로직을 호출합니다.");
+        PetResponse.PetDeviceCheckResponse response = petService.checkDeviceIdAvailability(request);
+
+        // then
+        log.info("사용 가능 여부와 메시지를 검증합니다.");
+        assertNotNull(response);
+        assertTrue(response.isAvailable());
+        assertEquals("사용 가능한 디바이스 ID입니다.", response.getMessage());
+        log.info("디바이스 ID 중복 확인 성공 테스트가 통과되었습니다.");
+    }
+
+    /**
+     * 디바이스 ID 중복 확인 실패 시나리오를 테스트합니다.
+     */
+    @Test
+    @DisplayName("디바이스 ID 중복 확인 실패: 이미 사용 중인 ID면 예외가 발생한다.")
+    void checkDeviceIdAvailability_Fail_DuplicateDeviceId() {
+        log.info("디바이스 ID 중복 확인 실패 테스트를 시작합니다.");
+        // given
+        String duplicateDeviceId = "DUPLICATE_DEV";
+        PetRequest.PetDeviceCheckRequest request = PetRequest.PetDeviceCheckRequest.builder()
+                .deviceId(duplicateDeviceId)
+                .build();
+
+        log.info("요청한 디바이스 ID가 이미 존재한다고 설정합니다.");
+        given(petRepository.existsByDeviceId(duplicateDeviceId)).willReturn(true);
+
+        // when
+        log.info("중복 확인 요청 시 예외가 발생하는지 확인합니다.");
+        PetException exception = assertThrows(PetException.class, () ->
+                petService.checkDeviceIdAvailability(request)
+        );
+
+        // then
+        log.info("발생한 예외 코드가 DEVICE_ID_DUPLICATED인지 검증합니다.");
+        assertEquals(PetErrorCode.DEVICE_ID_DUPLICATED, exception.getErrorCode());
+        log.info("디바이스 ID 중복 확인 실패 테스트가 통과되었습니다.");
     }
 
     /**

--- a/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
+++ b/src/test/java/com/dodo/backend/pet/service/PetServiceTest.java
@@ -632,7 +632,7 @@ class PetServiceTest {
      * 디바이스 ID 중복 확인 실패 시나리오를 테스트합니다.
      */
     @Test
-    @DisplayName("디바이스 ID 중복 확인 실패: 이미 사용 중인 ID면 예외가 발생한다.")
+    @DisplayName("디바이스 ID 중복 확인 실패: 이미 사용 중인 ID면 false를 반환한다.")
     void checkDeviceIdAvailability_Fail_DuplicateDeviceId() {
         log.info("디바이스 ID 중복 확인 실패 테스트를 시작합니다.");
         // given
@@ -645,14 +645,14 @@ class PetServiceTest {
         given(petRepository.existsByDeviceId(duplicateDeviceId)).willReturn(true);
 
         // when
-        log.info("중복 확인 요청 시 예외가 발생하는지 확인합니다.");
-        PetException exception = assertThrows(PetException.class, () ->
-                petService.checkDeviceIdAvailability(request)
-        );
+        log.info("디바이스 ID 중복 확인 서비스 로직을 호출합니다.");
+        PetResponse.PetDeviceCheckResponse response = petService.checkDeviceIdAvailability(request);
 
         // then
-        log.info("발생한 예외 코드가 DEVICE_ID_DUPLICATED인지 검증합니다.");
-        assertEquals(PetErrorCode.DEVICE_ID_DUPLICATED, exception.getErrorCode());
+        log.info("사용 가능 여부가 false이고 적절한 메시지가 반환되었는지 검증합니다.");
+        assertNotNull(response);
+        assertFalse(response.isAvailable());
+        assertEquals("이미 다른 반려동물에 등록된 디바이스 ID입니다.", response.getMessage());
         log.info("디바이스 ID 중복 확인 실패 테스트가 통과되었습니다.");
     }
 


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 펫 등록 전 디바이스 ID 중복 여부를 확인하는 API 추가
- 펫 등록 시점에도 디바이스 ID 중복 검증 적용
- 디바이스 ID 중복 확인 요청/응답 DTO 및 서비스 로직 추가
- 디바이스 ID 중복 확인 서비스 테스트 추가
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #151
<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)
<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |
<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

디바이스 ID 중복 확인하는 기능이 재등록할때만 확인을 해서 따로 api 만들었습니다.