### PR TITLE
🔨 Refactor: 가족 초대 신청 상태별 예외 분기 처리

### DIFF
--- a/src/main/java/com/dodo/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dodo/backend/common/exception/GlobalExceptionHandler.java
@@ -78,6 +78,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UserPetException.class)
     protected ResponseEntity<ErrorResponse> handleUserPetException(UserPetException e) {
         log.error("UserPetException occurred: {}", e.getErrorCode());
+        if (e.getCustomMessage() != null) {
+            return toResponseEntity(e.getErrorCode(), e.getCustomMessage());
+        }
         return toResponseEntity(e.getErrorCode());
     }
 

--- a/src/main/java/com/dodo/backend/pet/controller/PetController.java
+++ b/src/main/java/com/dodo/backend/pet/controller/PetController.java
@@ -201,6 +201,9 @@ public class PetController {
             @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "가족 등록 신청이 차단되었습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"가족 등록 신청이 차단되었습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "만료되었거나 존재하지 않는 초대 코드입니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"만료되었거나 존재하지 않는 초대 코드입니다.\"}"))),
@@ -209,7 +212,7 @@ public class PetController {
                             examples = {
                                     @ExampleObject(name = "Already Family Member", value = "{\"status\": 409, \"message\": \"이미 가족으로 등록되어있습니다.\"}"),
                                     @ExampleObject(name = "Pending Family Request", value = "{\"status\": 409, \"message\": \"이미 가족 등록 신청이 대기 중입니다.\"}"),
-                                    @ExampleObject(name = "Rejected Family Request", value = "{\"status\": 409, \"message\": \"가족 등록 신청이 거절되었습니다.\"}")
+                                    @ExampleObject(name = "Rejected Family Request Cooldown", value = "{\"status\": 409, \"message\": \"가족 등록 신청이 거절되었습니다. 15분 후 다시 신청해주세요.\"}")
                             })),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
@@ -276,6 +279,49 @@ public class PetController {
                 request.getPetId(),
                 request.getTargetUserId(),
                 request.getAction()
+        ));
+    }
+
+    /**
+     * 차단된 가족 신청자의 차단 상태를 해제합니다.
+     * <p>
+     * 차단 해제 시 해당 UserPet 관계를 삭제하여, 대상 유저가 이후 초대 코드를 통해 다시 신청할 수 있도록 합니다.
+     *
+     * @param request     차단 해제할 반려동물 ID와 대상 유저 ID
+     * @param userDetails 인증된 사용자 정보
+     * @return 처리 결과 메시지 JSON
+     */
+    @Operation(summary = "가족 신청 차단 해제", description = "차단된 가족 신청자의 차단 상태를 해제하여 다시 신청할 수 있도록 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "차단 해제 성공",
+                    content = @Content(schema = @Schema(implementation = PetFamilyApprovalResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "400 Bad Request", value = "{\"status\": 400, \"message\": \"잘못된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 기능입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "401 Unauthorized", value = "{\"status\": 401, \"message\": \"로그인이 필요한 기능입니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "차단 해제 권한이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "403 Forbidden", value = "{\"status\": 403, \"message\": \"자신이 등록하거나 속해있는 반려동물만 초대할 수 있습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "차단된 신청 내역을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"초대하려는 사용자를 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+    })
+    @DeleteMapping("/family/block")
+    public ResponseEntity<PetFamilyApprovalResponse> unblockFamily(
+            @Valid @RequestBody PetFamilyBlockReleaseRequest request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        UUID requesterId = UUID.fromString(userDetails.getUsername());
+
+        return ResponseEntity.ok(petService.unblockFamily(
+                requesterId,
+                request.getPetId(),
+                request.getTargetUserId()
         ));
     }
 

--- a/src/main/java/com/dodo/backend/pet/controller/PetController.java
+++ b/src/main/java/com/dodo/backend/pet/controller/PetController.java
@@ -204,9 +204,13 @@ public class PetController {
             @ApiResponse(responseCode = "404", description = "만료되었거나 존재하지 않는 초대 코드입니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(name = "404 Not Found", value = "{\"status\": 404, \"message\": \"만료되었거나 존재하지 않는 초대 코드입니다.\"}"))),
-            @ApiResponse(responseCode = "409", description = "이미 가족으로 등록되어있습니다.",
+            @ApiResponse(responseCode = "409", description = "가족 신청 상태 충돌입니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "409 Conflict", value = "{\"status\": 409, \"message\": \"이미 가족으로 등록되어있습니다.\"}"))),
+                            examples = {
+                                    @ExampleObject(name = "Already Family Member", value = "{\"status\": 409, \"message\": \"이미 가족으로 등록되어있습니다.\"}"),
+                                    @ExampleObject(name = "Pending Family Request", value = "{\"status\": 409, \"message\": \"이미 가족 등록 신청이 대기 중입니다.\"}"),
+                                    @ExampleObject(name = "Rejected Family Request", value = "{\"status\": 409, \"message\": \"가족 등록 신청이 거절되었습니다.\"}")
+                            })),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(name = "500 Internal Server Error", value = "{\"status\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
@@ -518,7 +522,6 @@ public class PetController {
      * 디바이스 ID 중복 여부를 확인합니다.
      *
      * @param request     확인할 디바이스 ID
-     * @param userDetails 인증된 사용자 정보
      * @return 디바이스 ID 사용 가능 여부 응답
      */
     @Operation(summary = "디바이스 ID 중복 확인", description = "펫 등록 전에 디바이스 ID가 이미 다른 반려동물에 등록되어 있는지 확인합니다.")

--- a/src/main/java/com/dodo/backend/pet/dto/request/PetRequest.java
+++ b/src/main/java/com/dodo/backend/pet/dto/request/PetRequest.java
@@ -166,8 +166,27 @@ public class PetRequest {
         private UUID targetUserId;
 
         @NotBlank
-        @Schema(description = "처리할 상태 (APPROVED: 승인, REJECTED: 거절)", example = "APPROVED")
+        @Schema(description = "처리할 상태 (APPROVED: 승인, REJECTED: 거절, BLOCKED: 차단)", example = "APPROVED")
         private String action;
+    }
+
+    /**
+     * 가족 신청 차단 해제를 위한 DTO입니다.
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "가족 신청 차단 해제 요청")
+    public static class PetFamilyBlockReleaseRequest {
+
+        @NotNull
+        @Schema(description = "반려동물 ID", example = "1")
+        private Long petId;
+
+        @NotNull
+        @Schema(description = "차단 해제 대상 유저 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+        private UUID targetUserId;
     }
 
     /**

--- a/src/main/java/com/dodo/backend/pet/service/PetService.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetService.java
@@ -70,6 +70,16 @@ public interface PetService {
     PetFamilyApprovalResponse manageFamily(UUID requesterId, Long petId, UUID targetUserId, String action);
 
     /**
+     * 차단된 가족 신청자를 차단 해제합니다.
+     *
+     * @param requesterId  요청을 수행하는 관리자(기존 가족) ID
+     * @param petId        반려동물 ID
+     * @param targetUserId 차단 해제 대상 유저 ID
+     * @return 펫 ID와 처리 결과 메시지
+     */
+    PetFamilyApprovalResponse unblockFamily(UUID requesterId, Long petId, UUID targetUserId);
+
+    /**
      * 특정 반려동물에게 들어온 가족 신청 대기자 목록을 페이징하여 조회합니다.
      *
      * @param managerId 요청자(관리자)의 UUID

--- a/src/main/java/com/dodo/backend/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/dodo/backend/pet/service/PetServiceImpl.java
@@ -287,6 +287,15 @@ public class PetServiceImpl implements PetService {
         return PetFamilyApprovalResponse.toDto(petId, resultMessage);
     }
 
+    @Transactional
+    @Override
+    public PetFamilyApprovalResponse unblockFamily(UUID userId, Long petId, UUID targetUserId) {
+
+        String resultMessage = userPetService.unblockFamilyMember(userId, petId, targetUserId);
+
+        return PetFamilyApprovalResponse.toDto(petId, resultMessage);
+    }
+
     /**
      * 내가 관리하는 모든 반려동물에게 들어온 가족 신청(대기자) 목록을 페이징하여 조회합니다.
      * <p>

--- a/src/main/java/com/dodo/backend/userpet/entity/RegistrationStatus.java
+++ b/src/main/java/com/dodo/backend/userpet/entity/RegistrationStatus.java
@@ -3,8 +3,8 @@ package com.dodo.backend.userpet.entity;
 /**
  * 펫 등록 신청에 대한 승인 상태를 정의하는 Enum 클래스입니다.
  * <p>
- * 대기(PENDING), 승인(APPROVED), 거절(REJECTED) 상태를 관리합니다.
+ * 대기(PENDING), 승인(APPROVED), 거절(REJECTED), 차단(BLOCKED) 상태를 관리합니다.
  */
 public enum RegistrationStatus {
-    PENDING, APPROVED, REJECTED
+    PENDING, APPROVED, REJECTED, BLOCKED
 }

--- a/src/main/java/com/dodo/backend/userpet/exception/UserPetErrorCode.java
+++ b/src/main/java/com/dodo/backend/userpet/exception/UserPetErrorCode.java
@@ -79,6 +79,20 @@ public enum UserPetErrorCode implements BaseErrorCode {
     ALREADY_FAMILY_MEMBER(HttpStatus.CONFLICT, "이미 가족으로 등록되어있습니다."),
 
     /**
+     * 이미 가족 등록 신청이 승인 대기 중인 사용자가 다시 같은 반려동물 가족 신청을 시도할 때 사용합니다.
+     * <p>
+     * HTTP {@code 409 Conflict}를 반환합니다.
+     */
+    FAMILY_REQUEST_PENDING(HttpStatus.CONFLICT, "이미 가족 등록 신청이 대기 중입니다."),
+
+    /**
+     * 이전 가족 등록 신청이 거절된 사용자가 다시 같은 반려동물 가족 신청을 시도할 때 사용합니다.
+     * <p>
+     * HTTP {@code 409 Conflict}를 반환합니다.
+     */
+    FAMILY_REQUEST_REJECTED(HttpStatus.CONFLICT, "가족 등록 신청이 거절되었습니다."),
+
+    /**
      * 해당 반려동물에 대해 유효한 초대 코드가 이미 존재할 때 사용합니다.
      * <p>
      * 중복 발급을 방지하기 위해 사용되며, 기존 코드가 만료될 때까지 재발급이 제한됩니다.

--- a/src/main/java/com/dodo/backend/userpet/exception/UserPetErrorCode.java
+++ b/src/main/java/com/dodo/backend/userpet/exception/UserPetErrorCode.java
@@ -93,6 +93,13 @@ public enum UserPetErrorCode implements BaseErrorCode {
     FAMILY_REQUEST_REJECTED(HttpStatus.CONFLICT, "가족 등록 신청이 거절되었습니다."),
 
     /**
+     * 가족 등록 신청이 차단된 사용자가 다시 같은 반려동물 가족 신청을 시도할 때 사용합니다.
+     * <p>
+     * HTTP {@code 403 Forbidden}를 반환합니다.
+     */
+    FAMILY_REQUEST_BLOCKED(HttpStatus.FORBIDDEN, "가족 등록 신청이 차단되었습니다."),
+
+    /**
      * 해당 반려동물에 대해 유효한 초대 코드가 이미 존재할 때 사용합니다.
      * <p>
      * 중복 발급을 방지하기 위해 사용되며, 기존 코드가 만료될 때까지 재발급이 제한됩니다.

--- a/src/main/java/com/dodo/backend/userpet/exception/UserPetException.java
+++ b/src/main/java/com/dodo/backend/userpet/exception/UserPetException.java
@@ -1,6 +1,5 @@
 package com.dodo.backend.userpet.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
@@ -9,7 +8,6 @@ import lombok.Getter;
  * 가족 초대, 멤버십 관리, 초대 코드 검증 등 유저와 펫의 연결 관계 로직에서 예외 상황 발생 시 이 클래스를 throw 합니다.
  * {@code GlobalExceptionHandler}에서 이 예외를 가로채어 {@link UserPetErrorCode}에 정의된 표준 응답으로 변환합니다.
  */
-@AllArgsConstructor
 @Getter
 public class UserPetException extends RuntimeException {
 
@@ -17,4 +15,16 @@ public class UserPetException extends RuntimeException {
      * 발생한 예외의 구체적인 종류(상태 코드, 메시지)를 담고 있는 Enum입니다.
      */
     private final UserPetErrorCode errorCode;
+
+    private final String customMessage;
+
+    public UserPetException(UserPetErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.customMessage = null;
+    }
+
+    public UserPetException(UserPetErrorCode errorCode, String customMessage) {
+        this.errorCode = errorCode;
+        this.customMessage = customMessage;
+    }
 }

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetService.java
@@ -70,6 +70,16 @@ public interface UserPetService {
     String approveOrRejectFamilyMember(UUID requesterId, Long petId, UUID targetUserId, String action);
 
     /**
+     * 차단된 가족 신청자를 차단 해제합니다.
+     *
+     * @param requesterId  요청을 수행하는 관리자(기존 가족) ID
+     * @param petId        반려동물 ID
+     * @param targetUserId 차단 해제 대상 유저 ID
+     * @return 처리 결과 메시지
+     */
+    String unblockFamilyMember(UUID requesterId, Long petId, UUID targetUserId);
+
+    /**
      * 특정 반려동물에게 신청된 승인 대기(PENDING) 상태의 유저 목록을 조회합니다.
      *
      * @param managerId 요청을 수행하는 관리자(기존 가족)의 UUID

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetServiceImpl.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetServiceImpl.java
@@ -21,9 +21,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.dodo.backend.user.exception.UserErrorCode.USER_NOT_FOUND;
@@ -43,6 +45,7 @@ public class UserPetServiceImpl implements UserPetService {
     private final UserPetMapper userPetMapper;
 
     private static final long EXPIRATION_MINUTES = 15;
+    private static final long REAPPLY_COOLDOWN_MINUTES = 15;
     private static final String REDIS_CODE_KEY_PREFIX = "invitation:code:";
     private static final String REDIS_PET_KEY_PREFIX = "invitation:pet:";
 
@@ -152,16 +155,25 @@ public class UserPetServiceImpl implements UserPetService {
 
         Long petId = Long.valueOf(petIdStr);
 
-        userPetRepository.findById(new UserPetId(userId, petId))
-                .ifPresent(userPet -> {
-                    if (userPet.getRegistrationStatus() == RegistrationStatus.PENDING) {
-                        throw new UserPetException(FAMILY_REQUEST_PENDING);
-                    }
-                    if (userPet.getRegistrationStatus() == RegistrationStatus.REJECTED) {
-                        throw new UserPetException(FAMILY_REQUEST_REJECTED);
-                    }
-                    throw new UserPetException(ALREADY_FAMILY_MEMBER);
-                });
+        Optional<UserPet> existingUserPet = userPetRepository.findById(new UserPetId(userId, petId));
+        if (existingUserPet.isPresent()) {
+            UserPet userPet = existingUserPet.get();
+            if (userPet.getRegistrationStatus() == RegistrationStatus.PENDING) {
+                throw new UserPetException(FAMILY_REQUEST_PENDING);
+            }
+            if (userPet.getRegistrationStatus() == RegistrationStatus.APPROVED) {
+                throw new UserPetException(ALREADY_FAMILY_MEMBER);
+            }
+            if (userPet.getRegistrationStatus() == RegistrationStatus.BLOCKED) {
+                throw new UserPetException(FAMILY_REQUEST_BLOCKED);
+            }
+            if (userPet.getRegistrationStatus() == RegistrationStatus.REJECTED) {
+                validateRejectedReapplyCooldown(userPet);
+                userPetMapper.updateRegistrationStatus(userId, petId, RegistrationStatus.PENDING.name());
+                log.info("가족 초대 재신청 (대기) - User: {}, PetId: {}", userId, petId);
+                return petId;
+            }
+        }
 
         Pet petRef = Pet.builder().petId(petId).build();
 
@@ -169,6 +181,27 @@ public class UserPetServiceImpl implements UserPetService {
         log.info("가족 초대 요청 (대기) - User: {}, PetId: {}", userId, petId);
 
         return petId;
+    }
+
+    private void validateRejectedReapplyCooldown(UserPet userPet) {
+        LocalDateTime rejectedAt = userPet.getRegistrationUpdatedAt();
+        if (rejectedAt == null) {
+            rejectedAt = userPet.getRegistrationCreatedAt();
+        }
+        if (rejectedAt == null) {
+            return;
+        }
+
+        LocalDateTime reapplyAvailableAt = rejectedAt.plusMinutes(REAPPLY_COOLDOWN_MINUTES);
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(reapplyAvailableAt)) {
+            long remainingSeconds = Duration.between(now, reapplyAvailableAt).getSeconds();
+            long remainingMinutes = Math.max(1, (remainingSeconds + 59) / 60);
+            throw new UserPetException(
+                    FAMILY_REQUEST_REJECTED,
+                    String.format("가족 등록 신청이 거절되었습니다. %d분 후 다시 신청해주세요.", remainingMinutes)
+            );
+        }
     }
 
     /**
@@ -238,6 +271,8 @@ public class UserPetServiceImpl implements UserPetService {
             message = "가족 신청을 승인했습니다.";
         } else if ("REJECTED".equals(action)) {
             message = "가족 신청을 거절했습니다.";
+        } else if ("BLOCKED".equals(action)) {
+            message = "가족 신청을 차단했습니다.";
         } else {
             throw new UserPetException(INVALID_REQUEST);
         }
@@ -247,6 +282,25 @@ public class UserPetServiceImpl implements UserPetService {
         log.info("가족 요청 처리 완료 - PetId: {}, TargetUser: {}, Status: {}", petId, targetUserId, action);
 
         return message;
+    }
+
+    @Transactional
+    @Override
+    public String unblockFamilyMember(UUID requesterId, Long petId, UUID targetUserId) {
+
+        userPetRepository.findById(new UserPetId(requesterId, petId))
+                .filter(up -> up.getRegistrationStatus() == RegistrationStatus.APPROVED)
+                .orElseThrow(() -> new UserPetException(INVITE_PERMISSION_DENIED));
+
+        UserPet blockedUserPet = userPetRepository.findById(new UserPetId(targetUserId, petId))
+                .filter(up -> up.getRegistrationStatus() == RegistrationStatus.BLOCKED)
+                .orElseThrow(() -> new UserPetException(INVITEE_NOT_FOUND));
+
+        userPetRepository.delete(blockedUserPet);
+
+        log.info("가족 신청 차단 해제 완료 - PetId: {}, TargetUser: {}", petId, targetUserId);
+
+        return "가족 신청 차단을 해제했습니다.";
     }
 
     /**

--- a/src/main/java/com/dodo/backend/userpet/service/UserPetServiceImpl.java
+++ b/src/main/java/com/dodo/backend/userpet/service/UserPetServiceImpl.java
@@ -152,9 +152,16 @@ public class UserPetServiceImpl implements UserPetService {
 
         Long petId = Long.valueOf(petIdStr);
 
-        if (userPetRepository.existsById(new UserPetId(userId, petId))) {
-            throw new UserPetException(ALREADY_FAMILY_MEMBER);
-        }
+        userPetRepository.findById(new UserPetId(userId, petId))
+                .ifPresent(userPet -> {
+                    if (userPet.getRegistrationStatus() == RegistrationStatus.PENDING) {
+                        throw new UserPetException(FAMILY_REQUEST_PENDING);
+                    }
+                    if (userPet.getRegistrationStatus() == RegistrationStatus.REJECTED) {
+                        throw new UserPetException(FAMILY_REQUEST_REJECTED);
+                    }
+                    throw new UserPetException(ALREADY_FAMILY_MEMBER);
+                });
 
         Pet petRef = Pet.builder().petId(petId).build();
 

--- a/src/main/resources/com/dodo/backend/userpet/mapper/UserPetMapper.xml
+++ b/src/main/resources/com/dodo/backend/userpet/mapper/UserPetMapper.xml
@@ -10,7 +10,8 @@
          4. WHERE 조건 : 특정 유저의 특정 반려동물만 업데이트 -->
     <update id="updateRegistrationStatus">
         UPDATE users_animals
-        SET registration_status = #{status}
+        SET registration_status = #{status},
+            registration_updated_at = CURRENT_TIMESTAMP
         WHERE user_id = #{userId}
           AND pet_id = #{petId}
     </update>

--- a/src/test/java/com/dodo/backend/userpet/service/UserPetServiceTest.java
+++ b/src/test/java/com/dodo/backend/userpet/service/UserPetServiceTest.java
@@ -137,7 +137,7 @@ class UserPetServiceTest {
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(anyString())).willReturn(petIdStr);
 
-        given(userPetRepository.existsById(any(UserPetId.class))).willReturn(false);
+        given(userPetRepository.findById(any(UserPetId.class))).willReturn(Optional.empty());
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
@@ -149,6 +149,56 @@ class UserPetServiceTest {
         ArgumentCaptor<UserPet> captor = ArgumentCaptor.forClass(UserPet.class);
         verify(userPetRepository).save(captor.capture());
         assertEquals(RegistrationStatus.PENDING, captor.getValue().getRegistrationStatus());
+    }
+
+    @Test
+    @DisplayName("초대 수락 실패: 이전 신청이 거절(REJECTED)된 경우 거절 메시지 에러를 반환한다.")
+    void registerByInvitation_Fail_RejectedRequest() {
+        // given
+        UUID userId = UUID.randomUUID();
+        String invitationCode = "7X9K2P";
+        Long petId = 100L;
+        UserPet rejectedUserPet = UserPet.builder()
+                .registrationStatus(RegistrationStatus.REJECTED)
+                .build();
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(anyString())).willReturn(String.valueOf(petId));
+        given(userPetRepository.findById(new UserPetId(userId, petId))).willReturn(Optional.of(rejectedUserPet));
+
+        // when
+        UserPetException exception = assertThrows(
+                UserPetException.class,
+                () -> userPetService.registerByInvitation(userId, invitationCode)
+        );
+
+        // then
+        assertEquals(UserPetErrorCode.FAMILY_REQUEST_REJECTED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("초대 수락 실패: 이미 신청 대기(PENDING) 중인 경우 대기 중 메시지 에러를 반환한다.")
+    void registerByInvitation_Fail_PendingRequest() {
+        // given
+        UUID userId = UUID.randomUUID();
+        String invitationCode = "7X9K2P";
+        Long petId = 100L;
+        UserPet pendingUserPet = UserPet.builder()
+                .registrationStatus(RegistrationStatus.PENDING)
+                .build();
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(anyString())).willReturn(String.valueOf(petId));
+        given(userPetRepository.findById(new UserPetId(userId, petId))).willReturn(Optional.of(pendingUserPet));
+
+        // when
+        UserPetException exception = assertThrows(
+                UserPetException.class,
+                () -> userPetService.registerByInvitation(userId, invitationCode)
+        );
+
+        // then
+        assertEquals(UserPetErrorCode.FAMILY_REQUEST_PENDING, exception.getErrorCode());
     }
 
     /**

--- a/src/test/java/com/dodo/backend/userpet/service/UserPetServiceTest.java
+++ b/src/test/java/com/dodo/backend/userpet/service/UserPetServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -152,14 +153,15 @@ class UserPetServiceTest {
     }
 
     @Test
-    @DisplayName("초대 수락 실패: 이전 신청이 거절(REJECTED)된 경우 거절 메시지 에러를 반환한다.")
-    void registerByInvitation_Fail_RejectedRequest() {
+    @DisplayName("초대 수락 실패: 이전 신청이 거절(REJECTED)된 후 15분이 지나지 않은 경우 남은 시간 메시지 에러를 반환한다.")
+    void registerByInvitation_Fail_RejectedRequestInCooldown() {
         // given
         UUID userId = UUID.randomUUID();
         String invitationCode = "7X9K2P";
         Long petId = 100L;
         UserPet rejectedUserPet = UserPet.builder()
                 .registrationStatus(RegistrationStatus.REJECTED)
+                .registrationUpdatedAt(LocalDateTime.now())
                 .build();
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
@@ -174,6 +176,31 @@ class UserPetServiceTest {
 
         // then
         assertEquals(UserPetErrorCode.FAMILY_REQUEST_REJECTED, exception.getErrorCode());
+        assertTrue(exception.getCustomMessage().contains("분 후 다시 신청해주세요."));
+    }
+
+    @Test
+    @DisplayName("초대 수락 성공: 이전 신청이 거절(REJECTED)된 후 15분이 지난 경우 대기(PENDING) 상태로 재신청한다.")
+    void registerByInvitation_Success_RejectedRequestAfterCooldown() {
+        // given
+        UUID userId = UUID.randomUUID();
+        String invitationCode = "7X9K2P";
+        Long petId = 100L;
+        UserPet rejectedUserPet = UserPet.builder()
+                .registrationStatus(RegistrationStatus.REJECTED)
+                .registrationUpdatedAt(LocalDateTime.now().minusMinutes(16))
+                .build();
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(anyString())).willReturn(String.valueOf(petId));
+        given(userPetRepository.findById(new UserPetId(userId, petId))).willReturn(Optional.of(rejectedUserPet));
+
+        // when
+        Long resultPetId = userPetService.registerByInvitation(userId, invitationCode);
+
+        // then
+        assertEquals(petId, resultPetId);
+        verify(userPetMapper).updateRegistrationStatus(userId, petId, RegistrationStatus.PENDING.name());
     }
 
     @Test
@@ -252,5 +279,27 @@ class UserPetServiceTest {
         // then
         assertEquals("가족 신청을 승인했습니다.", result);
         verify(userPetMapper).updateRegistrationStatus(targetUserId, petId, "APPROVED");
+    }
+
+    @Test
+    @DisplayName("가족 신청 차단 해제 성공: 요청자가 승인된 가족이고 대상이 차단 상태이면 관계를 삭제한다.")
+    void unblockFamilyMember_Success() {
+        // given
+        UUID requesterId = UUID.randomUUID();
+        UUID targetUserId = UUID.randomUUID();
+        Long petId = 100L;
+
+        UserPet requester = UserPet.builder().registrationStatus(RegistrationStatus.APPROVED).build();
+        UserPet blockedTarget = UserPet.builder().registrationStatus(RegistrationStatus.BLOCKED).build();
+
+        given(userPetRepository.findById(new UserPetId(requesterId, petId))).willReturn(Optional.of(requester));
+        given(userPetRepository.findById(new UserPetId(targetUserId, petId))).willReturn(Optional.of(blockedTarget));
+
+        // when
+        String result = userPetService.unblockFamilyMember(requesterId, petId, targetUserId);
+
+        // then
+        assertEquals("가족 신청 차단을 해제했습니다.", result);
+        verify(userPetRepository).delete(blockedTarget);
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- 가족 초대 재신청 시 기존 UserPet 상태에 따라 409 응답 메시지 분기
- PENDING 상태일 경우 신청 대기 중 메시지 반환
- REJECTED 상태일 경우 거절 메시지 반환
- 가족 초대 신청 API의 409 OpenAPI 예시 추가
- 상태별 예외 분기 단위 테스트 추가
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

-   Closes: #159
<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)
<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

409 에러 코드 세분화했습니다. 